### PR TITLE
CLOUDP-184833: include do not merge just in case someone approves PR

### DIFF
--- a/.github/workflows/autoupdate-dev.yaml
+++ b/.github/workflows/autoupdate-dev.yaml
@@ -45,6 +45,7 @@ jobs:
           branch: dev-latest
           body: |
             Automatic update for MongoDB Atlas Go Client based on **release candidate* OpenAPI file.
+            ** DO NOT MERGE THIS PR TO THE MAIN BRANCH **
 
             > NOTE: This PR provides notifications for stability of the RC OpenAPI files
             > It is not intented to be merged!


### PR DESCRIPTION
## Description

Nit: We need to clearly inform developers that dev channel changes should not be merged.
We have number of other mitigations in place including branch protection but they still can be avoided when no clear message about the purpose of the PR is provided. 