### PR TITLE
CLOUDP-194380: revisit experimental section in docs

### DIFF
--- a/docs/doc_1_concepts.md
+++ b/docs/doc_1_concepts.md
@@ -49,12 +49,11 @@ Use the `{Operation}()` method to perform modifications. For example:
 
 ## Experimental Methods
 
-Please note that we have some methods marked as experimental, denoted by the [experimental] tag in the operation description. 
-This signifies that the method might be changed in the future without compatibility guarantees.
+GO SDK uses experimental labels in documentation and codebase to mark newly introduced methods that have not yet undergone extensive usage and testing. 
 
-If you encounter any problems with methods marked as experimental, feel free to raise a [Github issue](https://github.com/mongodb/atlas-sdk-go/issues/new/choose) and the team will work to resolve it.
+> NOTE: `Experimental` label is specifically associated with GO SDK methods, and does not pertain to the underlying Atlas feature itself. 
 
-If you belive a method should be marked as stable, feel free to raise a PR appending the method's OperationId to our [operations.stable.json](https://github.com/mongodb/atlas-sdk-go/blob/main/tools/transformer/src/operations.stable.json) set.
+If you encounter any problems with methods marked as experimental, feel free to raise a [Github issue](https://github.com/mongodb/atlas-sdk-go/issues/new/choose).
 
 ## Example
 

--- a/docs/doc_1_concepts.md
+++ b/docs/doc_1_concepts.md
@@ -49,7 +49,7 @@ Use the `{Operation}()` method to perform modifications. For example:
 
 ## Experimental Methods
 
-GO SDK uses experimental labels in documentation and codebase to mark newly introduced methods that have not yet undergone extensive usage and testing. 
+GO SDK uses `experimental` label in documentation and codebase to mark newly introduced methods that have not yet undergone extensive usage and testing. 
 
 > NOTE: `Experimental` label is specifically associated with GO SDK methods, and does not pertain to the underlying Atlas feature itself. 
 

--- a/docs/doc_last_reference.md
+++ b/docs/doc_last_reference.md
@@ -4,7 +4,7 @@
 
 All URIs are relative to *https://cloud.mongodb.com*
 
-Class        | Method        | HTTP request  | Description   | Stability level   
+Class        | Method        | HTTP request  | Description   | [SDK Maturity](https://github.com/mongodb/atlas-sdk-go/blob/main/docs/doc_1_concepts.md#experimental-methods)   
 ------------ | ------------- | ------------- | ------------- | -------------
 *AWSClustersDNSApi* | [GetAWSCustomDNS](./docs/AWSClustersDNSApi.md#getawscustomdns) | **Get** /api/atlas/v2/groups/{groupId}/awsCustomDNS | Return One Custom DNS Configuration for Atlas Clusters on AWS | Experimental
 *AWSClustersDNSApi* | [ToggleAWSCustomDNS](./docs/AWSClustersDNSApi.md#toggleawscustomdns) | **Patch** /api/atlas/v2/groups/{groupId}/awsCustomDNS | Toggle State of One Custom DNS Configuration for Atlas Clusters on AWS | Experimental

--- a/tools/config/go-templates/README.mustache
+++ b/tools/config/go-templates/README.mustache
@@ -4,7 +4,7 @@
 
 All URIs are relative to *{{basePath}}*
 
-Class        | Method        | HTTP request  | Description   | Stability level   
+Class        | Method        | HTTP request  | Description   | [SDK Maturity](https://github.com/mongodb/atlas-sdk-go/blob/main/docs/doc_1_concepts.md#experimental-methods)   
 ------------ | ------------- | ------------- | ------------- | -------------
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{classname}}* | [{{operationId}}](./{{apiDocPath}}{{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{summary}} | {{#vendorExtensions.x-xgen-experimental}}Experimental{{/vendorExtensions.x-xgen-experimental}}{{^vendorExtensions.x-xgen-experimental}}Stable{{/vendorExtensions.x-xgen-experimental}}
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}


### PR DESCRIPTION
## Description

Based on feedback from the product we need to adjust our experimental section for clarity.
Removed internal parts of the experimental section covering update of the operationIds

