### PR TITLE
fix: rename example file to match expected naming

### DIFF
--- a/test/example_client_test.go
+++ b/test/example_client_test.go
@@ -17,7 +17,7 @@ func ExampleNewClient() {
 		admin.UseDebug(false))
 
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 	serverURL := sdk.GetConfig().Servers[0].URL


### PR DESCRIPTION
## Description

Rename file to match expected naming practices for examples

