### PR TITLE
task: fix message in transformation engine

### DIFF
--- a/tools/transformer/src/transformations/oneOf.js
+++ b/tools/transformer/src/transformations/oneOf.js
@@ -108,7 +108,7 @@ function transformOneOfProperties(parentObject, api) {
           "OpenAPI object is missing properties or allOf field. This is usually an error in the OpenAPI spec."
         );
         console.error(
-          "Please ensure that elements of oneOf schema are objects (classes) instead of single types."
+          "Please ensure that elements of oneOf schema are objects (classes) instead of single types (bool, string etc.)."
         );
         throw new Error(`${JSON.stringify(childObject, "", 2)}`);
       }

--- a/tools/transformer/src/transformations/oneOf.js
+++ b/tools/transformer/src/transformations/oneOf.js
@@ -104,8 +104,12 @@ function transformOneOfProperties(parentObject, api) {
         }
       } else {
         // Otherwise this situation require human intervention
-        console.error("OpenAPI object is missing properties or allOf field. This is usually an error in the OpenAPI spec.")
-        console.error("Please ensure that elements of oneOf schema are objects (classes) instead of single types.")
+        console.error(
+          "OpenAPI object is missing properties or allOf field. This is usually an error in the OpenAPI spec."
+        );
+        console.error(
+          "Please ensure that elements of oneOf schema are objects (classes) instead of single types."
+        );
         throw new Error(`${JSON.stringify(childObject, "", 2)}`);
       }
     }

--- a/tools/transformer/src/transformations/oneOf.js
+++ b/tools/transformer/src/transformations/oneOf.js
@@ -104,6 +104,8 @@ function transformOneOfProperties(parentObject, api) {
         }
       } else {
         // Otherwise this situation require human intervention
+        console.error("OpenAPI object is missing properties or allOf field. This is usually an error in the OpenAPI spec.")
+        console.error("Please ensure that elements of oneOf schema are objects (classes) instead of single types.")
         throw new Error(`${JSON.stringify(childObject, "", 2)}`);
       }
     }


### PR DESCRIPTION
## Description

Add error information for situations when OpenAPI schema contains base types (int,bool, string etc.) instead of objects.
We do have error returned for this cases but were missing explanation why this is happening.

## Reason

OneOf of mixed types cannot be represented correctly. When dealing with objects we can merge them but any other form of base types will introduce invalid behaviour. 

 