### PR TITLE
CLOUDP-202699: use echo for release script instead of fprint

### DIFF
--- a/tools/releaser/scripts/new-version.sh
+++ b/tools/releaser/scripts/new-version.sh
@@ -22,10 +22,11 @@ else
 	echo "Resource Version is not up to date. Changing major version."
 	NEW_MAJOR_VERSION="${NEW_RESOURCE_VERSION}001"
 	SDK_VERSION="v${NEW_MAJOR_VERSION}.0.0" 
-	echo "Modifying $NEW_RESOURCE_VERSION to $SDK_RESOURCE_VERSION Resource Version across the repository."
+	echo "Modifying all instances of version from $SDK_RESOURCE_VERSION to $NEW_RESOURCE_VERSION across the repository."
 	npm exec -c "replace-in-file /$SDK_MAJOR_VERSION/g $NEW_MAJOR_VERSION $VERSION_UPDATE_PATHS --isRegex"
-	echo "Creating empty breaking changes file for $SDK_MAJOR_VERSION"
-	touch "$script_path/../breaking_changes/${NEW_MAJOR_VERSION}.md"
+	echo "Creating empty breaking changes file for $NEW_MAJOR_VERSION"
+	echo "# Breaking Changes \n https://www.mongodb.com/docs/atlas/reference/api-resources-spec/changelog" \
+		> "$script_path/../breaking_changes/${BUMPED_MAJOR_VERSION}.md"
 fi 
 
 echo "Creating new version.go file with $SDK_VERSION and resource version: $NEW_RESOURCE_VERSION"

--- a/tools/releaser/scripts/new-version.sh
+++ b/tools/releaser/scripts/new-version.sh
@@ -25,7 +25,7 @@ else
 	echo "Modifying all instances of version from $SDK_RESOURCE_VERSION to $NEW_RESOURCE_VERSION across the repository."
 	npm exec -c "replace-in-file /$SDK_MAJOR_VERSION/g $NEW_MAJOR_VERSION $VERSION_UPDATE_PATHS --isRegex"
 	echo "Creating empty breaking changes file for $NEW_MAJOR_VERSION"
-	echo "# Breaking Changes \n https://www.mongodb.com/docs/atlas/reference/api-resources-spec/changelog" \
+	echo -e "# Breaking Changes \n https://www.mongodb.com/docs/atlas/reference/api-resources-spec/changelog" \
 		> "$script_path/../breaking_changes/${BUMPED_MAJOR_VERSION}.md"
 fi 
 

--- a/tools/releaser/scripts/setghenv.sh
+++ b/tools/releaser/scripts/setghenv.sh
@@ -22,8 +22,13 @@ export HYPEN_RESOURCE_VERSION="${HYPEN_RESOURCE_VERSION}"
 EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
 
 RELEASE_NOTES=$(envsubst < "$script_path/../templates/RELEASE_NOTES.tmpl")
-BREAKING_CHANGES=$(cat "$script_path/../breaking_changes/${SDK_MAJOR_VERSION}.md")
-RELEASE_NOTES=$(fprintf "${RELEASE_NOTES}\n${BREAKING_CHANGES}")
+breaking_changes_path="$script_path/../breaking_changes/${SDK_MAJOR_VERSION}.md"
+if [ -f "$breaking_changes_path" ]; then
+   echo "Found breaking changes file for $SDK_MAJOR_VERSION"
+   BREAKING_CHANGES=$(cat $breaking_changes_path)
+   RELEASE_NOTES=$(echo -e "${RELEASE_NOTES}\n\n${BREAKING_CHANGES}")
+fi
+
 
 ## Multiline string
 {

--- a/tools/releaser/scripts/setghenv.sh
+++ b/tools/releaser/scripts/setghenv.sh
@@ -25,7 +25,7 @@ RELEASE_NOTES=$(envsubst < "$script_path/../templates/RELEASE_NOTES.tmpl")
 breaking_changes_path="$script_path/../breaking_changes/${SDK_MAJOR_VERSION}.md"
 if [ -f "$breaking_changes_path" ]; then
    echo "Found breaking changes file for $SDK_MAJOR_VERSION"
-   BREAKING_CHANGES=$(cat $breaking_changes_path)
+   BREAKING_CHANGES=$(cat "$breaking_changes_path")
    RELEASE_NOTES=$(echo -e "${RELEASE_NOTES}\n\n${BREAKING_CHANGES}")
 fi
 


### PR DESCRIPTION
## Description

Minor improvements to the release automation that have failed due to missing fprint binary in github actions:

```
Extracted version versions.json: '20230201'.
./releaser/scripts/setghenv.sh: line 26: fprintf: command not found
```


