### PR TITLE
CLOUDP-206550: regression in breaking changes

### DIFF
--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -75,8 +75,8 @@ jobs:
             ## Manual Review Procedure
 
             1. Review changes in the OpenAPI file (openapi/atlas-api.yaml)
-            2. Review breaking changes information in generated `./releaser/breaking_changes/{release_version}.md` file
-            3. Merge PR into the main branch 
+            2. If PR contains breaking changes, review `./releaser/breaking_changes/{release_version}.md` file
+            3. Approve and merge PR into the main branch 
             4. After the merge automated release process will be triggered. 
             
           


### PR DESCRIPTION
## Description

Breaking changes started to return no results if the base path of the repository is not in the current directory.
I'm going to fix the issue upstream. Providing a workaround to unblock us in the SDK