### PR TITLE
CLOUDP-181547: transformation for nested hashmaps

### DIFF
--- a/admin/model_fts_mappings.go
+++ b/admin/model_fts_mappings.go
@@ -14,7 +14,7 @@ type FTSMappings struct {
 	// Flag that indicates whether the index uses dynamic or static mappings. Required if **mappings.fields** is omitted.
 	Dynamic *bool `json:"dynamic,omitempty"`
 	// One or more field specifications for the Atlas Search index. Required if **mappings.dynamic** is omitted or set to **false**.
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"`
+	Fields map[string]interface{} `json:"fields,omitempty"`
 }
 
 // NewFTSMappings instantiates a new FTSMappings object
@@ -71,9 +71,9 @@ func (o *FTSMappings) SetDynamic(v bool) {
 }
 
 // GetFields returns the Fields field value if set, zero value otherwise.
-func (o *FTSMappings) GetFields() map[string]map[string]interface{} {
+func (o *FTSMappings) GetFields() map[string]interface{} {
 	if o == nil || IsNil(o.Fields) {
-		var ret map[string]map[string]interface{}
+		var ret map[string]interface{}
 		return ret
 	}
 	return o.Fields
@@ -81,9 +81,9 @@ func (o *FTSMappings) GetFields() map[string]map[string]interface{} {
 
 // GetFieldsOk returns a tuple with the Fields field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FTSMappings) GetFieldsOk() (map[string]map[string]interface{}, bool) {
+func (o *FTSMappings) GetFieldsOk() (map[string]interface{}, bool) {
 	if o == nil || IsNil(o.Fields) {
-		return map[string]map[string]interface{}{}, false
+		return map[string]interface{}{}, false
 	}
 	return o.Fields, true
 }
@@ -97,8 +97,8 @@ func (o *FTSMappings) HasFields() bool {
 	return false
 }
 
-// SetFields gets a reference to the given map[string]map[string]interface{} and assigns it to the Fields field.
-func (o *FTSMappings) SetFields(v map[string]map[string]interface{}) {
+// SetFields gets a reference to the given map[string]interface{} and assigns it to the Fields field.
+func (o *FTSMappings) SetFields(v map[string]interface{}) {
 	o.Fields = v
 }
 

--- a/admin/model_index_options.go
+++ b/admin/model_index_options.go
@@ -36,17 +36,17 @@ type IndexOptions struct {
 	// Human-readable label that identifies this index. This option applies to all index types.
 	Name *string `json:"name,omitempty"`
 	// Rules that limit the documents that the index references to a filter expression. All MongoDB index types accept a **partialFilterExpression** option. **partialFilterExpression** can include following expressions:  - equality (`\"parameter\" : \"value\"` or using the `$eq` operator) - `\"$exists\": true` , maximum: `$gt`, `$gte`, `$lt`, `$lte` comparisons - `$type` - `$and` (top-level only)  This option applies to all index types.
-	PartialFilterExpression map[string]map[string]interface{} `json:"partialFilterExpression,omitempty"`
+	PartialFilterExpression map[string]interface{} `json:"partialFilterExpression,omitempty"`
 	// Flag that indicates whether the index references documents that only have the specified parameter. These indexes use less space but behave differently in some situations like when sorting. The following index types default to sparse and ignore this option: `2dsphere`, `2d`, `geoHaystack`, `text`.  Compound indexes that includes one or more indexes with `2dsphere` keys alongside other key types, only the `2dsphere` index parameters determine which documents the index references. If you run MongoDB 3.2 or later, use partial indexes. This option applies to all index types.
 	Sparse *bool `json:"sparse,omitempty"`
 	// Storage engine set for the specific index. This value can be set only at creation. This option uses the following format: `\"storageEngine\" : { \"<storage-engine-name>\" : \"<options>\" }` MongoDB validates storage engine configuration options when creating indexes. To support replica sets with members with different storage engines, MongoDB logs these options to the oplog during replication. This option applies to all index types.
-	StorageEngine map[string]map[string]interface{} `json:"storageEngine,omitempty"`
+	StorageEngine map[string]interface{} `json:"storageEngine,omitempty"`
 	// Version applied to this text index. MongoDB 3.2 and later use version `3`. Use this option to override the default version number. This option applies to the **text** index type only.
 	TextIndexVersion *int `json:"textIndexVersion,omitempty"`
 	// Flag that indicates whether this index can accept insertion or update of documents when the index key value matches an existing index key value. Set `\"unique\" : true` to set this index as unique. You can't set a hashed index to be unique. This option applies to all index types.
 	Unique *bool `json:"unique,omitempty"`
 	// Relative importance to place upon provided index parameters. This object expresses this as key/value pairs of index parameter and weight to apply to that parameter. You can specify weights for some or all the indexed parameters. The weight must be an integer between 1 and 99,999. MongoDB 5.0 and later can apply **weights** to **text** indexes only.
-	Weights map[string]map[string]interface{} `json:"weights,omitempty"`
+	Weights map[string]interface{} `json:"weights,omitempty"`
 }
 
 // NewIndexOptions instantiates a new IndexOptions object
@@ -495,9 +495,9 @@ func (o *IndexOptions) SetName(v string) {
 }
 
 // GetPartialFilterExpression returns the PartialFilterExpression field value if set, zero value otherwise.
-func (o *IndexOptions) GetPartialFilterExpression() map[string]map[string]interface{} {
+func (o *IndexOptions) GetPartialFilterExpression() map[string]interface{} {
 	if o == nil || IsNil(o.PartialFilterExpression) {
-		var ret map[string]map[string]interface{}
+		var ret map[string]interface{}
 		return ret
 	}
 	return o.PartialFilterExpression
@@ -505,9 +505,9 @@ func (o *IndexOptions) GetPartialFilterExpression() map[string]map[string]interf
 
 // GetPartialFilterExpressionOk returns a tuple with the PartialFilterExpression field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *IndexOptions) GetPartialFilterExpressionOk() (map[string]map[string]interface{}, bool) {
+func (o *IndexOptions) GetPartialFilterExpressionOk() (map[string]interface{}, bool) {
 	if o == nil || IsNil(o.PartialFilterExpression) {
-		return map[string]map[string]interface{}{}, false
+		return map[string]interface{}{}, false
 	}
 	return o.PartialFilterExpression, true
 }
@@ -521,8 +521,8 @@ func (o *IndexOptions) HasPartialFilterExpression() bool {
 	return false
 }
 
-// SetPartialFilterExpression gets a reference to the given map[string]map[string]interface{} and assigns it to the PartialFilterExpression field.
-func (o *IndexOptions) SetPartialFilterExpression(v map[string]map[string]interface{}) {
+// SetPartialFilterExpression gets a reference to the given map[string]interface{} and assigns it to the PartialFilterExpression field.
+func (o *IndexOptions) SetPartialFilterExpression(v map[string]interface{}) {
 	o.PartialFilterExpression = v
 }
 
@@ -559,9 +559,9 @@ func (o *IndexOptions) SetSparse(v bool) {
 }
 
 // GetStorageEngine returns the StorageEngine field value if set, zero value otherwise.
-func (o *IndexOptions) GetStorageEngine() map[string]map[string]interface{} {
+func (o *IndexOptions) GetStorageEngine() map[string]interface{} {
 	if o == nil || IsNil(o.StorageEngine) {
-		var ret map[string]map[string]interface{}
+		var ret map[string]interface{}
 		return ret
 	}
 	return o.StorageEngine
@@ -569,9 +569,9 @@ func (o *IndexOptions) GetStorageEngine() map[string]map[string]interface{} {
 
 // GetStorageEngineOk returns a tuple with the StorageEngine field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *IndexOptions) GetStorageEngineOk() (map[string]map[string]interface{}, bool) {
+func (o *IndexOptions) GetStorageEngineOk() (map[string]interface{}, bool) {
 	if o == nil || IsNil(o.StorageEngine) {
-		return map[string]map[string]interface{}{}, false
+		return map[string]interface{}{}, false
 	}
 	return o.StorageEngine, true
 }
@@ -585,8 +585,8 @@ func (o *IndexOptions) HasStorageEngine() bool {
 	return false
 }
 
-// SetStorageEngine gets a reference to the given map[string]map[string]interface{} and assigns it to the StorageEngine field.
-func (o *IndexOptions) SetStorageEngine(v map[string]map[string]interface{}) {
+// SetStorageEngine gets a reference to the given map[string]interface{} and assigns it to the StorageEngine field.
+func (o *IndexOptions) SetStorageEngine(v map[string]interface{}) {
 	o.StorageEngine = v
 }
 
@@ -655,9 +655,9 @@ func (o *IndexOptions) SetUnique(v bool) {
 }
 
 // GetWeights returns the Weights field value if set, zero value otherwise.
-func (o *IndexOptions) GetWeights() map[string]map[string]interface{} {
+func (o *IndexOptions) GetWeights() map[string]interface{} {
 	if o == nil || IsNil(o.Weights) {
-		var ret map[string]map[string]interface{}
+		var ret map[string]interface{}
 		return ret
 	}
 	return o.Weights
@@ -665,9 +665,9 @@ func (o *IndexOptions) GetWeights() map[string]map[string]interface{} {
 
 // GetWeightsOk returns a tuple with the Weights field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *IndexOptions) GetWeightsOk() (map[string]map[string]interface{}, bool) {
+func (o *IndexOptions) GetWeightsOk() (map[string]interface{}, bool) {
 	if o == nil || IsNil(o.Weights) {
-		return map[string]map[string]interface{}{}, false
+		return map[string]interface{}{}, false
 	}
 	return o.Weights, true
 }
@@ -681,8 +681,8 @@ func (o *IndexOptions) HasWeights() bool {
 	return false
 }
 
-// SetWeights gets a reference to the given map[string]map[string]interface{} and assigns it to the Weights field.
-func (o *IndexOptions) SetWeights(v map[string]map[string]interface{}) {
+// SetWeights gets a reference to the given map[string]interface{} and assigns it to the Weights field.
+func (o *IndexOptions) SetWeights(v map[string]interface{}) {
 	o.Weights = v
 }
 

--- a/openapi/atlas-api-transformed.yaml
+++ b/openapi/atlas-api-transformed.yaml
@@ -15386,7 +15386,6 @@ components:
         partialFilterExpression:
           type: object
           additionalProperties:
-            type: object
             description: >-
               Rules that limit the documents that the index references to a
               filter expression. All MongoDB index types accept a
@@ -15436,7 +15435,6 @@ components:
         storageEngine:
           type: object
           additionalProperties:
-            type: object
             description: 'Storage engine set for the specific index. This value can be set
               only at creation. This option uses the following format:
               `"storageEngine" : { "<storage-engine-name>" : "<options>" }`
@@ -15475,7 +15473,6 @@ components:
         weights:
           type: object
           additionalProperties:
-            type: object
             description: Relative importance to place upon provided index parameters. This
               object expresses this as key/value pairs of index parameter and
               weight to apply to that parameter. You can specify weights for
@@ -28536,7 +28533,6 @@ components:
         fields:
           type: object
           additionalProperties:
-            type: object
             externalDocs:
               description: Atlas Search Field Mappings
               url: https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings/#define-field-mappings

--- a/openapi/atlas-api.yaml
+++ b/openapi/atlas-api.yaml
@@ -33902,7 +33902,6 @@ components:
         partialFilterExpression:
           type: object
           additionalProperties:
-            type: object
             description: |-
               Rules that limit the documents that the index references to a filter expression. All MongoDB index types accept a **partialFilterExpression** option. **partialFilterExpression** can include following expressions:
 

--- a/tools/transformer/src/atlasTransformations.js
+++ b/tools/transformer/src/atlasTransformations.js
@@ -6,6 +6,7 @@ const {
   applyArrayTransformations,
   transformOneOfProperties,
   applyRemoveEnumsTransformations,
+  applyRemoveObjectAdditonalProperties,
 } = require("./transformations");
 
 const removeUnusedSchemas = require("./engine/removeUnused");
@@ -77,6 +78,7 @@ module.exports = function runTransformations(openapi) {
   ]);
 
   applyRemoveEnumsTransformations(openapi);
+  applyRemoveObjectAdditonalProperties(openapi);
 
   // Required for RegionConfig
   workaroundNestedTransformations(openapi);

--- a/tools/transformer/src/transformations/additionalPropertiesObject.js
+++ b/tools/transformer/src/transformations/additionalPropertiesObject.js
@@ -1,0 +1,49 @@
+/**
+ * Remove all AdditonalProperties object section
+ * That generates an map[string]map[string]string objects for SDK
+ * but for our API much safer is to rely on the map[string]interface{}
+ * This is due to the fact that dynamic field can be array which would
+ * not be possible to represent in map[string]map[string]string structure.
+ * @param {*} api OpenAPI JSON File
+ * @param modelNames
+ * @returns OpenAPI JSON File
+ */
+function applyRemoveObjectAdditonalProperties(api) {
+  const hasSchemas = api && api.components && api.components.schemas;
+  if (!hasSchemas) {
+    throw new Error("Missing schemas in openapi");
+  }
+  // Recursive function to traverse the OpenAPI object
+  function removeObjectAdditonalProperties(obj) {
+    if (typeof obj !== "object" || obj === null) {
+      return;
+    }
+
+    if (Array.isArray(obj)) {
+      for (let i = 0; i < obj.length; i++) {
+        removeObjectAdditonalProperties(obj[i]);
+      }
+    } else {
+      // Remove enum field if present
+      if (obj.hasOwnProperty("additionalProperties")) {
+        if (obj.additionalProperties.type === "object") {
+          delete obj.additionalProperties.type;
+        }
+      }
+
+      // Traverse nested properties
+      for (const prop in obj) {
+        if (obj.hasOwnProperty(prop)) {
+          removeObjectAdditonalProperties(obj[prop]);
+        }
+      }
+    }
+  }
+
+  // Start removing enum fields from the OpenAPI object
+  removeObjectAdditonalProperties(api);
+}
+
+module.exports = {
+  applyRemoveObjectAdditonalProperties,
+};

--- a/tools/transformer/src/transformations/index.js
+++ b/tools/transformer/src/transformations/index.js
@@ -8,6 +8,9 @@ const {
 const { applyDiscriminatorTransformations } = require("./discriminator");
 const { applyArrayTransformations } = require("./swapArray");
 const { applyRemoveEnumsTransformations } = require("./removeEnums");
+const {
+  applyRemoveObjectAdditonalProperties,
+} = require("./additionalPropertiesObject");
 
 module.exports = {
   applyModelNameTransformations,
@@ -19,4 +22,5 @@ module.exports = {
   applyDiscriminatorTransformations,
   applyArrayTransformations,
   applyRemoveEnumsTransformations,
+  applyRemoveObjectAdditonalProperties,
 };


### PR DESCRIPTION
## Description

New transformation is required to relax json parser for cases when we want to support object and array.
Api with additionalProperties properly generates an map[string]map[string]interface{} objects for SDK.
However in multiple cases for search all we need is  map[string]interface{}