### PR TITLE
fix: Array workaround -  do not throw error when model name is changed

### DIFF
--- a/tools/transformer/src/transformations/swapArray.js
+++ b/tools/transformer/src/transformations/swapArray.js
@@ -17,7 +17,7 @@ function applyArrayTransformations(api, modelNames) {
     if (!api.components.schemas[modelName]) {
       // For cases when openapi is already fixed
       console.info(`Missing schema ${modelName} in openapi`);
-    } else {
+    } else if (api.components.schemas[modelName].type !== "array") {
       model = api.components.schemas[modelName];
       api.components.schemas[modelName] = {
         type: "array",

--- a/tools/transformer/src/transformations/swapArray.js
+++ b/tools/transformer/src/transformations/swapArray.js
@@ -15,15 +15,17 @@ function applyArrayTransformations(api, modelNames) {
   }
   for (const modelName of modelNames) {
     if (!api.components.schemas[modelName]) {
-      throw new Error(`Missing schema ${modelName} in openapi`);
+      // For cases when openapi is already fixed
+      console.info(`Missing schema ${modelName} in openapi`);
+    } else {
+      model = api.components.schemas[modelName];
+      api.components.schemas[modelName] = {
+        type: "array",
+        items: {
+          ...model,
+        },
+      };
     }
-    model = api.components.schemas[modelName];
-    api.components.schemas[modelName] = {
-      type: "array",
-      items: {
-        ...model,
-      },
-    };
   }
   return api;
 }


### PR DESCRIPTION
Dev will have those values renamed but we need that transformation for production.