### PR TITLE
fix: remove docs from readme.md change as it is autogenerated

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 # Removing teams
 /docs/docs @mongodb/apix1
 /docs/doc_last_reference.md @mongodb/apix1
+/docs/README.md @mongodb/apix1


### PR DESCRIPTION
We strive to ping docs team only for manual changes and have reviewer assignment actionable.