### PR TITLE
fix: order of the gh actions steps

### DIFF
--- a/.github/workflows/autoupdate-preview.yaml
+++ b/.github/workflows/autoupdate-preview.yaml
@@ -8,11 +8,11 @@ jobs:
   generate-client:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Fetch changes
         working-directory: ./tools
         run: make fetch_openapi

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -8,11 +8,11 @@ jobs:
   generate-client:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Fetch changes
         working-directory: ./tools
         run: make fetch_openapi


### PR DESCRIPTION
## Description

Order of the gh actions steps causing SDK generation to fail when go version is set before checkout.