### PR TITLE
CLOUDP-176385: add docs.go for clarity

### DIFF
--- a/admin/doc.go
+++ b/admin/doc.go
@@ -1,0 +1,6 @@
+/*
+Package admin supports the MongoDB Atlas Admin API.
+
+See: https://github.com/mongodb/atlas-sdk-go#getting-started for more information
+*/
+package admin

--- a/core/doc.go
+++ b/core/doc.go
@@ -1,0 +1,5 @@
+/*
+Core package for the Atlas Go SDK.
+Should not be used by end users.
+*/
+package core

--- a/tools/config/config.yaml
+++ b/tools/config/config.yaml
@@ -11,3 +11,6 @@ files:
   atlas_client.mustache:
     templateType: SupportingFiles
     destinationFilename: atlas_client.go
+  doc.mustache:
+    templateType: SupportingFiles
+    destinationFilename: doc.go

--- a/tools/config/go-templates/doc.mustache
+++ b/tools/config/go-templates/doc.mustache
@@ -1,0 +1,6 @@
+/*
+Package admin supports the MongoDB Atlas Admin API.
+
+See: https://github.com/mongodb/atlas-sdk-go#getting-started for more information
+*/
+package {{packageName}}


### PR DESCRIPTION
## Description

Add docs to all packages in the SDK (clarify the roles of the packages to end users. 
Without docs.go - go documentation lists all the files for the package without any context.
