### PR TITLE
chore: Use git refs for all the actions for security hardening

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -16,7 +16,7 @@ jobs:
         run: |
           ./releaser/scripts/setghenv.sh
       - name: Create Release 
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@c9b46fe7aad9f02afd89b12450b780f52dacfb2d
         with:
           body: ${{ env.RELEASE_NOTES }}
           draft: true

--- a/.github/workflows/autoupdate-dev.yaml
+++ b/.github/workflows/autoupdate-dev.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           API_BASE_URL=${{ secrets.MDB_CURRENT_API_PREVIEW_URL }} make fetch_openapi
       - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@v16
+        uses: tj-actions/verify-changed-files@54fe0b71ee3dcf98a88eb23a360ec8d80ba9ed40
         id: verify-changed-files
         with:
           files: |

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -18,7 +18,7 @@ jobs:
         working-directory: ./tools
         run: make fetch_openapi
       - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@v16
+        uses: tj-actions/verify-changed-files@54fe0b71ee3dcf98a88eb23a360ec8d80ba9ed40
         id: verify-changed-files
         with:
           files: |

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run ShellCheck
-        uses: bewuethr/shellcheck-action@v2
+        uses: bewuethr/shellcheck-action@12e22b4b31cc2328d06ce38f0a1c7bde5356277c

--- a/scripts/add-copy.sh
+++ b/scripts/add-copy.sh
@@ -31,4 +31,4 @@ echo "==> Adding copy notice..."
 for FILE in $(find_files); do
     addlicense -c "MongoDB Inc" "${FILE}"
 done
-echo "==> Done..."
+echo "==> Licensing operation finished with success."


### PR DESCRIPTION
## Description

Based on support and security review of our Github actions integration we have done a number of steps to ensure no script injections are possible and we cannot have to third party vendors attack. 

Adding SHA commits is going to be automatically supported by dependabot.

For more info see: 
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions