### PR TITLE
CLOUDP-193204: Ignore empty generation PRs. 

### DIFF
--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -17,17 +17,16 @@ jobs:
       - name: Fetch changes
         working-directory: ./tools
         run: make fetch_openapi
+      - name: Run generation
+        working-directory: ./tools
+        run: |
+          make clean_and_generate
       - name: Verify Changed files
         uses: tj-actions/verify-changed-files@54fe0b71ee3dcf98a88eb23a360ec8d80ba9ed40
         id: verify-changed-files
         with:
           files: |
-             **/atlas-api.yaml
-      - name: Run generation
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
-        working-directory: ./tools
-        run: |
-          make clean_and_generate
+             ./admin/**/*
       - name: Run docs generation
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: make gen-docs


### PR DESCRIPTION
Use generated source code as indication for the creation of the release PR. 