### PR TITLE
task: disable breaking changes job from failing

### DIFF
--- a/.github/workflows/breaking-changes.yaml
+++ b/.github/workflows/breaking-changes.yaml
@@ -16,6 +16,9 @@ jobs:
       with:
         go-version-file: 'go.mod'
     - uses: joelanford/go-apidiff@main
+      continue-on-error: true
+      with:
+        print-compatible: false
     - name: braking change detected
       if: ${{ failure() }}
       run: echo "Review for false positives. If you see any breaking change run `make update-version` and commit the changes."


### PR DESCRIPTION
## Description

Breaking changes job has many false positives and it is failing almost always on the generated PRs. 
I have made a number of fixes upstream that need to be merged. 
For the time being, we do not want our builds to fail but will use action output for inspecting possible breaking changes.
 
