### PR TITLE
CLOUDP-173481: amend array transformation for org events

### DIFF
--- a/admin/api_events.go
+++ b/admin/api_events.go
@@ -448,7 +448,7 @@ type ListOrganizationEventsApiRequest struct {
 	includeCount *bool
 	itemsPerPage *int
 	pageNum      *int
-	eventType    *[]map[string]interface{}
+	eventType    *[][]map[string]interface{}
 	includeRaw   *bool
 	maxDate      *time.Time
 	minDate      *time.Time
@@ -459,7 +459,7 @@ type ListOrganizationEventsApiParams struct {
 	IncludeCount *bool
 	ItemsPerPage *int
 	PageNum      *int
-	EventType    *[]map[string]interface{}
+	EventType    *[][]map[string]interface{}
 	IncludeRaw   *bool
 	MaxDate      *time.Time
 	MinDate      *time.Time
@@ -499,7 +499,7 @@ func (r ListOrganizationEventsApiRequest) PageNum(pageNum int) ListOrganizationE
 }
 
 // Category of incident recorded at this moment in time.  **IMPORTANT**: The complete list of event type values changes frequently.
-func (r ListOrganizationEventsApiRequest) EventType(eventType []map[string]interface{}) ListOrganizationEventsApiRequest {
+func (r ListOrganizationEventsApiRequest) EventType(eventType [][]map[string]interface{}) ListOrganizationEventsApiRequest {
 	r.eventType = &eventType
 	return r
 }

--- a/openapi/atlas-api-transformed.yaml
+++ b/openapi/atlas-api-transformed.yaml
@@ -15839,7 +15839,9 @@ components:
           - AGENT_VERSION_UNFIXED
           - TAGS_MODIFIED
     EventTypeForOrg:
-      type: object
+      type: array
+      items:
+        type: object
     EventViewForNdsGroup:
       type: object
       x-xgen-go-transform: merge-oneOf

--- a/tools/transformer/src/atlasTransformations.js
+++ b/tools/transformer/src/atlasTransformations.js
@@ -62,7 +62,7 @@ module.exports = function runTransformations(openapi) {
   // Temp workaround for CLOUDP-170462
   openapi = applyArrayTransformations(openapi, [
     "EventTypeForNdsGroup",
-    "EventTypeForForOrg",
+    "EventTypeForOrg",
   ]);
 
   let hasSchemaChanges = true;

--- a/tools/transformer/src/transformations/swapArray.js
+++ b/tools/transformer/src/transformations/swapArray.js
@@ -24,8 +24,8 @@ function applyArrayTransformations(api, modelNames) {
         ...model,
       },
     };
-    return api;
   }
+  return api;
 }
 
 module.exports = {


### PR DESCRIPTION
Jira: CLOUDP-173481

Follow-up on https://github.com/mongodb/atlas-sdk-go/pull/35

Correcting typo and moving return statement outside of loop to appropriately generate `EventTypeForOrg` as a string array (temporary workaround)