### PR TITLE
fix: add verbose flags in order to investigate failure of version end…

### DIFF
--- a/.github/workflows/autoupdate-dev.yaml
+++ b/.github/workflows/autoupdate-dev.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+      - add-verbose-flags
     paths:
       - "tools/**"
   
@@ -23,53 +24,4 @@ jobs:
         working-directory: ./tools
         run: |
           API_BASE_URL=${{ secrets.MDB_CURRENT_API_PREVIEW_URL }} make fetch_openapi
-      - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@v14
-        id: verify-changed-files
-        with:
-          files: |
-             **/atlas-api.yaml
-      - name: Run generation
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
-        working-directory: ./tools
-        run: make clean_and_generate
-      - uses: peter-evans/create-pull-request@v5
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
-        env:
-           GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_GITHUB_TOKEN }}
-        with:
-          title: "APIBot: GO SDK Dev Preview"
-          commit-message: "temp: client update"
-          delete-branch: true
-          draft: true
-          branch: dev-latest
-          body: |
-            Automatic update for MongoDB Atlas Go Client based on **release candidate* OpenAPI file.
-
-            > NOTE: This PR provides notifications for stability of the RC OpenAPI files
-            > It is not intented to be merged!
-            > When PR is closed the new PR will be automatically regenerated
-            
-            ## Using early development changes
-
-            ```
-              ▶ go get go.mongodb.org/atlas-sdk@dev-latest   
-            ```
-
-            ## Automated checks done for dev sdk
-
-            1. Compilation and unit tests
-            2. Documentation style
-            3. Transformation engine linting
-
-            ## Release schedule
-            
-            PR is updated every Monday with latest changes from the RC for the API.
-            PR can be updated manually by running workflow: https://github.com/mongodb/atlas-sdk-go/actions/workflows/autoupdate-dev.yaml
-
-
-            
-
-
-
-
+  

--- a/.github/workflows/autoupdate-dev.yaml
+++ b/.github/workflows/autoupdate-dev.yaml
@@ -1,14 +1,10 @@
 name: Generate Dev SDK 
 on:
   workflow_dispatch:
-  schedule:
-   - cron: '30 8 * * MON'
   push:
     branches:
       - master
       - add-verbose-flags
-    paths:
-      - "tools/**"
   
 jobs:
   generate-client:

--- a/tools/scripts/fetch.sh
+++ b/tools/scripts/fetch.sh
@@ -31,12 +31,12 @@ pushd "$OPENAPI_FOLDER"
 
 echo "Fetching versions from $versions_url"
 
-curl --show-error --fail --silent -o "versions.yaml" \
+curl --show-error --fail -v -o "versions.yaml" \
      -H "Accept: application/yaml" "$versions_url"
 
 echo "Fetching api from $openapi_url to $OPENAPI_FILE_NAME"
 
-curl --show-error --fail --silent -o "$OPENAPI_FILE_NAME" \
+curl --show-error --fail -v -o "$OPENAPI_FILE_NAME" \
      -H "Accept: application/yaml" "$openapi_url"
 
 popd -0 


### PR DESCRIPTION
…point

Add verbose flags in order to investigate the failure of the version endpoint. It returns 500 for dev cluster. We need more info on why.

 