### PR TITLE
Remove omitempty

### DIFF
--- a/admin/model_data_protection_settings.go
+++ b/admin/model_data_protection_settings.go
@@ -23,7 +23,7 @@ type DataProtectionSettings struct {
 	// Number of previous days that you can restore back to with Continuous Cloud Backup with a Backup Compliance Policy. You must specify a positive, non-zero integer, and the maximum retention window can't exceed the hourly retention time. This parameter applies only to Continuous Cloud Backups with a Backup Compliance Policy.
 	RestoreWindowDays *int `json:"restoreWindowDays,omitempty"`
 	// List that contains the specifications for one scheduled policy.
-	ScheduledPolicyItems []DiskBackupApiPolicyItem `json:"scheduledPolicyItems,omitempty"`
+	ScheduledPolicyItems []DiskBackupApiPolicyItem `json:"scheduledPolicyItems"`
 	// Label that indicates the state of the Backup Compliance Policy settings. MongoDB Cloud ignores this setting when you enable or update the Backup Compliance Policy settings.
 	State *string `json:"state,omitempty"`
 	// ISO 8601 timestamp format in UTC that indicates when the user updated the Data Protection Policy settings. MongoDB Cloud ignores this setting when you enable or update the Backup Compliance Policy settings.


### PR DESCRIPTION
## Description

Remove `omitempty` from `ScheduledPolicyItems`. The backend enforces that `ScheduledPolicyItems` is **not** empty, so this `omitempty` tag is virtually pointless and currently blocks some development in the CLI.

A ticket will be made to implement this change in the backend.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

