### PR TITLE
CLOUDP-182930:  fix discriminator parser 

### DIFF
--- a/admin/model_create_endpoint_request.go
+++ b/admin/model_create_endpoint_request.go
@@ -79,12 +79,9 @@ func (dst *CreateEndpointRequest) UnmarshalJSON(data []byte) error {
 	}
 
 	if match > 1 { // more than 1 match
-		// reset to nil
-		dst.CreateAWSEndpointRequest = nil
-		dst.CreateAzureEndpointRequest = nil
-		dst.CreateGCPEndpointGroupRequest = nil
-
-		return fmt.Errorf("data matches more than one schema in oneOf(CreateEndpointRequest)")
+		// We give number of objects to clients that can be parsed.
+		// Typically that should return error
+		return nil
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match

--- a/admin/model_fts_analyzers_char_filters_inner.go
+++ b/admin/model_fts_analyzers_char_filters_inner.go
@@ -100,13 +100,9 @@ func (dst *FTSAnalyzersCharFiltersInner) UnmarshalJSON(data []byte) error {
 	}
 
 	if match > 1 { // more than 1 match
-		// reset to nil
-		dst.CharFilterhtmlStrip = nil
-		dst.CharFiltericuNormalize = nil
-		dst.CharFiltermapping = nil
-		dst.CharFilterpersian = nil
-
-		return fmt.Errorf("data matches more than one schema in oneOf(FTSAnalyzersCharFiltersInner)")
+		// We give number of objects to clients that can be parsed.
+		// Typically that should return error
+		return nil
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match

--- a/admin/model_fts_analyzers_tokenizer.go
+++ b/admin/model_fts_analyzers_tokenizer.go
@@ -184,17 +184,9 @@ func (dst *FTSAnalyzersTokenizer) UnmarshalJSON(data []byte) error {
 	}
 
 	if match > 1 { // more than 1 match
-		// reset to nil
-		dst.TokenizeredgeGram = nil
-		dst.Tokenizerkeyword = nil
-		dst.TokenizernGram = nil
-		dst.TokenizerregexCaptureGroup = nil
-		dst.TokenizerregexSplit = nil
-		dst.Tokenizerstandard = nil
-		dst.TokenizeruaxUrlEmail = nil
-		dst.Tokenizerwhitespace = nil
-
-		return fmt.Errorf("data matches more than one schema in oneOf(FTSAnalyzersTokenizer)")
+		// We give number of objects to clients that can be parsed.
+		// Typically that should return error
+		return nil
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match

--- a/tools/config/go-templates/model_oneof.mustache
+++ b/tools/config/go-templates/model_oneof.mustache
@@ -70,12 +70,9 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 
 	{{/oneOf}}
 	if match > 1 { // more than 1 match
-		// reset to nil
-		{{#oneOf}}
-		dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}} = nil
-		{{/oneOf}}
-
-		return fmt.Errorf("data matches more than one schema in oneOf({{classname}})")
+		// We give number of objects to clients that can be parsed. 
+		// Typically that should return error
+		return nil
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match
@@ -101,12 +98,9 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 
 	{{/oneOf}}
 	if match > 1 { // more than 1 match
-		// reset to nil
-		{{#oneOf}}
-		dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}} = nil
-		{{/oneOf}}
-
-		return fmt.Errorf("data matches more than one schema in oneOf({{classname}})")
+		// We give number of objects to clients that can be parsed. 
+		// Typically that should return error
+		return nil
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match


### PR DESCRIPTION
## Description

Initially our design for SDK assumed that if we missing discriminator and we cannot in clear way make API to return one instance we should fail. This is semanitically valid for oneOf statement, but.. it does generate number of failures that are usually found at the later state of using SDK.  

This PR changes our approach for oneOf handling giving users the ability to access multiple parsed objects. 
This requires some validation and discussion but it seems like an alternative to just returning errors.
  
 NOTE: all modified source code in this PR might actually require discriminator mapping upstream or adding transformation extension to openapi. This way we going to solve problems globally. 