### PR TITLE
CLOUDP-209888: Remove temp file creation

### DIFF
--- a/admin/api_data_federation.go
+++ b/admin/api_data_federation.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 )
 
@@ -198,7 +197,7 @@ type DataFederationApi interface {
 	DownloadFederatedDatabaseQueryLogsWithParams(ctx context.Context, args *DownloadFederatedDatabaseQueryLogsApiParams) DownloadFederatedDatabaseQueryLogsApiRequest
 
 	// Interface only available internally
-	downloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (*os.File, *http.Response, error)
+	downloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (io.ReadCloser, *http.Response, error)
 
 	/*
 		GetDataFederationPrivateEndpoint Return One Federated Database Instance and Online Archive Private Endpoint in One Project
@@ -1293,7 +1292,7 @@ func (r DownloadFederatedDatabaseQueryLogsApiRequest) StartDate(startDate int64)
 	return r
 }
 
-func (r DownloadFederatedDatabaseQueryLogsApiRequest) Execute() (*os.File, *http.Response, error) {
+func (r DownloadFederatedDatabaseQueryLogsApiRequest) Execute() (io.ReadCloser, *http.Response, error) {
 	return r.ApiService.downloadFederatedDatabaseQueryLogsExecute(r)
 }
 
@@ -1318,13 +1317,13 @@ func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogs(ctx contex
 
 // Execute executes the request
 //
-//	@return *os.File
-func (a *DataFederationApiService) downloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (*os.File, *http.Response, error) {
+//	@return io.ReadCloser
+func (a *DataFederationApiService) downloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (io.ReadCloser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *os.File
+		localVarReturnValue io.ReadCloser
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DataFederationApiService.DownloadFederatedDatabaseQueryLogs")

--- a/admin/api_monitoring_and_logs.go
+++ b/admin/api_monitoring_and_logs.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -144,7 +143,7 @@ type MonitoringAndLogsApi interface {
 	GetHostLogsWithParams(ctx context.Context, args *GetHostLogsApiParams) GetHostLogsApiRequest
 
 	// Interface only available internally
-	getHostLogsExecute(r GetHostLogsApiRequest) (*os.File, *http.Response, error)
+	getHostLogsExecute(r GetHostLogsApiRequest) (io.ReadCloser, *http.Response, error)
 
 	/*
 		GetHostMeasurements Return Measurements for One MongoDB Process
@@ -1118,7 +1117,7 @@ func (r GetHostLogsApiRequest) StartDate(startDate int64) GetHostLogsApiRequest 
 	return r
 }
 
-func (r GetHostLogsApiRequest) Execute() (*os.File, *http.Response, error) {
+func (r GetHostLogsApiRequest) Execute() (io.ReadCloser, *http.Response, error) {
 	return r.ApiService.getHostLogsExecute(r)
 }
 
@@ -1145,13 +1144,13 @@ func (a *MonitoringAndLogsApiService) GetHostLogs(ctx context.Context, groupId s
 
 // Execute executes the request
 //
-//	@return *os.File
-func (a *MonitoringAndLogsApiService) getHostLogsExecute(r GetHostLogsApiRequest) (*os.File, *http.Response, error) {
+//	@return io.ReadCloser
+func (a *MonitoringAndLogsApiService) getHostLogsExecute(r GetHostLogsApiRequest) (io.ReadCloser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *os.File
+		localVarReturnValue io.ReadCloser
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "MonitoringAndLogsApiService.GetHostLogs")

--- a/admin/api_online_archive.go
+++ b/admin/api_online_archive.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 )
 
@@ -85,7 +84,7 @@ type OnlineArchiveApi interface {
 	DownloadOnlineArchiveQueryLogsWithParams(ctx context.Context, args *DownloadOnlineArchiveQueryLogsApiParams) DownloadOnlineArchiveQueryLogsApiRequest
 
 	// Interface only available internally
-	downloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (*os.File, *http.Response, error)
+	downloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (io.ReadCloser, *http.Response, error)
 
 	/*
 		GetOnlineArchive Return One Online Archive
@@ -518,7 +517,7 @@ func (r DownloadOnlineArchiveQueryLogsApiRequest) ArchiveOnly(archiveOnly bool) 
 	return r
 }
 
-func (r DownloadOnlineArchiveQueryLogsApiRequest) Execute() (*os.File, *http.Response, error) {
+func (r DownloadOnlineArchiveQueryLogsApiRequest) Execute() (io.ReadCloser, *http.Response, error) {
 	return r.ApiService.downloadOnlineArchiveQueryLogsExecute(r)
 }
 
@@ -543,13 +542,13 @@ func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogs(ctx context.Con
 
 // Execute executes the request
 //
-//	@return *os.File
-func (a *OnlineArchiveApiService) downloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (*os.File, *http.Response, error) {
+//	@return io.ReadCloser
+func (a *OnlineArchiveApiService) downloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (io.ReadCloser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *os.File
+		localVarReturnValue io.ReadCloser
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OnlineArchiveApiService.DownloadOnlineArchiveQueryLogs")

--- a/docs/doc_5_best_practices.md
+++ b/docs/doc_5_best_practices.md
@@ -54,6 +54,16 @@ When you have confirmed that the `time.Time pointer` is non-nil, you can safely 
     }
 ```
 
+## Working with Binary Responses
+
+In the Atlas Go SDK, the `io.ReadCloser` type is used to return binary data from APIs. 
+
+1. Use `io.Copy` if the intention is to store on a file or pass through another steam
+
+2. Use `io.ReadAll` if the intention is to read all bytes in memory
+
+3. Call the `.Close()` function after done reading the data
+
 ## Use Method for Creating Models
 
 Use dedicated methods for creating new models.

--- a/docs/docs/DataFederationApi.md
+++ b/docs/docs/DataFederationApi.md
@@ -487,7 +487,7 @@ Name | Type | Description  | Notes
 
 ## DownloadFederatedDatabaseQueryLogs
 
-> *os.File DownloadFederatedDatabaseQueryLogs(ctx, groupId, tenantName).EndDate(endDate).StartDate(startDate).Execute()
+> io.ReadCloser DownloadFederatedDatabaseQueryLogs(ctx, groupId, tenantName).EndDate(endDate).StartDate(startDate).Execute()
 
 Download Query Logs for One Federated Database Instance
 
@@ -522,7 +522,7 @@ func main() {
         apiError := admin.AsError(err)
         fmt.Fprintf(os.Stderr, "Error obj: %v\n", apiError)
     }
-    // response from `DownloadFederatedDatabaseQueryLogs`: *os.File
+    // response from `DownloadFederatedDatabaseQueryLogs`: io.ReadCloser
     fmt.Fprintf(os.Stdout, "Response from `DataFederationApi.DownloadFederatedDatabaseQueryLogs`: %v\n", resp)
 }
 ```
@@ -550,7 +550,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[***os.File**](*os.File.md)
+[**io.ReadCloser**](io.ReadCloser.md)
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/MonitoringAndLogsApi.md
+++ b/docs/docs/MonitoringAndLogsApi.md
@@ -361,7 +361,7 @@ Name | Type | Description  | Notes
 
 ## GetHostLogs
 
-> *os.File GetHostLogs(ctx, groupId, hostName, logName).EndDate(endDate).StartDate(startDate).Execute()
+> io.ReadCloser GetHostLogs(ctx, groupId, hostName, logName).EndDate(endDate).StartDate(startDate).Execute()
 
 Download Logs for One Cluster Host in One Project
 
@@ -397,7 +397,7 @@ func main() {
         apiError := admin.AsError(err)
         fmt.Fprintf(os.Stderr, "Error obj: %v\n", apiError)
     }
-    // response from `GetHostLogs`: *os.File
+    // response from `GetHostLogs`: io.ReadCloser
     fmt.Fprintf(os.Stdout, "Response from `MonitoringAndLogsApi.GetHostLogs`: %v\n", resp)
 }
 ```
@@ -427,7 +427,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[***os.File**](*os.File.md)
+[**io.ReadCloser**](io.ReadCloser.md)
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/OnlineArchiveApi.md
+++ b/docs/docs/OnlineArchiveApi.md
@@ -172,7 +172,7 @@ Name | Type | Description  | Notes
 
 ## DownloadOnlineArchiveQueryLogs
 
-> *os.File DownloadOnlineArchiveQueryLogs(ctx, groupId, clusterName).StartDate(startDate).EndDate(endDate).ArchiveOnly(archiveOnly).Execute()
+> io.ReadCloser DownloadOnlineArchiveQueryLogs(ctx, groupId, clusterName).StartDate(startDate).EndDate(endDate).ArchiveOnly(archiveOnly).Execute()
 
 Download Online Archive Query Logs
 
@@ -213,7 +213,7 @@ func main() {
         apiError := admin.AsError(err)
         fmt.Fprintf(os.Stderr, "Error obj: %v\n", apiError)
     }
-    // response from `DownloadOnlineArchiveQueryLogs`: *os.File
+    // response from `DownloadOnlineArchiveQueryLogs`: io.ReadCloser
     fmt.Fprintf(os.Stdout, "Response from `OnlineArchiveApi.DownloadOnlineArchiveQueryLogs`: %v\n", resp)
 }
 ```
@@ -242,7 +242,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[***os.File**](*os.File.md)
+[**io.ReadCloser**](io.ReadCloser.md)
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/examples/download/downloadLogs.go
+++ b/examples/download/downloadLogs.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -41,7 +40,7 @@ func main() {
 	if projects.GetTotalCount() == 0 {
 		log.Fatal("account should have at least single project")
 	}
-	var out io.Writer
+	var out io.Writer = os.Stdout
 	projectId := projects.GetResults()[0].GetId()
 
 	// -- 2. Get first Process
@@ -59,6 +58,9 @@ func main() {
 
 	logs, response, err := sdk.MonitoringAndLogsApi.GetHostLogsWithParams(ctx, params).Execute()
 	examples.HandleErr(err, response)
+	defer func() {
+		_ = logs.Close()
+	}()
 	_, err = io.Copy(out, logs)
-	fmt.Println(err)
+	examples.HandleErr(err, nil)
 }

--- a/tools/config/go-templates/client.mustache
+++ b/tools/config/go-templates/client.mustache
@@ -481,36 +481,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
-	if _, ok := v.(*os.File); ok {
-		f, err1 := os.CreateTemp("", "HttpClientFile")
-		if err1 != nil {
-			if c.cfg.Debug {
-				log.Printf("\n%s\n", err1)
-			}
-			return
-		}
-		_, err1 = f.Write(b)
-		if err != nil {
-			if c.cfg.Debug {
-				log.Printf("\n%s\n", err1)
-			}
-			return
-		}
-		
-		_, _ = f.Seek(0, io.SeekStart)
-	 	return
+	if r, ok := v.(*io.ReadCloser); ok {
+		reader := io.NopCloser(bytes.NewReader(b))
+		*r = reader
+		return nil
 	}
-	if f, ok := v.(**os.File); ok {
-		*f, err = os.CreateTemp("", "HttpClientFile")
-		if err != nil {
-			return
-		}
-		_, err = (*f).Write(b)
-		if err != nil {
-			return
-		}
-		_, err = (*f).Seek(0, io.SeekStart)
-		return
+	if r, ok := v.(**io.ReadCloser); ok {
+		reader := io.NopCloser(bytes.NewReader(b)) 
+		*r = &reader
+		return nil
 	}
 	if xmlCheck.MatchString(contentType) {
 		return xml.Unmarshal(b, v);
@@ -565,8 +544,8 @@ func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err e
 
 	if reader, ok := body.(io.Reader); ok {
 		_, err = bodyBuf.ReadFrom(reader)
-	} else if fp, ok := body.(*os.File); ok {
-		_, err = bodyBuf.ReadFrom(fp)
+	} else if fp, ok := body.(*io.ReadCloser); ok {
+		_, err = bodyBuf.ReadFrom(*fp)
 	} else if b, ok := body.([]byte); ok {
 		_, err = bodyBuf.Write(b)
 	} else if s, ok := body.(string); ok {

--- a/tools/scripts/generate.sh
+++ b/tools/scripts/generate.sh
@@ -34,6 +34,7 @@ npm exec openapi-generator-cli -- generate \
     -c "./config/config.yaml" -i "$openapiFileLocation" -o "$SDK_FOLDER" \
     --package-name="$client_package" \
     --type-mappings=integer=int \
+    --type-mappings=file=io.ReadCloser \
     --ignore-file-override=config/.go-ignore
 
 gofmt -s -w "$SDK_FOLDER/"*.go

--- a/tools/scripts/generate_docs.sh
+++ b/tools/scripts/generate_docs.sh
@@ -24,6 +24,7 @@ npm exec openapi-generator-cli -- generate \
     -c "./config/config.yaml" -i "$openapiFileLocation" -o "$DOC_FOLDER" \
     --package-name="$client_package" \
     --type-mappings=integer=int \
+    --type-mappings=file=io.ReadCloser \
     --ignore-file-override=config/.go-ignore-docs
 
 mv "$DOC_FOLDER"/README.md "$DOC_FOLDER"/doc_last_reference.md

--- a/tools/scripts/generate_tests.sh
+++ b/tools/scripts/generate_tests.sh
@@ -16,5 +16,6 @@ npm exec openapi-generator-cli -- generate \
     -c "./config/config.yaml" -i "$openapiFileLocation" -o "$FOLDER" \
     --package-name="$client_package" \
     --type-mappings=integer=int \
+    --type-mappings=file=io.ReadCloser \
     --ignore-file-override=config/.go-ignore-tests
 


### PR DESCRIPTION
## Description

Currently we are creating temp files on every API that downloads a file from network, this changes it to keep it in memory as oppose to write to disk

Link to any related issue(s):  https://jira.mongodb.org/browse/CLOUDP-209888

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

