### PR TITLE
fix: add missing line break to breaking changes file

### DIFF
--- a/tools/releaser/scripts/update-version.sh
+++ b/tools/releaser/scripts/update-version.sh
@@ -19,7 +19,7 @@ echo "Modifying $SDK_MAJOR_VERSION to $BUMPED_MAJOR_VERSION Resource Version acr
 npm exec -c "replace-in-file /$SDK_MAJOR_VERSION/g $BUMPED_MAJOR_VERSION $VERSION_UPDATE_PATHS --isRegex"
 
 echo "Creating empty breaking changes file for $BUMPED_MAJOR_VERSION"
-echo "\n# Breaking Changes" > "$script_path/../breaking_changes/${BUMPED_MAJOR_VERSION}.md"
+printf "\n# Breaking Changes" > "$script_path/../breaking_changes/${BUMPED_MAJOR_VERSION}.md"
 
 ## Explicitly update version.go file
 export SDK_VERSION="${BUMPED_MAJOR_VERSION}.0.0"

--- a/tools/releaser/scripts/update-version.sh
+++ b/tools/releaser/scripts/update-version.sh
@@ -19,7 +19,7 @@ echo "Modifying $SDK_MAJOR_VERSION to $BUMPED_MAJOR_VERSION Resource Version acr
 npm exec -c "replace-in-file /$SDK_MAJOR_VERSION/g $BUMPED_MAJOR_VERSION $VERSION_UPDATE_PATHS --isRegex"
 
 echo "Creating empty breaking changes file for $BUMPED_MAJOR_VERSION"
-printf "\n# Breaking Changes" > "$script_path/../breaking_changes/${BUMPED_MAJOR_VERSION}.md"
+printf "\n# Breaking Changes\n" > "$script_path/../breaking_changes/${BUMPED_MAJOR_VERSION}.md"
 
 ## Explicitly update version.go file
 export SDK_VERSION="${BUMPED_MAJOR_VERSION}.0.0"

--- a/tools/releaser/scripts/update-version.sh
+++ b/tools/releaser/scripts/update-version.sh
@@ -19,7 +19,7 @@ echo "Modifying $SDK_MAJOR_VERSION to $BUMPED_MAJOR_VERSION Resource Version acr
 npm exec -c "replace-in-file /$SDK_MAJOR_VERSION/g $BUMPED_MAJOR_VERSION $VERSION_UPDATE_PATHS --isRegex"
 
 echo "Creating empty breaking changes file for $BUMPED_MAJOR_VERSION"
-echo "# Breaking Changes" > "$script_path/../breaking_changes/${BUMPED_MAJOR_VERSION}.md"
+echo "\n# Breaking Changes" > "$script_path/../breaking_changes/${BUMPED_MAJOR_VERSION}.md"
 
 ## Explicitly update version.go file
 export SDK_VERSION="${BUMPED_MAJOR_VERSION}.0.0"


### PR DESCRIPTION
## Description

 When creating the release I noticed that breaking changes were added with a missing line breaks. 
 This small single-line fix will add the required line break to enable us to automatically release.