### PR TITLE
fix: do not run breaking changes on major release

### DIFF
--- a/.github/workflows/breaking-changes.yaml
+++ b/.github/workflows/breaking-changes.yaml
@@ -1,6 +1,7 @@
 name: (Optional) Detect Breaking Changes
 on: 
   pull_request: 
+     ## Exclude major releases containing breaking changes info
      paths: '!tools/releaser/breaking_changes/**'
 
 jobs:

--- a/.github/workflows/breaking-changes.yaml
+++ b/.github/workflows/breaking-changes.yaml
@@ -1,5 +1,8 @@
 name: (Optional) Detect Breaking Changes
-on: [ pull_request ]
+on: 
+  pull_request: 
+     paths: '!tools/releaser/breaking_changes/**'
+
 jobs:
   go-apidiff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Exclude breaking changes job when breaking changes documentation was provided (and major version was released)
Currently due to an issue in upstream library major releases trigger very large diff that we want to avoid generating. 