### PR TITLE
CLOUDP-195429: detect breaking changes in the SDK

### DIFF
--- a/.github/workflows/autoupdate-preview.yaml
+++ b/.github/workflows/autoupdate-preview.yaml
@@ -58,6 +58,10 @@ jobs:
             2. Documentation style
             3. Transformation engine linting
 
+            ## Breaking Changes
+            
+            For list of possible breaking changes please refer to `Detect Breaking Changes` job.
+
             ## Release schedule
             
             PR is updated 3 times a week with latest changes from the RC for the API.

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -63,9 +63,10 @@ jobs:
             ## Manual Review Procedure
 
             1. Review changes in the OpenAPI file (openapi/atlas-api.yaml)
-            2. If we see any breaking changes without new resource version 
+            2. If we see any breaking changes without new resource version (
+              - Review breaking changes listed in `Detect Breaking Changes` action
               - Checkout PR locally and run `make update-version`
-              - Provide breaking changes infomation in generated ``./releaser/breaking_changes/{release_version}.md` file
+              - Provide breaking changes infomation in generated `./releaser/breaking_changes/{release_version}.md` file
               - Push your changes directly to the automation PR. 
             3. If we have major version release request feedback from additional reviewer if possible.
             4. Merge PR into main branch 

--- a/.github/workflows/breaking-changes.yaml
+++ b/.github/workflows/breaking-changes.yaml
@@ -10,5 +10,5 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version-file: 'go.mod'
     - uses: joelanford/go-apidiff@main

--- a/.github/workflows/breaking-changes.yaml
+++ b/.github/workflows/breaking-changes.yaml
@@ -1,4 +1,4 @@
-name: Detect Breaking Changes
+name: (Optional) Detect Breaking Changes
 on: [ pull_request ]
 jobs:
   go-apidiff:

--- a/.github/workflows/breaking-changes.yaml
+++ b/.github/workflows/breaking-changes.yaml
@@ -7,7 +7,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v2
+    - name: Install Go
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.20
+        go-version: '1.20'
     - uses: joelanford/go-apidiff@main

--- a/.github/workflows/breaking-changes.yaml
+++ b/.github/workflows/breaking-changes.yaml
@@ -1,0 +1,13 @@
+name: Detect Breaking Changes
+on: [ pull_request ]
+jobs:
+  go-apidiff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.20
+    - uses: joelanford/go-apidiff@main


### PR DESCRIPTION
## Description

Detect breaking changes in the SDK using separate optional jobs.
Job failing will mean that we have breaking changes in place and need to take action by documenting changes.

## How this works

1. Job always compares with the main branch
2. It lists all the incompatibilities (it will be subject to false positives which is fine)
3. It is introduced as a separate step so it will be optional and only act as a helper for developers to verify breaking changes

## Not covered 

A lot of improvements in the upstream job is needed to be able to use this action for automatic merges.
I will be looking to help improve that job so we can rely on it with our current automation and minimize false positives, duplicates etc.

## Job in "action"

https://github.com/mongodb/atlas-sdk-go/actions/runs/5950387722/job/16138071247 