### PR TITLE
fix: add breaking changes folder

### DIFF
--- a/tools/releaser/scripts/update-version.sh
+++ b/tools/releaser/scripts/update-version.sh
@@ -17,6 +17,7 @@ major_version_bump=$((major_version_breaking_changes+1))
 major_version_bump=$(printf "%03d" "$major_version_bump")
 BUMPED_MAJOR_VERSION="v${SDK_RESOURCE_VERSION}${major_version_bump}"
 
+mkdir -p "$script_path/../breaking_changes/"
 export TARGET_BREAKING_CHANGES_FILE=${BUMPED_MAJOR_VERSION}
 echo -e "# Breaking Changes\n## SDK changes\n ${BREAKING_CHANGES:-TODO} \n## API Changelog\n https://www.mongodb.com/docs/atlas/reference/api-resources-spec/changelog" \
 		> "$script_path/../breaking_changes/${TARGET_BREAKING_CHANGES_FILE}.md"


### PR DESCRIPTION
## Description

Reason: The folder is required for scripts to function

## What

Adds folder required by breaking changes engine. 
Automatically removes folder if it was removed.

