### PR TITLE
fix: update issue.yml to use issue number as Ticket title

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -17,15 +17,13 @@
         id: create
         shell: bash
         env:
-          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
           JIRA_ASSIGNEE: ${{ secrets.ASSIGNEE_JIRA_TICKET }}
         run: |
 
-          # Use the tr command to remove the special characters from ISSUE_TITLE
-          ISSUE_TITLE_NO_SPECIAL_CHARS=$(echo "$ISSUE_TITLE" | tr -d '!$&*@#"\047\140')
           json_response=$(curl --request POST \
             --url 'https://jira.mongodb.org/rest/api/2/issue' \
             --header 'Authorization: Bearer '"${JIRA_API_TOKEN}" \
@@ -36,7 +34,7 @@
                   "project": {
                       "id": "10984"
                   },
-                  "summary": "HELP: '"${ISSUE_TITLE_NO_SPECIAL_CHARS}"'",
+                  "summary": "HELP: GitHub Issue n. '"${ISSUE_NUMBER}"'",
                   "issuetype": {
                       "id": "12"
                   },


### PR DESCRIPTION
## Description

The JIRA token has been already rotated in the repo. Once this PR is merged, we can enable the workflow again.

Link to any related issue(s): [INTMDB-1032]( https://jira.mongodb.org/browse/INTMDB-1032)
Follow up PR of https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1422


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

