### PR TITLE
fix: remove draft mode from autorelease script

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -21,6 +21,5 @@ jobs:
         uses: softprops/action-gh-release@c9b46fe7aad9f02afd89b12450b780f52dacfb2d
         with:
           body: ${{ env.RELEASE_NOTES }}
-          draft: true
           tag_name: ${{ env.RELEASE_TAG }}
           name: ${{ env.RELEASE_TAG }}


### PR DESCRIPTION
## Description

Since releases are very reliable and have been tested over the last +5 releases we can remove draft mode for releases.
Currently, every release requires manual button push that we did not document as it was only temporary measure.

> NOTE: Removing draft mode implies that S3 folder used for major releases contains the required index.html file. 
If not, file should be uploaded before merging auto-update PR. Draft mode gives us time to validate if s3 bucket is present.
