### PR TITLE
CLOUDP-181568: improve unit testing and mocking for API errors

### DIFF
--- a/admin/client.go
+++ b/admin/client.go
@@ -750,12 +750,12 @@ func (e GenericOpenAPIError) Model() Error {
 	return e.model
 }
 
-// Sets model instance: Should be only used for testing
+// SetModel sets model instance: Should be only used for testing
 func (e GenericOpenAPIError) SetModel(errorModel Error) {
 	e.model = errorModel
 }
 
-// Sets error string: Should be only used for testing
+// SetError sets error string: Should be only used for testing
 func (e GenericOpenAPIError) SetError(errorString string) {
 	e.error = errorString
 }

--- a/admin/client.go
+++ b/admin/client.go
@@ -750,6 +750,16 @@ func (e GenericOpenAPIError) Model() Error {
 	return e.model
 }
 
+// Sets model instance: Should be only used for testing
+func (e GenericOpenAPIError) SetModel(errorModel Error) {
+	e.model = errorModel
+}
+
+// Sets error string: Should be only used for testing
+func (e GenericOpenAPIError) SetError(errorString string) {
+	e.error = errorString
+}
+
 // format error message using title and detail when model implements Error
 func formatErrorMessage(status, path, method string, v Error) string {
 	return fmt.Sprintf("%v %v: HTTP %d (Error code: %q) Detail: %v Reason: %v. Params: %v",

--- a/tools/config/go-templates/client.mustache
+++ b/tools/config/go-templates/client.mustache
@@ -717,12 +717,12 @@ func (e GenericOpenAPIError) Model() Error {
 	return e.model
 }
 
-// Sets model instance: Should be only used for testing
+// SetModel sets model instance: Should be only used for testing
 func (e GenericOpenAPIError) SetModel(errorModel Error) {
 	e.model = errorModel;
 }
 
-// Sets error string: Should be only used for testing
+// SetError sets error string: Should be only used for testing
 func (e GenericOpenAPIError) SetError(errorString string) {
 	e.error = errorString;
 }

--- a/tools/config/go-templates/client.mustache
+++ b/tools/config/go-templates/client.mustache
@@ -717,6 +717,16 @@ func (e GenericOpenAPIError) Model() Error {
 	return e.model
 }
 
+// Sets model instance: Should be only used for testing
+func (e GenericOpenAPIError) SetModel(errorModel Error) {
+	e.model = errorModel;
+}
+
+// Sets error string: Should be only used for testing
+func (e GenericOpenAPIError) SetError(errorString string) {
+	e.error = errorString;
+}
+
 // format error message using title and detail when model implements Error
 func formatErrorMessage(status, path, method string, v Error) string {
 	return fmt.Sprintf("%v %v: HTTP %d (Error code: %q) Detail: %v Reason: %v. Params: %v",


### PR DESCRIPTION
## Description

We need to be able to set the values of the generic open API error for purpose of testing and mocking
Alternatively, we could use reflection but that seems overly problematic. 

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

