### PR TITLE
fix: remove unneeded reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    reviewers:
-      - "mongodb/apix-1"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
We do have codeowners in place for all repo so dependabot will not be able to add those