### PR TITLE
CLOUDP-221643: Document the meaning of read/write only fields

### DIFF
--- a/docs/doc_1_concepts.md
+++ b/docs/doc_1_concepts.md
@@ -55,6 +55,13 @@ Note: The `experimental` label refers specifically to the Atlas Go SDK methods. 
 
 If you encounter any problems with methods marked as experimental, feel free to raise a [Github issue](https://github.com/mongodb/atlas-sdk-go/issues/new/choose).
 
+## Read Only and Write Only Fields
+
+Some fields are documented as `read only` or `write only` in the [documentation](https://github.com/mongodb/atlas-sdk-go/blob/main/docs/doc_last_reference.md#documentation-for-models) and the Go doc comments.
+
+- `read only` fields are included in responses but not in requests
+- `write only` fields may be included in request but not in responses
+
 ## Example
 
 To learn more about using the SDK, see the [basic example](https://github.com/mongodb/atlas-sdk-go/blob/main/examples/basic/basic.go).

--- a/docs/doc_1_concepts.md
+++ b/docs/doc_1_concepts.md
@@ -57,10 +57,12 @@ If you encounter any problems with methods marked as experimental, feel free to 
 
 ## Read Only and Write Only Fields
 
-Some fields are documented as `read only` or `write only` in the [documentation](https://github.com/mongodb/atlas-sdk-go/blob/main/docs/doc_last_reference.md#documentation-for-models) and the Go doc comments.
+Each SDK request and response might contain read or write only fields identified by the [documentation](https://github.com/mongodb/atlas-sdk-go/blob/main/docs/doc_last_reference.md#documentation-for-models) and the Go doc comments.
 
-- `read only` fields are included in responses but not in requests
-- `write only` fields may be included in request but not in responses
+We use GoDoc comments to annotate fields as read and write only:
+
+- `// Read Only field.` means that the field is included in responses but not in requests
+- `// Write Only field.` means that the field may be included in requests but not in responses
 
 ## Example
 

--- a/docs/doc_1_concepts.md
+++ b/docs/doc_1_concepts.md
@@ -57,7 +57,7 @@ If you encounter any problems with methods marked as experimental, feel free to 
 
 ## Read Only and Write Only Fields
 
-Each SDK request and response might contain read or write only fields identified by the [documentation](https://github.com/mongodb/atlas-sdk-go/blob/main/docs/doc_last_reference.md#documentation-for-models) and the Go doc comments.
+Each SDK request and response might contain read or write only fields as identified by the [documentation](https://github.com/mongodb/atlas-sdk-go/blob/main/docs/doc_last_reference.md#documentation-for-models) and the Go doc comments.
 
 We use GoDoc comments to annotate fields as read and write only:
 


### PR DESCRIPTION
## Description

Added documentation on the `read only` and `write only` fields as a follow-up from a previous PR.

Previous change: [CLOUDP-219156](https://jira.mongodb.org/browse/CLOUDP-219156)