### PR TITLE
CLOUDP-155909: fetch should use dynamic version from versions.json file

### DIFF
--- a/tools/scripts/fetch.sh
+++ b/tools/scripts/fetch.sh
@@ -16,18 +16,17 @@ set -o nounset
 ## OpenAPI file (latest)
 OPENAPI_FILE_NAME=${OPENAPI_FILE_NAME:-"atlas-api.yaml"}
 
-
 ## Base URL
 API_BASE_URL=${API_BASE_URL:-"https://cloud.mongodb.com/api/openapi"}
 
 ## Folder used for fetching files
 OPENAPI_FOLDER=${OPENAPI_FOLDER:-"../openapi"}
 versions_url="$API_BASE_URL/versions"
+versions_file="versions.json"
 
 pushd "$OPENAPI_FOLDER"
-
 echo "Fetching versions from $versions_url"
-versions_file="versions.json"
+
 curl --show-error --fail --silent -o "$versions_file" \
      -H "Accept: application/json" "$versions_url"
 

--- a/tools/scripts/fetch.sh
+++ b/tools/scripts/fetch.sh
@@ -12,27 +12,28 @@ set -o nounset
 
 ## Input variables with defaults
 
-## Locked version of the versioned API
-CURRENT_REVISION=${CURRENT_REVISION:-"2023-02-01"}
 
 ## OpenAPI file (latest)
 OPENAPI_FILE_NAME=${OPENAPI_FILE_NAME:-"atlas-api.yaml"}
+
 
 ## Base URL
 API_BASE_URL=${API_BASE_URL:-"https://cloud.mongodb.com/api/openapi"}
 
 ## Folder used for fetching files
 OPENAPI_FOLDER=${OPENAPI_FOLDER:-"../openapi"}
-
-openapi_url="$API_BASE_URL/spec/2.0?version=$CURRENT_REVISION&filter=sdk"
 versions_url="$API_BASE_URL/versions"
 
 pushd "$OPENAPI_FOLDER"
 
 echo "Fetching versions from $versions_url"
-
-curl --show-error --fail --silent -o "versions.json" \
+versions_file="versions.json"
+curl --show-error --fail --silent -o "$versions_file" \
      -H "Accept: application/json" "$versions_url"
+
+## Dynamic Versioned API Version
+CURRENT_REVISION=$(cat ./$versions_file | jq -r '.versions."2.0" | .[-1]')
+openapi_url="$API_BASE_URL/spec/2.0?version=$CURRENT_REVISION&filter=sdk"
 
 echo "Fetching api from $openapi_url to $OPENAPI_FILE_NAME"
 


### PR DESCRIPTION
## Description

Automatic fetch operation should no longer be fixed to 2023-02-01 Resource version and rely on versioning metadata.

## Verification

1. Current version works unchanged
```
▶ make fetch_openapi                                    
./scripts/fetch.sh
~/Projects/cloud/atlas-sdk-go/openapi ~/Projects/cloud/atlas-sdk-go/tools
Fetching versions from https://cloud.mongodb.com/api/openapi/versions
Fetching api from https://cloud.mongodb.com/api/openapi/spec/2.0?version=2023-02-01&filter=sdk to atlas-api.yaml
~/Projects/cloud/atlas-sdk-go/openapi
```
2. Previous versions work properly as well. 

```
./scripts/fetch.sh
~/Projects/cloud/atlas-sdk-go/openapi ~/Projects/cloud/atlas-sdk-go/tools
Fetching versions from https://cloud.mongodb.com/api/openapi/versions
Fetching api from https://cloud.mongodb.com/api/openapi/spec/2.0?version=2023-01-01&filter=sdk to atlas-api.yaml
~/Projects/cloud/atlas-sdk-go/openapi
```
