### PR TITLE
CLOUDP-172196: reflect error when query contains array of objects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,5 +85,36 @@ Repository contains following SDKs
 - `tools`: tooling used to generate Atlas Admin SDK. See [./tools](./tools) for more information.
 - `examples`: SDK examples
 
+## VSCode debugging configuration
+VSCode developers might use following debugging configuration for transformer and go debugging
+```
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Go App",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${file}"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Transform",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "env": {
+                "OPENAPI_FILE_NAME": "./openapi/atlas-api.yaml"
+            },
+            "args": ["./openapi/atlas-api.yaml"],
+            "program": "${workspaceFolder}/tools/transformer/src/transform"
+        }
+    ]
+}
+
+```
+
 
 

--- a/admin/api_clusters.go
+++ b/admin/api_clusters.go
@@ -791,11 +791,10 @@ func (a *ClustersApiService) listCloudProviderRegionsExecute(r ListCloudProvider
 	}
 	if r.providers != nil {
 		t := *r.providers
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "providers", t, "multi")
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "providers", t, "multi")
-		}
+		// Workaround for unused import
+		_ = reflect.Append
+		parameterAddToHeaderOrQuery(localVarQueryParams, "providers", t, "multi")
+
 	}
 	if r.tier != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "tier", r.tier, "")

--- a/admin/api_clusters.go
+++ b/admin/api_clusters.go
@@ -792,10 +792,7 @@ func (a *ClustersApiService) listCloudProviderRegionsExecute(r ListCloudProvider
 	if r.providers != nil {
 		t := *r.providers
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "providers", s.Index(i), "multi")
-			}
+			parameterAddToHeaderOrQuery(localVarQueryParams, "providers", t, "multi")
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "providers", t, "multi")
 		}

--- a/admin/api_events.go
+++ b/admin/api_events.go
@@ -838,11 +838,10 @@ func (a *EventsApiService) listProjectEventsExecute(r ListProjectEventsApiReques
 	}
 	if r.clusterNames != nil {
 		t := *r.clusterNames
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "clusterNames", t, "multi")
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "clusterNames", t, "multi")
-		}
+		// Workaround for unused import
+		_ = reflect.Append
+		parameterAddToHeaderOrQuery(localVarQueryParams, "clusterNames", t, "multi")
+
 	}
 	if r.eventType != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "eventType", r.eventType, "")

--- a/admin/api_events.go
+++ b/admin/api_events.go
@@ -839,10 +839,7 @@ func (a *EventsApiService) listProjectEventsExecute(r ListProjectEventsApiReques
 	if r.clusterNames != nil {
 		t := *r.clusterNames
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "clusterNames", s.Index(i), "multi")
-			}
+			parameterAddToHeaderOrQuery(localVarQueryParams, "clusterNames", t, "multi")
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "clusterNames", t, "multi")
 		}

--- a/admin/api_monitoring_and_logs.go
+++ b/admin/api_monitoring_and_logs.go
@@ -753,10 +753,7 @@ func (a *MonitoringAndLogsApiService) getDatabaseMeasurementsExecute(r GetDataba
 	if r.m != nil {
 		t := *r.m
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "m", s.Index(i), "multi")
-			}
+			parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
 		}
@@ -921,10 +918,7 @@ func (a *MonitoringAndLogsApiService) getDiskMeasurementsExecute(r GetDiskMeasur
 	if r.m != nil {
 		t := *r.m
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "m", s.Index(i), "multi")
-			}
+			parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
 		}
@@ -1258,10 +1252,7 @@ func (a *MonitoringAndLogsApiService) getHostMeasurementsExecute(r GetHostMeasur
 	if r.m != nil {
 		t := *r.m
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "m", s.Index(i), "multi")
-			}
+			parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
 		}
@@ -1490,10 +1481,7 @@ func (a *MonitoringAndLogsApiService) getIndexMetricsExecute(r GetIndexMetricsAp
 	{
 		t := *r.metrics
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", s.Index(i), "multi")
-			}
+			parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
 		}
@@ -1701,10 +1689,7 @@ func (a *MonitoringAndLogsApiService) getMeasurementsExecute(r GetMeasurementsAp
 	{
 		t := *r.metrics
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", s.Index(i), "multi")
-			}
+			parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
 		}
@@ -2618,10 +2603,7 @@ func (a *MonitoringAndLogsApiService) listIndexMetricsExecute(r ListIndexMetrics
 	{
 		t := *r.metrics
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", s.Index(i), "multi")
-			}
+			parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
 		}

--- a/admin/api_monitoring_and_logs.go
+++ b/admin/api_monitoring_and_logs.go
@@ -752,11 +752,10 @@ func (a *MonitoringAndLogsApiService) getDatabaseMeasurementsExecute(r GetDataba
 
 	if r.m != nil {
 		t := *r.m
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
-		}
+		// Workaround for unused import
+		_ = reflect.Append
+		parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
+
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -917,11 +916,10 @@ func (a *MonitoringAndLogsApiService) getDiskMeasurementsExecute(r GetDiskMeasur
 
 	if r.m != nil {
 		t := *r.m
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
-		}
+		// Workaround for unused import
+		_ = reflect.Append
+		parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
+
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -1251,11 +1249,10 @@ func (a *MonitoringAndLogsApiService) getHostMeasurementsExecute(r GetHostMeasur
 
 	if r.m != nil {
 		t := *r.m
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
-		}
+		// Workaround for unused import
+		_ = reflect.Append
+		parameterAddToHeaderOrQuery(localVarQueryParams, "m", t, "multi")
+
 	}
 	if r.period != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "period", r.period, "")
@@ -1480,11 +1477,9 @@ func (a *MonitoringAndLogsApiService) getIndexMetricsExecute(r GetIndexMetricsAp
 	}
 	{
 		t := *r.metrics
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
-		}
+		// Workaround for unused import
+		_ = reflect.Append
+		parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -1688,11 +1683,9 @@ func (a *MonitoringAndLogsApiService) getMeasurementsExecute(r GetMeasurementsAp
 	}
 	{
 		t := *r.metrics
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
-		}
+		// Workaround for unused import
+		_ = reflect.Append
+		parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -2602,11 +2595,9 @@ func (a *MonitoringAndLogsApiService) listIndexMetricsExecute(r ListIndexMetrics
 	}
 	{
 		t := *r.metrics
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
-		}
+		// Workaround for unused import
+		_ = reflect.Append
+		parameterAddToHeaderOrQuery(localVarQueryParams, "metrics", t, "multi")
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}

--- a/admin/api_performance_advisor.go
+++ b/admin/api_performance_advisor.go
@@ -487,11 +487,10 @@ func (a *PerformanceAdvisorApiService) listSlowQueriesExecute(r ListSlowQueriesA
 	}
 	if r.namespaces != nil {
 		t := *r.namespaces
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "namespaces", t, "multi")
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "namespaces", t, "multi")
-		}
+		// Workaround for unused import
+		_ = reflect.Append
+		parameterAddToHeaderOrQuery(localVarQueryParams, "namespaces", t, "multi")
+
 	}
 	if r.nLogs != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "nLogs", r.nLogs, "")
@@ -897,11 +896,10 @@ func (a *PerformanceAdvisorApiService) listSuggestedIndexesExecute(r ListSuggest
 	}
 	if r.namespaces != nil {
 		t := *r.namespaces
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "namespaces", t, "multi")
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "namespaces", t, "multi")
-		}
+		// Workaround for unused import
+		_ = reflect.Append
+		parameterAddToHeaderOrQuery(localVarQueryParams, "namespaces", t, "multi")
+
 	}
 	if r.nExamples != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "nExamples", r.nExamples, "")

--- a/admin/api_performance_advisor.go
+++ b/admin/api_performance_advisor.go
@@ -488,10 +488,7 @@ func (a *PerformanceAdvisorApiService) listSlowQueriesExecute(r ListSlowQueriesA
 	if r.namespaces != nil {
 		t := *r.namespaces
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "namespaces", s.Index(i), "multi")
-			}
+			parameterAddToHeaderOrQuery(localVarQueryParams, "namespaces", t, "multi")
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "namespaces", t, "multi")
 		}
@@ -901,10 +898,7 @@ func (a *PerformanceAdvisorApiService) listSuggestedIndexesExecute(r ListSuggest
 	if r.namespaces != nil {
 		t := *r.namespaces
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "namespaces", s.Index(i), "multi")
-			}
+			parameterAddToHeaderOrQuery(localVarQueryParams, "namespaces", t, "multi")
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "namespaces", t, "multi")
 		}

--- a/examples/regions/example_cluster_regions.go
+++ b/examples/regions/example_cluster_regions.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+
+	"context"
+
+	"go.mongodb.org/atlas-sdk/admin"
+)
+
+/*
+* MongoDB Atlas Go SDK Example
+*
+* Example performs following actions:
+* - Finds first project in the user organization
+* - Creates new MongoDB cluster backed by AWS provider in that project
+* - Creates database user for connection
+* - Creates IP access to enable connection
+ */
+func main() {
+	ctx := context.Background()
+	// Values provided as part of env variables
+	// See: https://www.mongodb.com/docs/atlas/app-services/authentication/api-key/
+	apiKey := os.Getenv("MDB_API_KEY")
+	apiSecret := os.Getenv("MDB_API_SECRET")
+
+	sdk, err := admin.NewClient(
+		admin.UseDigestAuth(apiKey, apiSecret),
+		admin.UseBaseURL("https://cloud-dev.mongodb.com"),
+		admin.UseDebug(false))
+	handleErr(err, nil)
+
+	// -- 1. Get first project
+	projects, response, err := sdk.ProjectsApi.ListProjects(ctx).Execute()
+	handleErr(err, response)
+
+	if projects.GetTotalCount() == 0 {
+		log.Fatal("account should have at least single project")
+	}
+
+	projectId := projects.GetResults()[0].GetId()
+	providers := []string{"AWS","GCP","AZURE"}
+	regions,response, err :=sdk.ClustersApi.ListCloudProviderRegions(ctx,projectId).Providers(providers).Execute()
+	handleErr(err,response)
+	fmt.Println(regions);
+}
+
+func handleErr(err error, resp *http.Response) {
+	if err == nil {
+		return
+	}
+
+	if resp != nil {
+		fmt.Println(resp.Body)
+		// Printing generic message
+		fmt.Println(err.Error())
+	}
+	apiErr, _ := admin.AsError(err)
+	log.Fatalf("Error when performing SDK request: %v", apiErr.GetDetail())
+
+}
+
+func getIpAddress() string {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+
+	return localAddr.IP.String()
+}

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -214,10 +214,7 @@ func (a *{{{classname}}}Service) {{#lambda.camelcase}}{{{nickname}}}{{/lambda.ca
 	{
 		t := *r.{{paramName}}
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", s.Index(i), "{{collectionFormat}}")
-			}
+			parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", t, "{{collectionFormat}}")
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", t, "{{collectionFormat}}")
 		}
@@ -232,10 +229,7 @@ func (a *{{{classname}}}Service) {{#lambda.camelcase}}{{{nickname}}}{{/lambda.ca
 	{{#isCollectionFormatMulti}}
 		t := *r.{{paramName}}
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", s.Index(i), "{{collectionFormat}}")
-			}
+			parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", t, "{{collectionFormat}}")
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", t, "{{collectionFormat}}")
 		}

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -213,11 +213,9 @@ func (a *{{{classname}}}Service) {{#lambda.camelcase}}{{{nickname}}}{{/lambda.ca
 	{{#isCollectionFormatMulti}}
 	{
 		t := *r.{{paramName}}
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", t, "{{collectionFormat}}")
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", t, "{{collectionFormat}}")
-		}
+		// Workaround for unused import
+		_ = reflect.Append;
+		parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", t, "{{collectionFormat}}")
 	}
 	{{/isCollectionFormatMulti}}
 	{{^isCollectionFormatMulti}}
@@ -228,11 +226,10 @@ func (a *{{{classname}}}Service) {{#lambda.camelcase}}{{{nickname}}}{{/lambda.ca
 	if r.{{paramName}} != nil {
 	{{#isCollectionFormatMulti}}
 		t := *r.{{paramName}}
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", t, "{{collectionFormat}}")
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", t, "{{collectionFormat}}")
-		}
+		// Workaround for unused import
+		_ = reflect.Append;
+		parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", t, "{{collectionFormat}}")
+		
 	{{/isCollectionFormatMulti}}
 	{{^isCollectionFormatMulti}}
 		parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", r.{{paramName}}, "{{collectionFormat}}")


### PR DESCRIPTION
Fixing blocker for CLOUDP-172196 - removing redundant reflect. 

NOTE: openapi generator adds imports for reflection that we cannot remove in the template. 