### PR TITLE
(DOCSP-30718) Changes relative link that will 404 in Atlas docs

### DIFF
--- a/docs/doc_1_concepts.md
+++ b/docs/doc_1_concepts.md
@@ -54,7 +54,7 @@ This signifies that the method might be changed in the future without compatibil
 
 If you encounter any problems with methods marked as experimental, feel free to raise a [Github issue](https://github.com/mongodb/atlas-sdk-go/issues/new/choose) and the team will work to resolve it.
 
-If you belive a method should be marked as stable, feel free to raise a PR appending the method's OperationId to our [operations.stable.json](../tools/transformer/src/operations.stable.json) set
+If you belive a method should be marked as stable, feel free to raise a PR appending the method's OperationId to our [operations.stable.json](https://github.com/mongodb/atlas-sdk-go/blob/main/tools/transformer/src/operations.stable.json) set.
 
 ## Example
 


### PR DESCRIPTION
## Description

The last docs PR added a relative link, which will 404 when we pull it into Atlas docs. This PR changes it to an absolute URL

Link to any related issue(s): https://jira.mongodb.org/browse/DOCSP-30718

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

