### PR TITLE
CLOUDP-197445: paths to the version.go file

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths: 
-      - "./internal/core/version.go"
+      - "internal/core/version.go"
   
 jobs:
   release:


### PR DESCRIPTION
## Description

Paths should be git repository paths from git diff.

`./` is not valid prefix as paths aren't executed by bash - they are matched against git diff. 