### PR TITLE
fix: update invalid team in dependabot update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
       interval: weekly
       day: monday
     reviewers:
-      - "mongodb/apix-1"
+      - "mongodb/APIx1"


### PR DESCRIPTION
## Description

Single line change. Updates team name to request reviews properly for dependency updates.