### PR TITLE
Fixes formatting issues that won't transform properly into rST (bold links, relative links, indented notes)

### DIFF
--- a/docs/doc_1_concepts.md
+++ b/docs/doc_1_concepts.md
@@ -32,9 +32,9 @@ Alternatively you can use shorter `{Operation}()` method using builder pattern t
 	    ItemsPerPage(1).Execute()
 ```
 
-> NOTE: Path parameters are always required and they will be supplied directly in the `{Operation}()` method:
+Note: Path parameters are always required and they will be supplied directly in the `{Operation}()` method:
 
-> NOTE: SDK supplies default values for both query and post objects.
+Note: SDK supplies default values for both query and post objects.
 
 
 ## Performing Data Modification

--- a/docs/doc_3_migration.md
+++ b/docs/doc_3_migration.md
@@ -33,7 +33,7 @@ sdk, err := admin.NewClient(
     admin.UseDigestAuth(apiKey, apiSecret))
 ```
 
-> NOTE: Both SDKs use Digest based authentication. The same credentials will apply. 
+Note: Both SDKs use Digest based authentication. The same credentials will apply. 
 
 Please follow [authentication guide](https://github.com/mongodb/atlas-sdk-go#authentication) for more information.
 

--- a/tools/config/go-templates/README.mustache
+++ b/tools/config/go-templates/README.mustache
@@ -6,7 +6,7 @@ All URIs are relative to *{{basePath}}*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{classname}}* | [**{{operationId}}**]({{apiDocPath}}{{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{summary}}
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{classname}}* | [{{operationId}}](https://github.com/mongodb/atlas-sdk-go/blob/main/docs/{{apiDocPath}}{{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{summary}}
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 
 ## Documentation For Models


### PR DESCRIPTION
## Description

Fixes a few things that don't work when transforming md files to rST: notes aren't rendering properly, bold links display with asterisks, and need absolute path for links (please let me know if I did that last part wrong and I'll fix it)

Link to any related issue(s): 
https://jira.mongodb.org/browse/DOCSP-30282

## Type of change:

N/A- docs change only
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works N/A
- [X] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

Not sure if I have to run make gen-docs or something similar to generate the reference files?
