### PR TITLE
CLOUDP-222817: make execute methods mockable

### DIFF
--- a/admin/api_access_tracking.go
+++ b/admin/api_access_tracking.go
@@ -35,7 +35,7 @@ type AccessTrackingApi interface {
 	ListAccessLogsByClusterNameWithParams(ctx context.Context, args *ListAccessLogsByClusterNameApiParams) ListAccessLogsByClusterNameApiRequest
 
 	// Interface only available internally
-	listAccessLogsByClusterNameExecute(r ListAccessLogsByClusterNameApiRequest) (*MongoDBAccessLogsList, *http.Response, error)
+	ListAccessLogsByClusterNameExecute(r ListAccessLogsByClusterNameApiRequest) (*MongoDBAccessLogsList, *http.Response, error)
 
 	/*
 		ListAccessLogsByHostname Return Database Access History for One Cluster using Its Hostname
@@ -59,7 +59,7 @@ type AccessTrackingApi interface {
 	ListAccessLogsByHostnameWithParams(ctx context.Context, args *ListAccessLogsByHostnameApiParams) ListAccessLogsByHostnameApiRequest
 
 	// Interface only available internally
-	listAccessLogsByHostnameExecute(r ListAccessLogsByHostnameApiRequest) (*MongoDBAccessLogsList, *http.Response, error)
+	ListAccessLogsByHostnameExecute(r ListAccessLogsByHostnameApiRequest) (*MongoDBAccessLogsList, *http.Response, error)
 }
 
 // AccessTrackingApiService AccessTrackingApi service
@@ -132,7 +132,7 @@ func (r ListAccessLogsByClusterNameApiRequest) Start(start int64) ListAccessLogs
 }
 
 func (r ListAccessLogsByClusterNameApiRequest) Execute() (*MongoDBAccessLogsList, *http.Response, error) {
-	return r.ApiService.listAccessLogsByClusterNameExecute(r)
+	return r.ApiService.ListAccessLogsByClusterNameExecute(r)
 }
 
 /*
@@ -157,7 +157,7 @@ func (a *AccessTrackingApiService) ListAccessLogsByClusterName(ctx context.Conte
 // Execute executes the request
 //
 //	@return MongoDBAccessLogsList
-func (a *AccessTrackingApiService) listAccessLogsByClusterNameExecute(r ListAccessLogsByClusterNameApiRequest) (*MongoDBAccessLogsList, *http.Response, error) {
+func (a *AccessTrackingApiService) ListAccessLogsByClusterNameExecute(r ListAccessLogsByClusterNameApiRequest) (*MongoDBAccessLogsList, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -326,7 +326,7 @@ func (r ListAccessLogsByHostnameApiRequest) Start(start int64) ListAccessLogsByH
 }
 
 func (r ListAccessLogsByHostnameApiRequest) Execute() (*MongoDBAccessLogsList, *http.Response, error) {
-	return r.ApiService.listAccessLogsByHostnameExecute(r)
+	return r.ApiService.ListAccessLogsByHostnameExecute(r)
 }
 
 /*
@@ -351,7 +351,7 @@ func (a *AccessTrackingApiService) ListAccessLogsByHostname(ctx context.Context,
 // Execute executes the request
 //
 //	@return MongoDBAccessLogsList
-func (a *AccessTrackingApiService) listAccessLogsByHostnameExecute(r ListAccessLogsByHostnameApiRequest) (*MongoDBAccessLogsList, *http.Response, error) {
+func (a *AccessTrackingApiService) ListAccessLogsByHostnameExecute(r ListAccessLogsByHostnameApiRequest) (*MongoDBAccessLogsList, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_access_tracking.go
+++ b/admin/api_access_tracking.go
@@ -34,7 +34,7 @@ type AccessTrackingApi interface {
 	*/
 	ListAccessLogsByClusterNameWithParams(ctx context.Context, args *ListAccessLogsByClusterNameApiParams) ListAccessLogsByClusterNameApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListAccessLogsByClusterNameExecute(r ListAccessLogsByClusterNameApiRequest) (*MongoDBAccessLogsList, *http.Response, error)
 
 	/*
@@ -58,7 +58,7 @@ type AccessTrackingApi interface {
 	*/
 	ListAccessLogsByHostnameWithParams(ctx context.Context, args *ListAccessLogsByHostnameApiParams) ListAccessLogsByHostnameApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListAccessLogsByHostnameExecute(r ListAccessLogsByHostnameApiRequest) (*MongoDBAccessLogsList, *http.Response, error)
 }
 

--- a/admin/api_alert_configurations.go
+++ b/admin/api_alert_configurations.go
@@ -36,7 +36,7 @@ type AlertConfigurationsApi interface {
 	CreateAlertConfigurationWithParams(ctx context.Context, args *CreateAlertConfigurationApiParams) CreateAlertConfigurationApiRequest
 
 	// Interface only available internally
-	createAlertConfigurationExecute(r CreateAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error)
+	CreateAlertConfigurationExecute(r CreateAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error)
 
 	/*
 		DeleteAlertConfiguration Remove One Alert Configuration from One Project
@@ -62,7 +62,7 @@ type AlertConfigurationsApi interface {
 	DeleteAlertConfigurationWithParams(ctx context.Context, args *DeleteAlertConfigurationApiParams) DeleteAlertConfigurationApiRequest
 
 	// Interface only available internally
-	deleteAlertConfigurationExecute(r DeleteAlertConfigurationApiRequest) (*http.Response, error)
+	DeleteAlertConfigurationExecute(r DeleteAlertConfigurationApiRequest) (*http.Response, error)
 
 	/*
 		GetAlertConfiguration Return One Alert Configuration from One Project
@@ -88,7 +88,7 @@ type AlertConfigurationsApi interface {
 	GetAlertConfigurationWithParams(ctx context.Context, args *GetAlertConfigurationApiParams) GetAlertConfigurationApiRequest
 
 	// Interface only available internally
-	getAlertConfigurationExecute(r GetAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error)
+	GetAlertConfigurationExecute(r GetAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error)
 
 	/*
 		ListAlertConfigurationMatchersFieldNames Get All Alert Configuration Matchers Field Names
@@ -110,7 +110,7 @@ type AlertConfigurationsApi interface {
 	ListAlertConfigurationMatchersFieldNamesWithParams(ctx context.Context, args *ListAlertConfigurationMatchersFieldNamesApiParams) ListAlertConfigurationMatchersFieldNamesApiRequest
 
 	// Interface only available internally
-	listAlertConfigurationMatchersFieldNamesExecute(r ListAlertConfigurationMatchersFieldNamesApiRequest) ([]string, *http.Response, error)
+	ListAlertConfigurationMatchersFieldNamesExecute(r ListAlertConfigurationMatchersFieldNamesApiRequest) ([]string, *http.Response, error)
 
 	/*
 		ListAlertConfigurations Return All Alert Configurations for One Project
@@ -135,7 +135,7 @@ type AlertConfigurationsApi interface {
 	ListAlertConfigurationsWithParams(ctx context.Context, args *ListAlertConfigurationsApiParams) ListAlertConfigurationsApiRequest
 
 	// Interface only available internally
-	listAlertConfigurationsExecute(r ListAlertConfigurationsApiRequest) (*PaginatedAlertConfig, *http.Response, error)
+	ListAlertConfigurationsExecute(r ListAlertConfigurationsApiRequest) (*PaginatedAlertConfig, *http.Response, error)
 
 	/*
 		ListAlertConfigurationsByAlertId Return All Alert Configurations Set for One Alert
@@ -161,7 +161,7 @@ type AlertConfigurationsApi interface {
 	ListAlertConfigurationsByAlertIdWithParams(ctx context.Context, args *ListAlertConfigurationsByAlertIdApiParams) ListAlertConfigurationsByAlertIdApiRequest
 
 	// Interface only available internally
-	listAlertConfigurationsByAlertIdExecute(r ListAlertConfigurationsByAlertIdApiRequest) (*PaginatedAlertConfig, *http.Response, error)
+	ListAlertConfigurationsByAlertIdExecute(r ListAlertConfigurationsByAlertIdApiRequest) (*PaginatedAlertConfig, *http.Response, error)
 
 	/*
 		ToggleAlertConfiguration Toggle One State of One Alert Configuration in One Project
@@ -189,7 +189,7 @@ type AlertConfigurationsApi interface {
 	ToggleAlertConfigurationWithParams(ctx context.Context, args *ToggleAlertConfigurationApiParams) ToggleAlertConfigurationApiRequest
 
 	// Interface only available internally
-	toggleAlertConfigurationExecute(r ToggleAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error)
+	ToggleAlertConfigurationExecute(r ToggleAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error)
 
 	/*
 		UpdateAlertConfiguration Update One Alert Configuration for One Project
@@ -217,7 +217,7 @@ type AlertConfigurationsApi interface {
 	UpdateAlertConfigurationWithParams(ctx context.Context, args *UpdateAlertConfigurationApiParams) UpdateAlertConfigurationApiRequest
 
 	// Interface only available internally
-	updateAlertConfigurationExecute(r UpdateAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error)
+	UpdateAlertConfigurationExecute(r UpdateAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error)
 }
 
 // AlertConfigurationsApiService AlertConfigurationsApi service
@@ -245,7 +245,7 @@ func (a *AlertConfigurationsApiService) CreateAlertConfigurationWithParams(ctx c
 }
 
 func (r CreateAlertConfigurationApiRequest) Execute() (*GroupAlertsConfig, *http.Response, error) {
-	return r.ApiService.createAlertConfigurationExecute(r)
+	return r.ApiService.CreateAlertConfigurationExecute(r)
 }
 
 /*
@@ -271,7 +271,7 @@ func (a *AlertConfigurationsApiService) CreateAlertConfiguration(ctx context.Con
 // Execute executes the request
 //
 //	@return GroupAlertsConfig
-func (a *AlertConfigurationsApiService) createAlertConfigurationExecute(r CreateAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error) {
+func (a *AlertConfigurationsApiService) CreateAlertConfigurationExecute(r CreateAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -380,7 +380,7 @@ func (a *AlertConfigurationsApiService) DeleteAlertConfigurationWithParams(ctx c
 }
 
 func (r DeleteAlertConfigurationApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.deleteAlertConfigurationExecute(r)
+	return r.ApiService.DeleteAlertConfigurationExecute(r)
 }
 
 /*
@@ -405,7 +405,7 @@ func (a *AlertConfigurationsApiService) DeleteAlertConfiguration(ctx context.Con
 }
 
 // Execute executes the request
-func (a *AlertConfigurationsApiService) deleteAlertConfigurationExecute(r DeleteAlertConfigurationApiRequest) (*http.Response, error) {
+func (a *AlertConfigurationsApiService) DeleteAlertConfigurationExecute(r DeleteAlertConfigurationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -500,7 +500,7 @@ func (a *AlertConfigurationsApiService) GetAlertConfigurationWithParams(ctx cont
 }
 
 func (r GetAlertConfigurationApiRequest) Execute() (*GroupAlertsConfig, *http.Response, error) {
-	return r.ApiService.getAlertConfigurationExecute(r)
+	return r.ApiService.GetAlertConfigurationExecute(r)
 }
 
 /*
@@ -527,7 +527,7 @@ func (a *AlertConfigurationsApiService) GetAlertConfiguration(ctx context.Contex
 // Execute executes the request
 //
 //	@return GroupAlertsConfig
-func (a *AlertConfigurationsApiService) getAlertConfigurationExecute(r GetAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error) {
+func (a *AlertConfigurationsApiService) GetAlertConfigurationExecute(r GetAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -626,7 +626,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNames
 }
 
 func (r ListAlertConfigurationMatchersFieldNamesApiRequest) Execute() ([]string, *http.Response, error) {
-	return r.ApiService.listAlertConfigurationMatchersFieldNamesExecute(r)
+	return r.ApiService.ListAlertConfigurationMatchersFieldNamesExecute(r)
 }
 
 /*
@@ -647,7 +647,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNames
 // Execute executes the request
 //
 //	@return []string
-func (a *AlertConfigurationsApiService) listAlertConfigurationMatchersFieldNamesExecute(r ListAlertConfigurationMatchersFieldNamesApiRequest) ([]string, *http.Response, error) {
+func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNamesExecute(r ListAlertConfigurationMatchersFieldNamesApiRequest) ([]string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -774,7 +774,7 @@ func (r ListAlertConfigurationsApiRequest) PageNum(pageNum int) ListAlertConfigu
 }
 
 func (r ListAlertConfigurationsApiRequest) Execute() (*PaginatedAlertConfig, *http.Response, error) {
-	return r.ApiService.listAlertConfigurationsExecute(r)
+	return r.ApiService.ListAlertConfigurationsExecute(r)
 }
 
 /*
@@ -799,7 +799,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurations(ctx context.Cont
 // Execute executes the request
 //
 //	@return PaginatedAlertConfig
-func (a *AlertConfigurationsApiService) listAlertConfigurationsExecute(r ListAlertConfigurationsApiRequest) (*PaginatedAlertConfig, *http.Response, error) {
+func (a *AlertConfigurationsApiService) ListAlertConfigurationsExecute(r ListAlertConfigurationsApiRequest) (*PaginatedAlertConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -951,7 +951,7 @@ func (r ListAlertConfigurationsByAlertIdApiRequest) PageNum(pageNum int) ListAle
 }
 
 func (r ListAlertConfigurationsByAlertIdApiRequest) Execute() (*PaginatedAlertConfig, *http.Response, error) {
-	return r.ApiService.listAlertConfigurationsByAlertIdExecute(r)
+	return r.ApiService.ListAlertConfigurationsByAlertIdExecute(r)
 }
 
 /*
@@ -978,7 +978,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertId(ctx con
 // Execute executes the request
 //
 //	@return PaginatedAlertConfig
-func (a *AlertConfigurationsApiService) listAlertConfigurationsByAlertIdExecute(r ListAlertConfigurationsByAlertIdApiRequest) (*PaginatedAlertConfig, *http.Response, error) {
+func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertIdExecute(r ListAlertConfigurationsByAlertIdApiRequest) (*PaginatedAlertConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1107,7 +1107,7 @@ func (a *AlertConfigurationsApiService) ToggleAlertConfigurationWithParams(ctx c
 }
 
 func (r ToggleAlertConfigurationApiRequest) Execute() (*GroupAlertsConfig, *http.Response, error) {
-	return r.ApiService.toggleAlertConfigurationExecute(r)
+	return r.ApiService.ToggleAlertConfigurationExecute(r)
 }
 
 /*
@@ -1137,7 +1137,7 @@ func (a *AlertConfigurationsApiService) ToggleAlertConfiguration(ctx context.Con
 // Execute executes the request
 //
 //	@return GroupAlertsConfig
-func (a *AlertConfigurationsApiService) toggleAlertConfigurationExecute(r ToggleAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error) {
+func (a *AlertConfigurationsApiService) ToggleAlertConfigurationExecute(r ToggleAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -1250,7 +1250,7 @@ func (a *AlertConfigurationsApiService) UpdateAlertConfigurationWithParams(ctx c
 }
 
 func (r UpdateAlertConfigurationApiRequest) Execute() (*GroupAlertsConfig, *http.Response, error) {
-	return r.ApiService.updateAlertConfigurationExecute(r)
+	return r.ApiService.UpdateAlertConfigurationExecute(r)
 }
 
 /*
@@ -1280,7 +1280,7 @@ func (a *AlertConfigurationsApiService) UpdateAlertConfiguration(ctx context.Con
 // Execute executes the request
 //
 //	@return GroupAlertsConfig
-func (a *AlertConfigurationsApiService) updateAlertConfigurationExecute(r UpdateAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error) {
+func (a *AlertConfigurationsApiService) UpdateAlertConfigurationExecute(r UpdateAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
 		localVarPostBody    interface{}

--- a/admin/api_alert_configurations.go
+++ b/admin/api_alert_configurations.go
@@ -35,7 +35,7 @@ type AlertConfigurationsApi interface {
 	*/
 	CreateAlertConfigurationWithParams(ctx context.Context, args *CreateAlertConfigurationApiParams) CreateAlertConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateAlertConfigurationExecute(r CreateAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error)
 
 	/*
@@ -61,7 +61,7 @@ type AlertConfigurationsApi interface {
 	*/
 	DeleteAlertConfigurationWithParams(ctx context.Context, args *DeleteAlertConfigurationApiParams) DeleteAlertConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteAlertConfigurationExecute(r DeleteAlertConfigurationApiRequest) (*http.Response, error)
 
 	/*
@@ -87,7 +87,7 @@ type AlertConfigurationsApi interface {
 	*/
 	GetAlertConfigurationWithParams(ctx context.Context, args *GetAlertConfigurationApiParams) GetAlertConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetAlertConfigurationExecute(r GetAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error)
 
 	/*
@@ -109,7 +109,7 @@ type AlertConfigurationsApi interface {
 	*/
 	ListAlertConfigurationMatchersFieldNamesWithParams(ctx context.Context, args *ListAlertConfigurationMatchersFieldNamesApiParams) ListAlertConfigurationMatchersFieldNamesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListAlertConfigurationMatchersFieldNamesExecute(r ListAlertConfigurationMatchersFieldNamesApiRequest) ([]string, *http.Response, error)
 
 	/*
@@ -134,7 +134,7 @@ type AlertConfigurationsApi interface {
 	*/
 	ListAlertConfigurationsWithParams(ctx context.Context, args *ListAlertConfigurationsApiParams) ListAlertConfigurationsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListAlertConfigurationsExecute(r ListAlertConfigurationsApiRequest) (*PaginatedAlertConfig, *http.Response, error)
 
 	/*
@@ -160,7 +160,7 @@ type AlertConfigurationsApi interface {
 	*/
 	ListAlertConfigurationsByAlertIdWithParams(ctx context.Context, args *ListAlertConfigurationsByAlertIdApiParams) ListAlertConfigurationsByAlertIdApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListAlertConfigurationsByAlertIdExecute(r ListAlertConfigurationsByAlertIdApiRequest) (*PaginatedAlertConfig, *http.Response, error)
 
 	/*
@@ -188,7 +188,7 @@ type AlertConfigurationsApi interface {
 	*/
 	ToggleAlertConfigurationWithParams(ctx context.Context, args *ToggleAlertConfigurationApiParams) ToggleAlertConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ToggleAlertConfigurationExecute(r ToggleAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error)
 
 	/*
@@ -216,7 +216,7 @@ type AlertConfigurationsApi interface {
 	*/
 	UpdateAlertConfigurationWithParams(ctx context.Context, args *UpdateAlertConfigurationApiParams) UpdateAlertConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateAlertConfigurationExecute(r UpdateAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error)
 }
 

--- a/admin/api_alerts.go
+++ b/admin/api_alerts.go
@@ -36,7 +36,7 @@ type AlertsApi interface {
 	*/
 	AcknowledgeAlertWithParams(ctx context.Context, args *AcknowledgeAlertApiParams) AcknowledgeAlertApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	AcknowledgeAlertExecute(r AcknowledgeAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error)
 
 	/*
@@ -62,7 +62,7 @@ type AlertsApi interface {
 	*/
 	GetAlertWithParams(ctx context.Context, args *GetAlertApiParams) GetAlertApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetAlertExecute(r GetAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error)
 
 	/*
@@ -87,7 +87,7 @@ type AlertsApi interface {
 	*/
 	ListAlertsWithParams(ctx context.Context, args *ListAlertsApiParams) ListAlertsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListAlertsExecute(r ListAlertsApiRequest) (*PaginatedAlert, *http.Response, error)
 
 	/*
@@ -113,7 +113,7 @@ type AlertsApi interface {
 	*/
 	ListAlertsByAlertConfigurationIdWithParams(ctx context.Context, args *ListAlertsByAlertConfigurationIdApiParams) ListAlertsByAlertConfigurationIdApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListAlertsByAlertConfigurationIdExecute(r ListAlertsByAlertConfigurationIdApiRequest) (*PaginatedAlert, *http.Response, error)
 }
 

--- a/admin/api_alerts.go
+++ b/admin/api_alerts.go
@@ -37,7 +37,7 @@ type AlertsApi interface {
 	AcknowledgeAlertWithParams(ctx context.Context, args *AcknowledgeAlertApiParams) AcknowledgeAlertApiRequest
 
 	// Interface only available internally
-	acknowledgeAlertExecute(r AcknowledgeAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error)
+	AcknowledgeAlertExecute(r AcknowledgeAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error)
 
 	/*
 		GetAlert Return One Alert from One Project
@@ -63,7 +63,7 @@ type AlertsApi interface {
 	GetAlertWithParams(ctx context.Context, args *GetAlertApiParams) GetAlertApiRequest
 
 	// Interface only available internally
-	getAlertExecute(r GetAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error)
+	GetAlertExecute(r GetAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error)
 
 	/*
 		ListAlerts Return All Alerts from One Project
@@ -88,7 +88,7 @@ type AlertsApi interface {
 	ListAlertsWithParams(ctx context.Context, args *ListAlertsApiParams) ListAlertsApiRequest
 
 	// Interface only available internally
-	listAlertsExecute(r ListAlertsApiRequest) (*PaginatedAlert, *http.Response, error)
+	ListAlertsExecute(r ListAlertsApiRequest) (*PaginatedAlert, *http.Response, error)
 
 	/*
 		ListAlertsByAlertConfigurationId Return All Open Alerts for Alert Configuration
@@ -114,7 +114,7 @@ type AlertsApi interface {
 	ListAlertsByAlertConfigurationIdWithParams(ctx context.Context, args *ListAlertsByAlertConfigurationIdApiParams) ListAlertsByAlertConfigurationIdApiRequest
 
 	// Interface only available internally
-	listAlertsByAlertConfigurationIdExecute(r ListAlertsByAlertConfigurationIdApiRequest) (*PaginatedAlert, *http.Response, error)
+	ListAlertsByAlertConfigurationIdExecute(r ListAlertsByAlertConfigurationIdApiRequest) (*PaginatedAlert, *http.Response, error)
 }
 
 // AlertsApiService AlertsApi service
@@ -145,7 +145,7 @@ func (a *AlertsApiService) AcknowledgeAlertWithParams(ctx context.Context, args 
 }
 
 func (r AcknowledgeAlertApiRequest) Execute() (*AlertViewForNdsGroup, *http.Response, error) {
-	return r.ApiService.acknowledgeAlertExecute(r)
+	return r.ApiService.AcknowledgeAlertExecute(r)
 }
 
 /*
@@ -173,7 +173,7 @@ func (a *AlertsApiService) AcknowledgeAlert(ctx context.Context, groupId string,
 // Execute executes the request
 //
 //	@return AlertViewForNdsGroup
-func (a *AlertsApiService) acknowledgeAlertExecute(r AcknowledgeAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error) {
+func (a *AlertsApiService) AcknowledgeAlertExecute(r AcknowledgeAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -283,7 +283,7 @@ func (a *AlertsApiService) GetAlertWithParams(ctx context.Context, args *GetAler
 }
 
 func (r GetAlertApiRequest) Execute() (*AlertViewForNdsGroup, *http.Response, error) {
-	return r.ApiService.getAlertExecute(r)
+	return r.ApiService.GetAlertExecute(r)
 }
 
 /*
@@ -310,7 +310,7 @@ func (a *AlertsApiService) GetAlert(ctx context.Context, groupId string, alertId
 // Execute executes the request
 //
 //	@return AlertViewForNdsGroup
-func (a *AlertsApiService) getAlertExecute(r GetAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error) {
+func (a *AlertsApiService) GetAlertExecute(r GetAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -448,7 +448,7 @@ func (r ListAlertsApiRequest) Status(status string) ListAlertsApiRequest {
 }
 
 func (r ListAlertsApiRequest) Execute() (*PaginatedAlert, *http.Response, error) {
-	return r.ApiService.listAlertsExecute(r)
+	return r.ApiService.ListAlertsExecute(r)
 }
 
 /*
@@ -473,7 +473,7 @@ func (a *AlertsApiService) ListAlerts(ctx context.Context, groupId string) ListA
 // Execute executes the request
 //
 //	@return PaginatedAlert
-func (a *AlertsApiService) listAlertsExecute(r ListAlertsApiRequest) (*PaginatedAlert, *http.Response, error) {
+func (a *AlertsApiService) ListAlertsExecute(r ListAlertsApiRequest) (*PaginatedAlert, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -628,7 +628,7 @@ func (r ListAlertsByAlertConfigurationIdApiRequest) PageNum(pageNum int) ListAle
 }
 
 func (r ListAlertsByAlertConfigurationIdApiRequest) Execute() (*PaginatedAlert, *http.Response, error) {
-	return r.ApiService.listAlertsByAlertConfigurationIdExecute(r)
+	return r.ApiService.ListAlertsByAlertConfigurationIdExecute(r)
 }
 
 /*
@@ -655,7 +655,7 @@ func (a *AlertsApiService) ListAlertsByAlertConfigurationId(ctx context.Context,
 // Execute executes the request
 //
 //	@return PaginatedAlert
-func (a *AlertsApiService) listAlertsByAlertConfigurationIdExecute(r ListAlertsByAlertConfigurationIdApiRequest) (*PaginatedAlert, *http.Response, error) {
+func (a *AlertsApiService) ListAlertsByAlertConfigurationIdExecute(r ListAlertsByAlertConfigurationIdApiRequest) (*PaginatedAlert, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_atlas_search.go
+++ b/admin/api_atlas_search.go
@@ -34,7 +34,7 @@ type AtlasSearchApi interface {
 	*/
 	CreateAtlasSearchDeploymentWithParams(ctx context.Context, args *CreateAtlasSearchDeploymentApiParams) CreateAtlasSearchDeploymentApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateAtlasSearchDeploymentExecute(r CreateAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error)
 
 	/*
@@ -58,7 +58,7 @@ type AtlasSearchApi interface {
 	*/
 	CreateAtlasSearchIndexWithParams(ctx context.Context, args *CreateAtlasSearchIndexApiParams) CreateAtlasSearchIndexApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateAtlasSearchIndexExecute(r CreateAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error)
 
 	/*
@@ -82,7 +82,7 @@ type AtlasSearchApi interface {
 	*/
 	DeleteAtlasSearchDeploymentWithParams(ctx context.Context, args *DeleteAtlasSearchDeploymentApiParams) DeleteAtlasSearchDeploymentApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteAtlasSearchDeploymentExecute(r DeleteAtlasSearchDeploymentApiRequest) (*http.Response, error)
 
 	/*
@@ -107,7 +107,7 @@ type AtlasSearchApi interface {
 	*/
 	DeleteAtlasSearchIndexWithParams(ctx context.Context, args *DeleteAtlasSearchIndexApiParams) DeleteAtlasSearchIndexApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -131,7 +131,7 @@ type AtlasSearchApi interface {
 	*/
 	GetAtlasSearchDeploymentWithParams(ctx context.Context, args *GetAtlasSearchDeploymentApiParams) GetAtlasSearchDeploymentApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetAtlasSearchDeploymentExecute(r GetAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error)
 
 	/*
@@ -156,7 +156,7 @@ type AtlasSearchApi interface {
 	*/
 	GetAtlasSearchIndexWithParams(ctx context.Context, args *GetAtlasSearchIndexApiParams) GetAtlasSearchIndexApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetAtlasSearchIndexExecute(r GetAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error)
 
 	/*
@@ -182,7 +182,7 @@ type AtlasSearchApi interface {
 	*/
 	ListAtlasSearchIndexesWithParams(ctx context.Context, args *ListAtlasSearchIndexesApiParams) ListAtlasSearchIndexesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListAtlasSearchIndexesExecute(r ListAtlasSearchIndexesApiRequest) ([]ClusterSearchIndex, *http.Response, error)
 
 	/*
@@ -206,7 +206,7 @@ type AtlasSearchApi interface {
 	*/
 	UpdateAtlasSearchDeploymentWithParams(ctx context.Context, args *UpdateAtlasSearchDeploymentApiParams) UpdateAtlasSearchDeploymentApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateAtlasSearchDeploymentExecute(r UpdateAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error)
 
 	/*
@@ -231,7 +231,7 @@ type AtlasSearchApi interface {
 	*/
 	UpdateAtlasSearchIndexWithParams(ctx context.Context, args *UpdateAtlasSearchIndexApiParams) UpdateAtlasSearchIndexApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateAtlasSearchIndexExecute(r UpdateAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error)
 }
 

--- a/admin/api_atlas_search.go
+++ b/admin/api_atlas_search.go
@@ -35,7 +35,7 @@ type AtlasSearchApi interface {
 	CreateAtlasSearchDeploymentWithParams(ctx context.Context, args *CreateAtlasSearchDeploymentApiParams) CreateAtlasSearchDeploymentApiRequest
 
 	// Interface only available internally
-	createAtlasSearchDeploymentExecute(r CreateAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error)
+	CreateAtlasSearchDeploymentExecute(r CreateAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error)
 
 	/*
 		CreateAtlasSearchIndex Create One Atlas Search Index
@@ -59,7 +59,7 @@ type AtlasSearchApi interface {
 	CreateAtlasSearchIndexWithParams(ctx context.Context, args *CreateAtlasSearchIndexApiParams) CreateAtlasSearchIndexApiRequest
 
 	// Interface only available internally
-	createAtlasSearchIndexExecute(r CreateAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error)
+	CreateAtlasSearchIndexExecute(r CreateAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error)
 
 	/*
 		DeleteAtlasSearchDeployment Delete Search Nodes
@@ -83,7 +83,7 @@ type AtlasSearchApi interface {
 	DeleteAtlasSearchDeploymentWithParams(ctx context.Context, args *DeleteAtlasSearchDeploymentApiParams) DeleteAtlasSearchDeploymentApiRequest
 
 	// Interface only available internally
-	deleteAtlasSearchDeploymentExecute(r DeleteAtlasSearchDeploymentApiRequest) (*http.Response, error)
+	DeleteAtlasSearchDeploymentExecute(r DeleteAtlasSearchDeploymentApiRequest) (*http.Response, error)
 
 	/*
 		DeleteAtlasSearchIndex Remove One Atlas Search Index
@@ -108,7 +108,7 @@ type AtlasSearchApi interface {
 	DeleteAtlasSearchIndexWithParams(ctx context.Context, args *DeleteAtlasSearchIndexApiParams) DeleteAtlasSearchIndexApiRequest
 
 	// Interface only available internally
-	deleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetAtlasSearchDeployment Return Search Nodes
@@ -132,7 +132,7 @@ type AtlasSearchApi interface {
 	GetAtlasSearchDeploymentWithParams(ctx context.Context, args *GetAtlasSearchDeploymentApiParams) GetAtlasSearchDeploymentApiRequest
 
 	// Interface only available internally
-	getAtlasSearchDeploymentExecute(r GetAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error)
+	GetAtlasSearchDeploymentExecute(r GetAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error)
 
 	/*
 		GetAtlasSearchIndex Return One Atlas Search Index
@@ -157,7 +157,7 @@ type AtlasSearchApi interface {
 	GetAtlasSearchIndexWithParams(ctx context.Context, args *GetAtlasSearchIndexApiParams) GetAtlasSearchIndexApiRequest
 
 	// Interface only available internally
-	getAtlasSearchIndexExecute(r GetAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error)
+	GetAtlasSearchIndexExecute(r GetAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error)
 
 	/*
 		ListAtlasSearchIndexes Return All Atlas Search Indexes for One Collection
@@ -183,7 +183,7 @@ type AtlasSearchApi interface {
 	ListAtlasSearchIndexesWithParams(ctx context.Context, args *ListAtlasSearchIndexesApiParams) ListAtlasSearchIndexesApiRequest
 
 	// Interface only available internally
-	listAtlasSearchIndexesExecute(r ListAtlasSearchIndexesApiRequest) ([]ClusterSearchIndex, *http.Response, error)
+	ListAtlasSearchIndexesExecute(r ListAtlasSearchIndexesApiRequest) ([]ClusterSearchIndex, *http.Response, error)
 
 	/*
 		UpdateAtlasSearchDeployment Update Search Nodes
@@ -207,7 +207,7 @@ type AtlasSearchApi interface {
 	UpdateAtlasSearchDeploymentWithParams(ctx context.Context, args *UpdateAtlasSearchDeploymentApiParams) UpdateAtlasSearchDeploymentApiRequest
 
 	// Interface only available internally
-	updateAtlasSearchDeploymentExecute(r UpdateAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error)
+	UpdateAtlasSearchDeploymentExecute(r UpdateAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error)
 
 	/*
 		UpdateAtlasSearchIndex Update One Atlas Search Index
@@ -232,7 +232,7 @@ type AtlasSearchApi interface {
 	UpdateAtlasSearchIndexWithParams(ctx context.Context, args *UpdateAtlasSearchIndexApiParams) UpdateAtlasSearchIndexApiRequest
 
 	// Interface only available internally
-	updateAtlasSearchIndexExecute(r UpdateAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error)
+	UpdateAtlasSearchIndexExecute(r UpdateAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error)
 }
 
 // AtlasSearchApiService AtlasSearchApi service
@@ -263,7 +263,7 @@ func (a *AtlasSearchApiService) CreateAtlasSearchDeploymentWithParams(ctx contex
 }
 
 func (r CreateAtlasSearchDeploymentApiRequest) Execute() (*ApiSearchDeploymentResponse, *http.Response, error) {
-	return r.ApiService.createAtlasSearchDeploymentExecute(r)
+	return r.ApiService.CreateAtlasSearchDeploymentExecute(r)
 }
 
 /*
@@ -289,7 +289,7 @@ func (a *AtlasSearchApiService) CreateAtlasSearchDeployment(ctx context.Context,
 // Execute executes the request
 //
 //	@return ApiSearchDeploymentResponse
-func (a *AtlasSearchApiService) createAtlasSearchDeploymentExecute(r CreateAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error) {
+func (a *AtlasSearchApiService) CreateAtlasSearchDeploymentExecute(r CreateAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -402,7 +402,7 @@ func (a *AtlasSearchApiService) CreateAtlasSearchIndexWithParams(ctx context.Con
 }
 
 func (r CreateAtlasSearchIndexApiRequest) Execute() (*ClusterSearchIndex, *http.Response, error) {
-	return r.ApiService.createAtlasSearchIndexExecute(r)
+	return r.ApiService.CreateAtlasSearchIndexExecute(r)
 }
 
 /*
@@ -428,7 +428,7 @@ func (a *AtlasSearchApiService) CreateAtlasSearchIndex(ctx context.Context, grou
 // Execute executes the request
 //
 //	@return ClusterSearchIndex
-func (a *AtlasSearchApiService) createAtlasSearchIndexExecute(r CreateAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error) {
+func (a *AtlasSearchApiService) CreateAtlasSearchIndexExecute(r CreateAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -538,7 +538,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchDeploymentWithParams(ctx contex
 }
 
 func (r DeleteAtlasSearchDeploymentApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.deleteAtlasSearchDeploymentExecute(r)
+	return r.ApiService.DeleteAtlasSearchDeploymentExecute(r)
 }
 
 /*
@@ -561,7 +561,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchDeployment(ctx context.Context,
 }
 
 // Execute executes the request
-func (a *AtlasSearchApiService) deleteAtlasSearchDeploymentExecute(r DeleteAtlasSearchDeploymentApiRequest) (*http.Response, error) {
+func (a *AtlasSearchApiService) DeleteAtlasSearchDeploymentExecute(r DeleteAtlasSearchDeploymentApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -659,7 +659,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndexWithParams(ctx context.Con
 }
 
 func (r DeleteAtlasSearchIndexApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteAtlasSearchIndexExecute(r)
+	return r.ApiService.DeleteAtlasSearchIndexExecute(r)
 }
 
 /*
@@ -686,7 +686,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndex(ctx context.Context, grou
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *AtlasSearchApiService) deleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *AtlasSearchApiService) DeleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -792,7 +792,7 @@ func (a *AtlasSearchApiService) GetAtlasSearchDeploymentWithParams(ctx context.C
 }
 
 func (r GetAtlasSearchDeploymentApiRequest) Execute() (*ApiSearchDeploymentResponse, *http.Response, error) {
-	return r.ApiService.getAtlasSearchDeploymentExecute(r)
+	return r.ApiService.GetAtlasSearchDeploymentExecute(r)
 }
 
 /*
@@ -817,7 +817,7 @@ func (a *AtlasSearchApiService) GetAtlasSearchDeployment(ctx context.Context, gr
 // Execute executes the request
 //
 //	@return ApiSearchDeploymentResponse
-func (a *AtlasSearchApiService) getAtlasSearchDeploymentExecute(r GetAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error) {
+func (a *AtlasSearchApiService) GetAtlasSearchDeploymentExecute(r GetAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -925,7 +925,7 @@ func (a *AtlasSearchApiService) GetAtlasSearchIndexWithParams(ctx context.Contex
 }
 
 func (r GetAtlasSearchIndexApiRequest) Execute() (*ClusterSearchIndex, *http.Response, error) {
-	return r.ApiService.getAtlasSearchIndexExecute(r)
+	return r.ApiService.GetAtlasSearchIndexExecute(r)
 }
 
 /*
@@ -952,7 +952,7 @@ func (a *AtlasSearchApiService) GetAtlasSearchIndex(ctx context.Context, groupId
 // Execute executes the request
 //
 //	@return ClusterSearchIndex
-func (a *AtlasSearchApiService) getAtlasSearchIndexExecute(r GetAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error) {
+func (a *AtlasSearchApiService) GetAtlasSearchIndexExecute(r GetAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1064,7 +1064,7 @@ func (a *AtlasSearchApiService) ListAtlasSearchIndexesWithParams(ctx context.Con
 }
 
 func (r ListAtlasSearchIndexesApiRequest) Execute() ([]ClusterSearchIndex, *http.Response, error) {
-	return r.ApiService.listAtlasSearchIndexesExecute(r)
+	return r.ApiService.ListAtlasSearchIndexesExecute(r)
 }
 
 /*
@@ -1093,7 +1093,7 @@ func (a *AtlasSearchApiService) ListAtlasSearchIndexes(ctx context.Context, grou
 // Execute executes the request
 //
 //	@return []ClusterSearchIndex
-func (a *AtlasSearchApiService) listAtlasSearchIndexesExecute(r ListAtlasSearchIndexesApiRequest) ([]ClusterSearchIndex, *http.Response, error) {
+func (a *AtlasSearchApiService) ListAtlasSearchIndexesExecute(r ListAtlasSearchIndexesApiRequest) ([]ClusterSearchIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1203,7 +1203,7 @@ func (a *AtlasSearchApiService) UpdateAtlasSearchDeploymentWithParams(ctx contex
 }
 
 func (r UpdateAtlasSearchDeploymentApiRequest) Execute() (*ApiSearchDeploymentResponse, *http.Response, error) {
-	return r.ApiService.updateAtlasSearchDeploymentExecute(r)
+	return r.ApiService.UpdateAtlasSearchDeploymentExecute(r)
 }
 
 /*
@@ -1229,7 +1229,7 @@ func (a *AtlasSearchApiService) UpdateAtlasSearchDeployment(ctx context.Context,
 // Execute executes the request
 //
 //	@return ApiSearchDeploymentResponse
-func (a *AtlasSearchApiService) updateAtlasSearchDeploymentExecute(r UpdateAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error) {
+func (a *AtlasSearchApiService) UpdateAtlasSearchDeploymentExecute(r UpdateAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -1345,7 +1345,7 @@ func (a *AtlasSearchApiService) UpdateAtlasSearchIndexWithParams(ctx context.Con
 }
 
 func (r UpdateAtlasSearchIndexApiRequest) Execute() (*ClusterSearchIndex, *http.Response, error) {
-	return r.ApiService.updateAtlasSearchIndexExecute(r)
+	return r.ApiService.UpdateAtlasSearchIndexExecute(r)
 }
 
 /*
@@ -1373,7 +1373,7 @@ func (a *AtlasSearchApiService) UpdateAtlasSearchIndex(ctx context.Context, grou
 // Execute executes the request
 //
 //	@return ClusterSearchIndex
-func (a *AtlasSearchApiService) updateAtlasSearchIndexExecute(r UpdateAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error) {
+func (a *AtlasSearchApiService) UpdateAtlasSearchIndexExecute(r UpdateAtlasSearchIndexApiRequest) (*ClusterSearchIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_auditing.go
+++ b/admin/api_auditing.go
@@ -34,7 +34,7 @@ type AuditingApi interface {
 	GetAuditingConfigurationWithParams(ctx context.Context, args *GetAuditingConfigurationApiParams) GetAuditingConfigurationApiRequest
 
 	// Interface only available internally
-	getAuditingConfigurationExecute(r GetAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error)
+	GetAuditingConfigurationExecute(r GetAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error)
 
 	/*
 		UpdateAuditingConfiguration Update Auditing Configuration for One Project
@@ -57,7 +57,7 @@ type AuditingApi interface {
 	UpdateAuditingConfigurationWithParams(ctx context.Context, args *UpdateAuditingConfigurationApiParams) UpdateAuditingConfigurationApiRequest
 
 	// Interface only available internally
-	updateAuditingConfigurationExecute(r UpdateAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error)
+	UpdateAuditingConfigurationExecute(r UpdateAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error)
 }
 
 // AuditingApiService AuditingApi service
@@ -82,7 +82,7 @@ func (a *AuditingApiService) GetAuditingConfigurationWithParams(ctx context.Cont
 }
 
 func (r GetAuditingConfigurationApiRequest) Execute() (*AuditLog, *http.Response, error) {
-	return r.ApiService.getAuditingConfigurationExecute(r)
+	return r.ApiService.GetAuditingConfigurationExecute(r)
 }
 
 /*
@@ -105,7 +105,7 @@ func (a *AuditingApiService) GetAuditingConfiguration(ctx context.Context, group
 // Execute executes the request
 //
 //	@return AuditLog
-func (a *AuditingApiService) getAuditingConfigurationExecute(r GetAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error) {
+func (a *AuditingApiService) GetAuditingConfigurationExecute(r GetAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -209,7 +209,7 @@ func (a *AuditingApiService) UpdateAuditingConfigurationWithParams(ctx context.C
 }
 
 func (r UpdateAuditingConfigurationApiRequest) Execute() (*AuditLog, *http.Response, error) {
-	return r.ApiService.updateAuditingConfigurationExecute(r)
+	return r.ApiService.UpdateAuditingConfigurationExecute(r)
 }
 
 /*
@@ -233,7 +233,7 @@ func (a *AuditingApiService) UpdateAuditingConfiguration(ctx context.Context, gr
 // Execute executes the request
 //
 //	@return AuditLog
-func (a *AuditingApiService) updateAuditingConfigurationExecute(r UpdateAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error) {
+func (a *AuditingApiService) UpdateAuditingConfigurationExecute(r UpdateAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_auditing.go
+++ b/admin/api_auditing.go
@@ -33,7 +33,7 @@ type AuditingApi interface {
 	*/
 	GetAuditingConfigurationWithParams(ctx context.Context, args *GetAuditingConfigurationApiParams) GetAuditingConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetAuditingConfigurationExecute(r GetAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error)
 
 	/*
@@ -56,7 +56,7 @@ type AuditingApi interface {
 	*/
 	UpdateAuditingConfigurationWithParams(ctx context.Context, args *UpdateAuditingConfigurationApiParams) UpdateAuditingConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateAuditingConfigurationExecute(r UpdateAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error)
 }
 

--- a/admin/api_aws_clusters_dns.go
+++ b/admin/api_aws_clusters_dns.go
@@ -33,7 +33,7 @@ type AWSClustersDNSApi interface {
 	*/
 	GetAWSCustomDNSWithParams(ctx context.Context, args *GetAWSCustomDNSApiParams) GetAWSCustomDNSApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetAWSCustomDNSExecute(r GetAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error)
 
 	/*
@@ -56,7 +56,7 @@ type AWSClustersDNSApi interface {
 	*/
 	ToggleAWSCustomDNSWithParams(ctx context.Context, args *ToggleAWSCustomDNSApiParams) ToggleAWSCustomDNSApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ToggleAWSCustomDNSExecute(r ToggleAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error)
 }
 

--- a/admin/api_aws_clusters_dns.go
+++ b/admin/api_aws_clusters_dns.go
@@ -34,7 +34,7 @@ type AWSClustersDNSApi interface {
 	GetAWSCustomDNSWithParams(ctx context.Context, args *GetAWSCustomDNSApiParams) GetAWSCustomDNSApiRequest
 
 	// Interface only available internally
-	getAWSCustomDNSExecute(r GetAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error)
+	GetAWSCustomDNSExecute(r GetAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error)
 
 	/*
 		ToggleAWSCustomDNS Toggle State of One Custom DNS Configuration for Atlas Clusters on AWS
@@ -57,7 +57,7 @@ type AWSClustersDNSApi interface {
 	ToggleAWSCustomDNSWithParams(ctx context.Context, args *ToggleAWSCustomDNSApiParams) ToggleAWSCustomDNSApiRequest
 
 	// Interface only available internally
-	toggleAWSCustomDNSExecute(r ToggleAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error)
+	ToggleAWSCustomDNSExecute(r ToggleAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error)
 }
 
 // AWSClustersDNSApiService AWSClustersDNSApi service
@@ -82,7 +82,7 @@ func (a *AWSClustersDNSApiService) GetAWSCustomDNSWithParams(ctx context.Context
 }
 
 func (r GetAWSCustomDNSApiRequest) Execute() (*AWSCustomDNSEnabled, *http.Response, error) {
-	return r.ApiService.getAWSCustomDNSExecute(r)
+	return r.ApiService.GetAWSCustomDNSExecute(r)
 }
 
 /*
@@ -105,7 +105,7 @@ func (a *AWSClustersDNSApiService) GetAWSCustomDNS(ctx context.Context, groupId 
 // Execute executes the request
 //
 //	@return AWSCustomDNSEnabled
-func (a *AWSClustersDNSApiService) getAWSCustomDNSExecute(r GetAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
+func (a *AWSClustersDNSApiService) GetAWSCustomDNSExecute(r GetAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -209,7 +209,7 @@ func (a *AWSClustersDNSApiService) ToggleAWSCustomDNSWithParams(ctx context.Cont
 }
 
 func (r ToggleAWSCustomDNSApiRequest) Execute() (*AWSCustomDNSEnabled, *http.Response, error) {
-	return r.ApiService.toggleAWSCustomDNSExecute(r)
+	return r.ApiService.ToggleAWSCustomDNSExecute(r)
 }
 
 /*
@@ -233,7 +233,7 @@ func (a *AWSClustersDNSApiService) ToggleAWSCustomDNS(ctx context.Context, group
 // Execute executes the request
 //
 //	@return AWSCustomDNSEnabled
-func (a *AWSClustersDNSApiService) toggleAWSCustomDNSExecute(r ToggleAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
+func (a *AWSClustersDNSApiService) ToggleAWSCustomDNSExecute(r ToggleAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_cloud_backups.go
+++ b/admin/api_cloud_backups.go
@@ -35,7 +35,7 @@ type CloudBackupsApi interface {
 	*/
 	CancelBackupRestoreJobWithParams(ctx context.Context, args *CancelBackupRestoreJobApiParams) CancelBackupRestoreJobApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -59,7 +59,7 @@ type CloudBackupsApi interface {
 	*/
 	CreateBackupExportJobWithParams(ctx context.Context, args *CreateBackupExportJobApiParams) CreateBackupExportJobApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateBackupExportJobExecute(r CreateBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error)
 
 	/*
@@ -85,7 +85,7 @@ type CloudBackupsApi interface {
 	*/
 	CreateBackupRestoreJobWithParams(ctx context.Context, args *CreateBackupRestoreJobApiParams) CreateBackupRestoreJobApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateBackupRestoreJobExecute(r CreateBackupRestoreJobApiRequest) (*DiskBackupSnapshotRestoreJob, *http.Response, error)
 
 	/*
@@ -108,7 +108,7 @@ type CloudBackupsApi interface {
 	*/
 	CreateExportBucketWithParams(ctx context.Context, args *CreateExportBucketApiParams) CreateExportBucketApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateExportBucketExecute(r CreateExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
 
 	/*
@@ -132,7 +132,7 @@ type CloudBackupsApi interface {
 	*/
 	CreateServerlessBackupRestoreJobWithParams(ctx context.Context, args *CreateServerlessBackupRestoreJobApiParams) CreateServerlessBackupRestoreJobApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateServerlessBackupRestoreJobExecute(r CreateServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
 
 	/*
@@ -156,7 +156,7 @@ type CloudBackupsApi interface {
 	*/
 	DeleteAllBackupSchedulesWithParams(ctx context.Context, args *DeleteAllBackupSchedulesApiParams) DeleteAllBackupSchedulesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteAllBackupSchedulesExecute(r DeleteAllBackupSchedulesApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
 
 	/*
@@ -180,7 +180,7 @@ type CloudBackupsApi interface {
 	*/
 	DeleteExportBucketWithParams(ctx context.Context, args *DeleteExportBucketApiParams) DeleteExportBucketApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteExportBucketExecute(r DeleteExportBucketApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -205,7 +205,7 @@ type CloudBackupsApi interface {
 	*/
 	DeleteReplicaSetBackupWithParams(ctx context.Context, args *DeleteReplicaSetBackupApiParams) DeleteReplicaSetBackupApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -230,7 +230,7 @@ type CloudBackupsApi interface {
 	*/
 	DeleteShardedClusterBackupWithParams(ctx context.Context, args *DeleteShardedClusterBackupApiParams) DeleteShardedClusterBackupApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -255,7 +255,7 @@ type CloudBackupsApi interface {
 	*/
 	GetBackupExportJobWithParams(ctx context.Context, args *GetBackupExportJobApiParams) GetBackupExportJobApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetBackupExportJobExecute(r GetBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error)
 
 	/*
@@ -280,7 +280,7 @@ type CloudBackupsApi interface {
 	*/
 	GetBackupRestoreJobWithParams(ctx context.Context, args *GetBackupRestoreJobApiParams) GetBackupRestoreJobApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetBackupRestoreJobExecute(r GetBackupRestoreJobApiRequest) (*DiskBackupSnapshotRestoreJob, *http.Response, error)
 
 	/*
@@ -304,7 +304,7 @@ type CloudBackupsApi interface {
 	*/
 	GetBackupScheduleWithParams(ctx context.Context, args *GetBackupScheduleApiParams) GetBackupScheduleApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetBackupScheduleExecute(r GetBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
 
 	/*
@@ -327,7 +327,7 @@ type CloudBackupsApi interface {
 	*/
 	GetDataProtectionSettingsWithParams(ctx context.Context, args *GetDataProtectionSettingsApiParams) GetDataProtectionSettingsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetDataProtectionSettingsExecute(r GetDataProtectionSettingsApiRequest) (*DataProtectionSettings20231001, *http.Response, error)
 
 	/*
@@ -351,7 +351,7 @@ type CloudBackupsApi interface {
 	*/
 	GetExportBucketWithParams(ctx context.Context, args *GetExportBucketApiParams) GetExportBucketApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetExportBucketExecute(r GetExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
 
 	/*
@@ -376,7 +376,7 @@ type CloudBackupsApi interface {
 	*/
 	GetReplicaSetBackupWithParams(ctx context.Context, args *GetReplicaSetBackupApiParams) GetReplicaSetBackupApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetReplicaSetBackupExecute(r GetReplicaSetBackupApiRequest) (*DiskBackupReplicaSet, *http.Response, error)
 
 	/*
@@ -401,7 +401,7 @@ type CloudBackupsApi interface {
 	*/
 	GetServerlessBackupWithParams(ctx context.Context, args *GetServerlessBackupApiParams) GetServerlessBackupApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetServerlessBackupExecute(r GetServerlessBackupApiRequest) (*ServerlessBackupSnapshot, *http.Response, error)
 
 	/*
@@ -426,7 +426,7 @@ type CloudBackupsApi interface {
 	*/
 	GetServerlessBackupRestoreJobWithParams(ctx context.Context, args *GetServerlessBackupRestoreJobApiParams) GetServerlessBackupRestoreJobApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetServerlessBackupRestoreJobExecute(r GetServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
 
 	/*
@@ -451,7 +451,7 @@ type CloudBackupsApi interface {
 	*/
 	GetShardedClusterBackupWithParams(ctx context.Context, args *GetShardedClusterBackupApiParams) GetShardedClusterBackupApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetShardedClusterBackupExecute(r GetShardedClusterBackupApiRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error)
 
 	/*
@@ -475,7 +475,7 @@ type CloudBackupsApi interface {
 	*/
 	ListBackupExportJobsWithParams(ctx context.Context, args *ListBackupExportJobsApiParams) ListBackupExportJobsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListBackupExportJobsExecute(r ListBackupExportJobsApiRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error)
 
 	/*
@@ -499,7 +499,7 @@ type CloudBackupsApi interface {
 	*/
 	ListBackupRestoreJobsWithParams(ctx context.Context, args *ListBackupRestoreJobsApiParams) ListBackupRestoreJobsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListBackupRestoreJobsExecute(r ListBackupRestoreJobsApiRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error)
 
 	/*
@@ -522,7 +522,7 @@ type CloudBackupsApi interface {
 	*/
 	ListExportBucketsWithParams(ctx context.Context, args *ListExportBucketsApiParams) ListExportBucketsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListExportBucketsExecute(r ListExportBucketsApiRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error)
 
 	/*
@@ -546,7 +546,7 @@ type CloudBackupsApi interface {
 	*/
 	ListReplicaSetBackupsWithParams(ctx context.Context, args *ListReplicaSetBackupsApiParams) ListReplicaSetBackupsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListReplicaSetBackupsExecute(r ListReplicaSetBackupsApiRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error)
 
 	/*
@@ -570,7 +570,7 @@ type CloudBackupsApi interface {
 	*/
 	ListServerlessBackupRestoreJobsWithParams(ctx context.Context, args *ListServerlessBackupRestoreJobsApiParams) ListServerlessBackupRestoreJobsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListServerlessBackupRestoreJobsExecute(r ListServerlessBackupRestoreJobsApiRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error)
 
 	/*
@@ -594,7 +594,7 @@ type CloudBackupsApi interface {
 	*/
 	ListServerlessBackupsWithParams(ctx context.Context, args *ListServerlessBackupsApiParams) ListServerlessBackupsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListServerlessBackupsExecute(r ListServerlessBackupsApiRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error)
 
 	/*
@@ -618,7 +618,7 @@ type CloudBackupsApi interface {
 	*/
 	ListShardedClusterBackupsWithParams(ctx context.Context, args *ListShardedClusterBackupsApiParams) ListShardedClusterBackupsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListShardedClusterBackupsExecute(r ListShardedClusterBackupsApiRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error)
 
 	/*
@@ -644,7 +644,7 @@ type CloudBackupsApi interface {
 	*/
 	TakeSnapshotWithParams(ctx context.Context, args *TakeSnapshotApiParams) TakeSnapshotApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	TakeSnapshotExecute(r TakeSnapshotApiRequest) (*DiskBackupSnapshot, *http.Response, error)
 
 	/*
@@ -668,7 +668,7 @@ type CloudBackupsApi interface {
 	*/
 	UpdateBackupScheduleWithParams(ctx context.Context, args *UpdateBackupScheduleApiParams) UpdateBackupScheduleApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateBackupScheduleExecute(r UpdateBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
 
 	/*
@@ -691,7 +691,7 @@ type CloudBackupsApi interface {
 	*/
 	UpdateDataProtectionSettingsWithParams(ctx context.Context, args *UpdateDataProtectionSettingsApiParams) UpdateDataProtectionSettingsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateDataProtectionSettingsExecute(r UpdateDataProtectionSettingsApiRequest) (*DataProtectionSettings20231001, *http.Response, error)
 
 	/*
@@ -716,7 +716,7 @@ type CloudBackupsApi interface {
 	*/
 	UpdateSnapshotRetentionWithParams(ctx context.Context, args *UpdateSnapshotRetentionApiParams) UpdateSnapshotRetentionApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateSnapshotRetentionExecute(r UpdateSnapshotRetentionApiRequest) (*DiskBackupReplicaSet, *http.Response, error)
 }
 

--- a/admin/api_cloud_backups.go
+++ b/admin/api_cloud_backups.go
@@ -36,7 +36,7 @@ type CloudBackupsApi interface {
 	CancelBackupRestoreJobWithParams(ctx context.Context, args *CancelBackupRestoreJobApiParams) CancelBackupRestoreJobApiRequest
 
 	// Interface only available internally
-	cancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (map[string]interface{}, *http.Response, error)
+	CancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		CreateBackupExportJob Create One Cloud Backup Snapshot Export Job
@@ -60,7 +60,7 @@ type CloudBackupsApi interface {
 	CreateBackupExportJobWithParams(ctx context.Context, args *CreateBackupExportJobApiParams) CreateBackupExportJobApiRequest
 
 	// Interface only available internally
-	createBackupExportJobExecute(r CreateBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error)
+	CreateBackupExportJobExecute(r CreateBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error)
 
 	/*
 		CreateBackupRestoreJob Restore One Snapshot of One Cluster
@@ -86,7 +86,7 @@ type CloudBackupsApi interface {
 	CreateBackupRestoreJobWithParams(ctx context.Context, args *CreateBackupRestoreJobApiParams) CreateBackupRestoreJobApiRequest
 
 	// Interface only available internally
-	createBackupRestoreJobExecute(r CreateBackupRestoreJobApiRequest) (*DiskBackupSnapshotRestoreJob, *http.Response, error)
+	CreateBackupRestoreJobExecute(r CreateBackupRestoreJobApiRequest) (*DiskBackupSnapshotRestoreJob, *http.Response, error)
 
 	/*
 		CreateExportBucket Grant Access to AWS S3 Bucket for Cloud Backup Snapshot Exports
@@ -109,7 +109,7 @@ type CloudBackupsApi interface {
 	CreateExportBucketWithParams(ctx context.Context, args *CreateExportBucketApiParams) CreateExportBucketApiRequest
 
 	// Interface only available internally
-	createExportBucketExecute(r CreateExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
+	CreateExportBucketExecute(r CreateExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
 
 	/*
 		CreateServerlessBackupRestoreJob Restore One Snapshot of One Serverless Instance
@@ -133,7 +133,7 @@ type CloudBackupsApi interface {
 	CreateServerlessBackupRestoreJobWithParams(ctx context.Context, args *CreateServerlessBackupRestoreJobApiParams) CreateServerlessBackupRestoreJobApiRequest
 
 	// Interface only available internally
-	createServerlessBackupRestoreJobExecute(r CreateServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
+	CreateServerlessBackupRestoreJobExecute(r CreateServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
 
 	/*
 		DeleteAllBackupSchedules Remove All Cloud Backup Schedules
@@ -157,7 +157,7 @@ type CloudBackupsApi interface {
 	DeleteAllBackupSchedulesWithParams(ctx context.Context, args *DeleteAllBackupSchedulesApiParams) DeleteAllBackupSchedulesApiRequest
 
 	// Interface only available internally
-	deleteAllBackupSchedulesExecute(r DeleteAllBackupSchedulesApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
+	DeleteAllBackupSchedulesExecute(r DeleteAllBackupSchedulesApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
 
 	/*
 		DeleteExportBucket Revoke Access to AWS S3 Bucket for Cloud Backup Snapshot Exports
@@ -181,7 +181,7 @@ type CloudBackupsApi interface {
 	DeleteExportBucketWithParams(ctx context.Context, args *DeleteExportBucketApiParams) DeleteExportBucketApiRequest
 
 	// Interface only available internally
-	deleteExportBucketExecute(r DeleteExportBucketApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteExportBucketExecute(r DeleteExportBucketApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DeleteReplicaSetBackup Remove One Replica Set Cloud Backup
@@ -206,7 +206,7 @@ type CloudBackupsApi interface {
 	DeleteReplicaSetBackupWithParams(ctx context.Context, args *DeleteReplicaSetBackupApiParams) DeleteReplicaSetBackupApiRequest
 
 	// Interface only available internally
-	deleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DeleteShardedClusterBackup Remove One Sharded Cluster Cloud Backup
@@ -231,7 +231,7 @@ type CloudBackupsApi interface {
 	DeleteShardedClusterBackupWithParams(ctx context.Context, args *DeleteShardedClusterBackupApiParams) DeleteShardedClusterBackupApiRequest
 
 	// Interface only available internally
-	deleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetBackupExportJob Return One Cloud Backup Snapshot Export Job
@@ -256,7 +256,7 @@ type CloudBackupsApi interface {
 	GetBackupExportJobWithParams(ctx context.Context, args *GetBackupExportJobApiParams) GetBackupExportJobApiRequest
 
 	// Interface only available internally
-	getBackupExportJobExecute(r GetBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error)
+	GetBackupExportJobExecute(r GetBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error)
 
 	/*
 		GetBackupRestoreJob Return One Restore Job of One Cluster
@@ -281,7 +281,7 @@ type CloudBackupsApi interface {
 	GetBackupRestoreJobWithParams(ctx context.Context, args *GetBackupRestoreJobApiParams) GetBackupRestoreJobApiRequest
 
 	// Interface only available internally
-	getBackupRestoreJobExecute(r GetBackupRestoreJobApiRequest) (*DiskBackupSnapshotRestoreJob, *http.Response, error)
+	GetBackupRestoreJobExecute(r GetBackupRestoreJobApiRequest) (*DiskBackupSnapshotRestoreJob, *http.Response, error)
 
 	/*
 		GetBackupSchedule Return One Cloud Backup Schedule
@@ -305,7 +305,7 @@ type CloudBackupsApi interface {
 	GetBackupScheduleWithParams(ctx context.Context, args *GetBackupScheduleApiParams) GetBackupScheduleApiRequest
 
 	// Interface only available internally
-	getBackupScheduleExecute(r GetBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
+	GetBackupScheduleExecute(r GetBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
 
 	/*
 		GetDataProtectionSettings Return the Backup Compliance Policy settings
@@ -328,7 +328,7 @@ type CloudBackupsApi interface {
 	GetDataProtectionSettingsWithParams(ctx context.Context, args *GetDataProtectionSettingsApiParams) GetDataProtectionSettingsApiRequest
 
 	// Interface only available internally
-	getDataProtectionSettingsExecute(r GetDataProtectionSettingsApiRequest) (*DataProtectionSettings20231001, *http.Response, error)
+	GetDataProtectionSettingsExecute(r GetDataProtectionSettingsApiRequest) (*DataProtectionSettings20231001, *http.Response, error)
 
 	/*
 		GetExportBucket Return One AWS S3 Bucket Used for Cloud Backup Snapshot Exports
@@ -352,7 +352,7 @@ type CloudBackupsApi interface {
 	GetExportBucketWithParams(ctx context.Context, args *GetExportBucketApiParams) GetExportBucketApiRequest
 
 	// Interface only available internally
-	getExportBucketExecute(r GetExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
+	GetExportBucketExecute(r GetExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
 
 	/*
 		GetReplicaSetBackup Return One Replica Set Cloud Backup
@@ -377,7 +377,7 @@ type CloudBackupsApi interface {
 	GetReplicaSetBackupWithParams(ctx context.Context, args *GetReplicaSetBackupApiParams) GetReplicaSetBackupApiRequest
 
 	// Interface only available internally
-	getReplicaSetBackupExecute(r GetReplicaSetBackupApiRequest) (*DiskBackupReplicaSet, *http.Response, error)
+	GetReplicaSetBackupExecute(r GetReplicaSetBackupApiRequest) (*DiskBackupReplicaSet, *http.Response, error)
 
 	/*
 		GetServerlessBackup Return One Snapshot of One Serverless Instance
@@ -402,7 +402,7 @@ type CloudBackupsApi interface {
 	GetServerlessBackupWithParams(ctx context.Context, args *GetServerlessBackupApiParams) GetServerlessBackupApiRequest
 
 	// Interface only available internally
-	getServerlessBackupExecute(r GetServerlessBackupApiRequest) (*ServerlessBackupSnapshot, *http.Response, error)
+	GetServerlessBackupExecute(r GetServerlessBackupApiRequest) (*ServerlessBackupSnapshot, *http.Response, error)
 
 	/*
 		GetServerlessBackupRestoreJob Return One Restore Job for One Serverless Instance
@@ -427,7 +427,7 @@ type CloudBackupsApi interface {
 	GetServerlessBackupRestoreJobWithParams(ctx context.Context, args *GetServerlessBackupRestoreJobApiParams) GetServerlessBackupRestoreJobApiRequest
 
 	// Interface only available internally
-	getServerlessBackupRestoreJobExecute(r GetServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
+	GetServerlessBackupRestoreJobExecute(r GetServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
 
 	/*
 		GetShardedClusterBackup Return One Sharded Cluster Cloud Backup
@@ -452,7 +452,7 @@ type CloudBackupsApi interface {
 	GetShardedClusterBackupWithParams(ctx context.Context, args *GetShardedClusterBackupApiParams) GetShardedClusterBackupApiRequest
 
 	// Interface only available internally
-	getShardedClusterBackupExecute(r GetShardedClusterBackupApiRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error)
+	GetShardedClusterBackupExecute(r GetShardedClusterBackupApiRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error)
 
 	/*
 		ListBackupExportJobs Return All Cloud Backup Snapshot Export Jobs
@@ -476,7 +476,7 @@ type CloudBackupsApi interface {
 	ListBackupExportJobsWithParams(ctx context.Context, args *ListBackupExportJobsApiParams) ListBackupExportJobsApiRequest
 
 	// Interface only available internally
-	listBackupExportJobsExecute(r ListBackupExportJobsApiRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error)
+	ListBackupExportJobsExecute(r ListBackupExportJobsApiRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error)
 
 	/*
 		ListBackupRestoreJobs Return All Restore Jobs for One Cluster
@@ -500,7 +500,7 @@ type CloudBackupsApi interface {
 	ListBackupRestoreJobsWithParams(ctx context.Context, args *ListBackupRestoreJobsApiParams) ListBackupRestoreJobsApiRequest
 
 	// Interface only available internally
-	listBackupRestoreJobsExecute(r ListBackupRestoreJobsApiRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error)
+	ListBackupRestoreJobsExecute(r ListBackupRestoreJobsApiRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error)
 
 	/*
 		ListExportBuckets Return All AWS S3 Buckets Used for Cloud Backup Snapshot Exports
@@ -523,7 +523,7 @@ type CloudBackupsApi interface {
 	ListExportBucketsWithParams(ctx context.Context, args *ListExportBucketsApiParams) ListExportBucketsApiRequest
 
 	// Interface only available internally
-	listExportBucketsExecute(r ListExportBucketsApiRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error)
+	ListExportBucketsExecute(r ListExportBucketsApiRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error)
 
 	/*
 		ListReplicaSetBackups Return All Replica Set Cloud Backups
@@ -547,7 +547,7 @@ type CloudBackupsApi interface {
 	ListReplicaSetBackupsWithParams(ctx context.Context, args *ListReplicaSetBackupsApiParams) ListReplicaSetBackupsApiRequest
 
 	// Interface only available internally
-	listReplicaSetBackupsExecute(r ListReplicaSetBackupsApiRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error)
+	ListReplicaSetBackupsExecute(r ListReplicaSetBackupsApiRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error)
 
 	/*
 		ListServerlessBackupRestoreJobs Return All Restore Jobs for One Serverless Instance
@@ -571,7 +571,7 @@ type CloudBackupsApi interface {
 	ListServerlessBackupRestoreJobsWithParams(ctx context.Context, args *ListServerlessBackupRestoreJobsApiParams) ListServerlessBackupRestoreJobsApiRequest
 
 	// Interface only available internally
-	listServerlessBackupRestoreJobsExecute(r ListServerlessBackupRestoreJobsApiRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error)
+	ListServerlessBackupRestoreJobsExecute(r ListServerlessBackupRestoreJobsApiRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error)
 
 	/*
 		ListServerlessBackups Return All Snapshots of One Serverless Instance
@@ -595,7 +595,7 @@ type CloudBackupsApi interface {
 	ListServerlessBackupsWithParams(ctx context.Context, args *ListServerlessBackupsApiParams) ListServerlessBackupsApiRequest
 
 	// Interface only available internally
-	listServerlessBackupsExecute(r ListServerlessBackupsApiRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error)
+	ListServerlessBackupsExecute(r ListServerlessBackupsApiRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error)
 
 	/*
 		ListShardedClusterBackups Return All Sharded Cluster Cloud Backups
@@ -619,7 +619,7 @@ type CloudBackupsApi interface {
 	ListShardedClusterBackupsWithParams(ctx context.Context, args *ListShardedClusterBackupsApiParams) ListShardedClusterBackupsApiRequest
 
 	// Interface only available internally
-	listShardedClusterBackupsExecute(r ListShardedClusterBackupsApiRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error)
+	ListShardedClusterBackupsExecute(r ListShardedClusterBackupsApiRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error)
 
 	/*
 		TakeSnapshot Take One On-Demand Snapshot
@@ -645,7 +645,7 @@ type CloudBackupsApi interface {
 	TakeSnapshotWithParams(ctx context.Context, args *TakeSnapshotApiParams) TakeSnapshotApiRequest
 
 	// Interface only available internally
-	takeSnapshotExecute(r TakeSnapshotApiRequest) (*DiskBackupSnapshot, *http.Response, error)
+	TakeSnapshotExecute(r TakeSnapshotApiRequest) (*DiskBackupSnapshot, *http.Response, error)
 
 	/*
 		UpdateBackupSchedule Update Cloud Backup Schedule for One Cluster
@@ -669,7 +669,7 @@ type CloudBackupsApi interface {
 	UpdateBackupScheduleWithParams(ctx context.Context, args *UpdateBackupScheduleApiParams) UpdateBackupScheduleApiRequest
 
 	// Interface only available internally
-	updateBackupScheduleExecute(r UpdateBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
+	UpdateBackupScheduleExecute(r UpdateBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
 
 	/*
 		UpdateDataProtectionSettings Update or enable the Backup Compliance Policy settings
@@ -692,7 +692,7 @@ type CloudBackupsApi interface {
 	UpdateDataProtectionSettingsWithParams(ctx context.Context, args *UpdateDataProtectionSettingsApiParams) UpdateDataProtectionSettingsApiRequest
 
 	// Interface only available internally
-	updateDataProtectionSettingsExecute(r UpdateDataProtectionSettingsApiRequest) (*DataProtectionSettings20231001, *http.Response, error)
+	UpdateDataProtectionSettingsExecute(r UpdateDataProtectionSettingsApiRequest) (*DataProtectionSettings20231001, *http.Response, error)
 
 	/*
 		UpdateSnapshotRetention Change Expiration Date for One Cloud Backup
@@ -717,7 +717,7 @@ type CloudBackupsApi interface {
 	UpdateSnapshotRetentionWithParams(ctx context.Context, args *UpdateSnapshotRetentionApiParams) UpdateSnapshotRetentionApiRequest
 
 	// Interface only available internally
-	updateSnapshotRetentionExecute(r UpdateSnapshotRetentionApiRequest) (*DiskBackupReplicaSet, *http.Response, error)
+	UpdateSnapshotRetentionExecute(r UpdateSnapshotRetentionApiRequest) (*DiskBackupReplicaSet, *http.Response, error)
 }
 
 // CloudBackupsApiService CloudBackupsApi service
@@ -748,7 +748,7 @@ func (a *CloudBackupsApiService) CancelBackupRestoreJobWithParams(ctx context.Co
 }
 
 func (r CancelBackupRestoreJobApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.cancelBackupRestoreJobExecute(r)
+	return r.ApiService.CancelBackupRestoreJobExecute(r)
 }
 
 /*
@@ -775,7 +775,7 @@ func (a *CloudBackupsApiService) CancelBackupRestoreJob(ctx context.Context, gro
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *CloudBackupsApiService) cancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *CloudBackupsApiService) CancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -884,7 +884,7 @@ func (a *CloudBackupsApiService) CreateBackupExportJobWithParams(ctx context.Con
 }
 
 func (r CreateBackupExportJobApiRequest) Execute() (*DiskBackupExportJob, *http.Response, error) {
-	return r.ApiService.createBackupExportJobExecute(r)
+	return r.ApiService.CreateBackupExportJobExecute(r)
 }
 
 /*
@@ -910,7 +910,7 @@ func (a *CloudBackupsApiService) CreateBackupExportJob(ctx context.Context, grou
 // Execute executes the request
 //
 //	@return DiskBackupExportJob
-func (a *CloudBackupsApiService) createBackupExportJobExecute(r CreateBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error) {
+func (a *CloudBackupsApiService) CreateBackupExportJobExecute(r CreateBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -1023,7 +1023,7 @@ func (a *CloudBackupsApiService) CreateBackupRestoreJobWithParams(ctx context.Co
 }
 
 func (r CreateBackupRestoreJobApiRequest) Execute() (*DiskBackupSnapshotRestoreJob, *http.Response, error) {
-	return r.ApiService.createBackupRestoreJobExecute(r)
+	return r.ApiService.CreateBackupRestoreJobExecute(r)
 }
 
 /*
@@ -1051,7 +1051,7 @@ func (a *CloudBackupsApiService) CreateBackupRestoreJob(ctx context.Context, gro
 // Execute executes the request
 //
 //	@return DiskBackupSnapshotRestoreJob
-func (a *CloudBackupsApiService) createBackupRestoreJobExecute(r CreateBackupRestoreJobApiRequest) (*DiskBackupSnapshotRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) CreateBackupRestoreJobExecute(r CreateBackupRestoreJobApiRequest) (*DiskBackupSnapshotRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -1161,7 +1161,7 @@ func (a *CloudBackupsApiService) CreateExportBucketWithParams(ctx context.Contex
 }
 
 func (r CreateExportBucketApiRequest) Execute() (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
-	return r.ApiService.createExportBucketExecute(r)
+	return r.ApiService.CreateExportBucketExecute(r)
 }
 
 /*
@@ -1185,7 +1185,7 @@ func (a *CloudBackupsApiService) CreateExportBucket(ctx context.Context, groupId
 // Execute executes the request
 //
 //	@return DiskBackupSnapshotAWSExportBucket
-func (a *CloudBackupsApiService) createExportBucketExecute(r CreateExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
+func (a *CloudBackupsApiService) CreateExportBucketExecute(r CreateExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -1297,7 +1297,7 @@ func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJobWithParams(ctx 
 }
 
 func (r CreateServerlessBackupRestoreJobApiRequest) Execute() (*ServerlessBackupRestoreJob, *http.Response, error) {
-	return r.ApiService.createServerlessBackupRestoreJobExecute(r)
+	return r.ApiService.CreateServerlessBackupRestoreJobExecute(r)
 }
 
 /*
@@ -1323,7 +1323,7 @@ func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJob(ctx context.Co
 // Execute executes the request
 //
 //	@return ServerlessBackupRestoreJob
-func (a *CloudBackupsApiService) createServerlessBackupRestoreJobExecute(r CreateServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJobExecute(r CreateServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -1433,7 +1433,7 @@ func (a *CloudBackupsApiService) DeleteAllBackupSchedulesWithParams(ctx context.
 }
 
 func (r DeleteAllBackupSchedulesApiRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
-	return r.ApiService.deleteAllBackupSchedulesExecute(r)
+	return r.ApiService.DeleteAllBackupSchedulesExecute(r)
 }
 
 /*
@@ -1458,7 +1458,7 @@ func (a *CloudBackupsApiService) DeleteAllBackupSchedules(ctx context.Context, g
 // Execute executes the request
 //
 //	@return DiskBackupSnapshotSchedule
-func (a *CloudBackupsApiService) deleteAllBackupSchedulesExecute(r DeleteAllBackupSchedulesApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
+func (a *CloudBackupsApiService) DeleteAllBackupSchedulesExecute(r DeleteAllBackupSchedulesApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -1563,7 +1563,7 @@ func (a *CloudBackupsApiService) DeleteExportBucketWithParams(ctx context.Contex
 }
 
 func (r DeleteExportBucketApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteExportBucketExecute(r)
+	return r.ApiService.DeleteExportBucketExecute(r)
 }
 
 /*
@@ -1588,7 +1588,7 @@ func (a *CloudBackupsApiService) DeleteExportBucket(ctx context.Context, groupId
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *CloudBackupsApiService) deleteExportBucketExecute(r DeleteExportBucketApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *CloudBackupsApiService) DeleteExportBucketExecute(r DeleteExportBucketApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -1696,7 +1696,7 @@ func (a *CloudBackupsApiService) DeleteReplicaSetBackupWithParams(ctx context.Co
 }
 
 func (r DeleteReplicaSetBackupApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteReplicaSetBackupExecute(r)
+	return r.ApiService.DeleteReplicaSetBackupExecute(r)
 }
 
 /*
@@ -1723,7 +1723,7 @@ func (a *CloudBackupsApiService) DeleteReplicaSetBackup(ctx context.Context, gro
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *CloudBackupsApiService) deleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *CloudBackupsApiService) DeleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -1832,7 +1832,7 @@ func (a *CloudBackupsApiService) DeleteShardedClusterBackupWithParams(ctx contex
 }
 
 func (r DeleteShardedClusterBackupApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteShardedClusterBackupExecute(r)
+	return r.ApiService.DeleteShardedClusterBackupExecute(r)
 }
 
 /*
@@ -1859,7 +1859,7 @@ func (a *CloudBackupsApiService) DeleteShardedClusterBackup(ctx context.Context,
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *CloudBackupsApiService) deleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *CloudBackupsApiService) DeleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -1968,7 +1968,7 @@ func (a *CloudBackupsApiService) GetBackupExportJobWithParams(ctx context.Contex
 }
 
 func (r GetBackupExportJobApiRequest) Execute() (*DiskBackupExportJob, *http.Response, error) {
-	return r.ApiService.getBackupExportJobExecute(r)
+	return r.ApiService.GetBackupExportJobExecute(r)
 }
 
 /*
@@ -1995,7 +1995,7 @@ func (a *CloudBackupsApiService) GetBackupExportJob(ctx context.Context, groupId
 // Execute executes the request
 //
 //	@return DiskBackupExportJob
-func (a *CloudBackupsApiService) getBackupExportJobExecute(r GetBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error) {
+func (a *CloudBackupsApiService) GetBackupExportJobExecute(r GetBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2104,7 +2104,7 @@ func (a *CloudBackupsApiService) GetBackupRestoreJobWithParams(ctx context.Conte
 }
 
 func (r GetBackupRestoreJobApiRequest) Execute() (*DiskBackupSnapshotRestoreJob, *http.Response, error) {
-	return r.ApiService.getBackupRestoreJobExecute(r)
+	return r.ApiService.GetBackupRestoreJobExecute(r)
 }
 
 /*
@@ -2131,7 +2131,7 @@ func (a *CloudBackupsApiService) GetBackupRestoreJob(ctx context.Context, groupI
 // Execute executes the request
 //
 //	@return DiskBackupSnapshotRestoreJob
-func (a *CloudBackupsApiService) getBackupRestoreJobExecute(r GetBackupRestoreJobApiRequest) (*DiskBackupSnapshotRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) GetBackupRestoreJobExecute(r GetBackupRestoreJobApiRequest) (*DiskBackupSnapshotRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2237,7 +2237,7 @@ func (a *CloudBackupsApiService) GetBackupScheduleWithParams(ctx context.Context
 }
 
 func (r GetBackupScheduleApiRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
-	return r.ApiService.getBackupScheduleExecute(r)
+	return r.ApiService.GetBackupScheduleExecute(r)
 }
 
 /*
@@ -2262,7 +2262,7 @@ func (a *CloudBackupsApiService) GetBackupSchedule(ctx context.Context, groupId 
 // Execute executes the request
 //
 //	@return DiskBackupSnapshotSchedule
-func (a *CloudBackupsApiService) getBackupScheduleExecute(r GetBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
+func (a *CloudBackupsApiService) GetBackupScheduleExecute(r GetBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2364,7 +2364,7 @@ func (a *CloudBackupsApiService) GetDataProtectionSettingsWithParams(ctx context
 }
 
 func (r GetDataProtectionSettingsApiRequest) Execute() (*DataProtectionSettings20231001, *http.Response, error) {
-	return r.ApiService.getDataProtectionSettingsExecute(r)
+	return r.ApiService.GetDataProtectionSettingsExecute(r)
 }
 
 /*
@@ -2387,7 +2387,7 @@ func (a *CloudBackupsApiService) GetDataProtectionSettings(ctx context.Context, 
 // Execute executes the request
 //
 //	@return DataProtectionSettings20231001
-func (a *CloudBackupsApiService) getDataProtectionSettingsExecute(r GetDataProtectionSettingsApiRequest) (*DataProtectionSettings20231001, *http.Response, error) {
+func (a *CloudBackupsApiService) GetDataProtectionSettingsExecute(r GetDataProtectionSettingsApiRequest) (*DataProtectionSettings20231001, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2491,7 +2491,7 @@ func (a *CloudBackupsApiService) GetExportBucketWithParams(ctx context.Context, 
 }
 
 func (r GetExportBucketApiRequest) Execute() (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
-	return r.ApiService.getExportBucketExecute(r)
+	return r.ApiService.GetExportBucketExecute(r)
 }
 
 /*
@@ -2516,7 +2516,7 @@ func (a *CloudBackupsApiService) GetExportBucket(ctx context.Context, groupId st
 // Execute executes the request
 //
 //	@return DiskBackupSnapshotAWSExportBucket
-func (a *CloudBackupsApiService) getExportBucketExecute(r GetExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
+func (a *CloudBackupsApiService) GetExportBucketExecute(r GetExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2624,7 +2624,7 @@ func (a *CloudBackupsApiService) GetReplicaSetBackupWithParams(ctx context.Conte
 }
 
 func (r GetReplicaSetBackupApiRequest) Execute() (*DiskBackupReplicaSet, *http.Response, error) {
-	return r.ApiService.getReplicaSetBackupExecute(r)
+	return r.ApiService.GetReplicaSetBackupExecute(r)
 }
 
 /*
@@ -2651,7 +2651,7 @@ func (a *CloudBackupsApiService) GetReplicaSetBackup(ctx context.Context, groupI
 // Execute executes the request
 //
 //	@return DiskBackupReplicaSet
-func (a *CloudBackupsApiService) getReplicaSetBackupExecute(r GetReplicaSetBackupApiRequest) (*DiskBackupReplicaSet, *http.Response, error) {
+func (a *CloudBackupsApiService) GetReplicaSetBackupExecute(r GetReplicaSetBackupApiRequest) (*DiskBackupReplicaSet, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2760,7 +2760,7 @@ func (a *CloudBackupsApiService) GetServerlessBackupWithParams(ctx context.Conte
 }
 
 func (r GetServerlessBackupApiRequest) Execute() (*ServerlessBackupSnapshot, *http.Response, error) {
-	return r.ApiService.getServerlessBackupExecute(r)
+	return r.ApiService.GetServerlessBackupExecute(r)
 }
 
 /*
@@ -2787,7 +2787,7 @@ func (a *CloudBackupsApiService) GetServerlessBackup(ctx context.Context, groupI
 // Execute executes the request
 //
 //	@return ServerlessBackupSnapshot
-func (a *CloudBackupsApiService) getServerlessBackupExecute(r GetServerlessBackupApiRequest) (*ServerlessBackupSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) GetServerlessBackupExecute(r GetServerlessBackupApiRequest) (*ServerlessBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2896,7 +2896,7 @@ func (a *CloudBackupsApiService) GetServerlessBackupRestoreJobWithParams(ctx con
 }
 
 func (r GetServerlessBackupRestoreJobApiRequest) Execute() (*ServerlessBackupRestoreJob, *http.Response, error) {
-	return r.ApiService.getServerlessBackupRestoreJobExecute(r)
+	return r.ApiService.GetServerlessBackupRestoreJobExecute(r)
 }
 
 /*
@@ -2923,7 +2923,7 @@ func (a *CloudBackupsApiService) GetServerlessBackupRestoreJob(ctx context.Conte
 // Execute executes the request
 //
 //	@return ServerlessBackupRestoreJob
-func (a *CloudBackupsApiService) getServerlessBackupRestoreJobExecute(r GetServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) GetServerlessBackupRestoreJobExecute(r GetServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -3032,7 +3032,7 @@ func (a *CloudBackupsApiService) GetShardedClusterBackupWithParams(ctx context.C
 }
 
 func (r GetShardedClusterBackupApiRequest) Execute() (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
-	return r.ApiService.getShardedClusterBackupExecute(r)
+	return r.ApiService.GetShardedClusterBackupExecute(r)
 }
 
 /*
@@ -3059,7 +3059,7 @@ func (a *CloudBackupsApiService) GetShardedClusterBackup(ctx context.Context, gr
 // Execute executes the request
 //
 //	@return DiskBackupShardedClusterSnapshot
-func (a *CloudBackupsApiService) getShardedClusterBackupExecute(r GetShardedClusterBackupApiRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) GetShardedClusterBackupExecute(r GetShardedClusterBackupApiRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -3192,7 +3192,7 @@ func (r ListBackupExportJobsApiRequest) PageNum(pageNum int) ListBackupExportJob
 }
 
 func (r ListBackupExportJobsApiRequest) Execute() (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error) {
-	return r.ApiService.listBackupExportJobsExecute(r)
+	return r.ApiService.ListBackupExportJobsExecute(r)
 }
 
 /*
@@ -3217,7 +3217,7 @@ func (a *CloudBackupsApiService) ListBackupExportJobs(ctx context.Context, group
 // Execute executes the request
 //
 //	@return PaginatedApiAtlasDiskBackupExportJob
-func (a *CloudBackupsApiService) listBackupExportJobsExecute(r ListBackupExportJobsApiRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error) {
+func (a *CloudBackupsApiService) ListBackupExportJobsExecute(r ListBackupExportJobsApiRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -3370,7 +3370,7 @@ func (r ListBackupRestoreJobsApiRequest) PageNum(pageNum int) ListBackupRestoreJ
 }
 
 func (r ListBackupRestoreJobsApiRequest) Execute() (*PaginatedCloudBackupRestoreJob, *http.Response, error) {
-	return r.ApiService.listBackupRestoreJobsExecute(r)
+	return r.ApiService.ListBackupRestoreJobsExecute(r)
 }
 
 /*
@@ -3395,7 +3395,7 @@ func (a *CloudBackupsApiService) ListBackupRestoreJobs(ctx context.Context, grou
 // Execute executes the request
 //
 //	@return PaginatedCloudBackupRestoreJob
-func (a *CloudBackupsApiService) listBackupRestoreJobsExecute(r ListBackupRestoreJobsApiRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) ListBackupRestoreJobsExecute(r ListBackupRestoreJobsApiRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -3545,7 +3545,7 @@ func (r ListExportBucketsApiRequest) PageNum(pageNum int) ListExportBucketsApiRe
 }
 
 func (r ListExportBucketsApiRequest) Execute() (*PaginatedBackupSnapshotExportBucket, *http.Response, error) {
-	return r.ApiService.listExportBucketsExecute(r)
+	return r.ApiService.ListExportBucketsExecute(r)
 }
 
 /*
@@ -3568,7 +3568,7 @@ func (a *CloudBackupsApiService) ListExportBuckets(ctx context.Context, groupId 
 // Execute executes the request
 //
 //	@return PaginatedBackupSnapshotExportBucket
-func (a *CloudBackupsApiService) listExportBucketsExecute(r ListExportBucketsApiRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error) {
+func (a *CloudBackupsApiService) ListExportBucketsExecute(r ListExportBucketsApiRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -3720,7 +3720,7 @@ func (r ListReplicaSetBackupsApiRequest) PageNum(pageNum int) ListReplicaSetBack
 }
 
 func (r ListReplicaSetBackupsApiRequest) Execute() (*PaginatedCloudBackupReplicaSet, *http.Response, error) {
-	return r.ApiService.listReplicaSetBackupsExecute(r)
+	return r.ApiService.ListReplicaSetBackupsExecute(r)
 }
 
 /*
@@ -3745,7 +3745,7 @@ func (a *CloudBackupsApiService) ListReplicaSetBackups(ctx context.Context, grou
 // Execute executes the request
 //
 //	@return PaginatedCloudBackupReplicaSet
-func (a *CloudBackupsApiService) listReplicaSetBackupsExecute(r ListReplicaSetBackupsApiRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error) {
+func (a *CloudBackupsApiService) ListReplicaSetBackupsExecute(r ListReplicaSetBackupsApiRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -3898,7 +3898,7 @@ func (r ListServerlessBackupRestoreJobsApiRequest) PageNum(pageNum int) ListServ
 }
 
 func (r ListServerlessBackupRestoreJobsApiRequest) Execute() (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
-	return r.ApiService.listServerlessBackupRestoreJobsExecute(r)
+	return r.ApiService.ListServerlessBackupRestoreJobsExecute(r)
 }
 
 /*
@@ -3923,7 +3923,7 @@ func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobs(ctx context.Con
 // Execute executes the request
 //
 //	@return PaginatedApiAtlasServerlessBackupRestoreJob
-func (a *CloudBackupsApiService) listServerlessBackupRestoreJobsExecute(r ListServerlessBackupRestoreJobsApiRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobsExecute(r ListServerlessBackupRestoreJobsApiRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -4076,7 +4076,7 @@ func (r ListServerlessBackupsApiRequest) PageNum(pageNum int) ListServerlessBack
 }
 
 func (r ListServerlessBackupsApiRequest) Execute() (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error) {
-	return r.ApiService.listServerlessBackupsExecute(r)
+	return r.ApiService.ListServerlessBackupsExecute(r)
 }
 
 /*
@@ -4101,7 +4101,7 @@ func (a *CloudBackupsApiService) ListServerlessBackups(ctx context.Context, grou
 // Execute executes the request
 //
 //	@return PaginatedApiAtlasServerlessBackupSnapshot
-func (a *CloudBackupsApiService) listServerlessBackupsExecute(r ListServerlessBackupsApiRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) ListServerlessBackupsExecute(r ListServerlessBackupsApiRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -4227,7 +4227,7 @@ func (a *CloudBackupsApiService) ListShardedClusterBackupsWithParams(ctx context
 }
 
 func (r ListShardedClusterBackupsApiRequest) Execute() (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
-	return r.ApiService.listShardedClusterBackupsExecute(r)
+	return r.ApiService.ListShardedClusterBackupsExecute(r)
 }
 
 /*
@@ -4252,7 +4252,7 @@ func (a *CloudBackupsApiService) ListShardedClusterBackups(ctx context.Context, 
 // Execute executes the request
 //
 //	@return PaginatedCloudBackupShardedClusterSnapshot
-func (a *CloudBackupsApiService) listShardedClusterBackupsExecute(r ListShardedClusterBackupsApiRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) ListShardedClusterBackupsExecute(r ListShardedClusterBackupsApiRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -4360,7 +4360,7 @@ func (a *CloudBackupsApiService) TakeSnapshotWithParams(ctx context.Context, arg
 }
 
 func (r TakeSnapshotApiRequest) Execute() (*DiskBackupSnapshot, *http.Response, error) {
-	return r.ApiService.takeSnapshotExecute(r)
+	return r.ApiService.TakeSnapshotExecute(r)
 }
 
 /*
@@ -4388,7 +4388,7 @@ func (a *CloudBackupsApiService) TakeSnapshot(ctx context.Context, groupId strin
 // Execute executes the request
 //
 //	@return DiskBackupSnapshot
-func (a *CloudBackupsApiService) takeSnapshotExecute(r TakeSnapshotApiRequest) (*DiskBackupSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) TakeSnapshotExecute(r TakeSnapshotApiRequest) (*DiskBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -4501,7 +4501,7 @@ func (a *CloudBackupsApiService) UpdateBackupScheduleWithParams(ctx context.Cont
 }
 
 func (r UpdateBackupScheduleApiRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
-	return r.ApiService.updateBackupScheduleExecute(r)
+	return r.ApiService.UpdateBackupScheduleExecute(r)
 }
 
 /*
@@ -4527,7 +4527,7 @@ func (a *CloudBackupsApiService) UpdateBackupSchedule(ctx context.Context, group
 // Execute executes the request
 //
 //	@return DiskBackupSnapshotSchedule
-func (a *CloudBackupsApiService) updateBackupScheduleExecute(r UpdateBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
+func (a *CloudBackupsApiService) UpdateBackupScheduleExecute(r UpdateBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -4637,7 +4637,7 @@ func (a *CloudBackupsApiService) UpdateDataProtectionSettingsWithParams(ctx cont
 }
 
 func (r UpdateDataProtectionSettingsApiRequest) Execute() (*DataProtectionSettings20231001, *http.Response, error) {
-	return r.ApiService.updateDataProtectionSettingsExecute(r)
+	return r.ApiService.UpdateDataProtectionSettingsExecute(r)
 }
 
 /*
@@ -4661,7 +4661,7 @@ func (a *CloudBackupsApiService) UpdateDataProtectionSettings(ctx context.Contex
 // Execute executes the request
 //
 //	@return DataProtectionSettings20231001
-func (a *CloudBackupsApiService) updateDataProtectionSettingsExecute(r UpdateDataProtectionSettingsApiRequest) (*DataProtectionSettings20231001, *http.Response, error) {
+func (a *CloudBackupsApiService) UpdateDataProtectionSettingsExecute(r UpdateDataProtectionSettingsApiRequest) (*DataProtectionSettings20231001, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
 		localVarPostBody    interface{}
@@ -4776,7 +4776,7 @@ func (a *CloudBackupsApiService) UpdateSnapshotRetentionWithParams(ctx context.C
 }
 
 func (r UpdateSnapshotRetentionApiRequest) Execute() (*DiskBackupReplicaSet, *http.Response, error) {
-	return r.ApiService.updateSnapshotRetentionExecute(r)
+	return r.ApiService.UpdateSnapshotRetentionExecute(r)
 }
 
 /*
@@ -4804,7 +4804,7 @@ func (a *CloudBackupsApiService) UpdateSnapshotRetention(ctx context.Context, gr
 // Execute executes the request
 //
 //	@return DiskBackupReplicaSet
-func (a *CloudBackupsApiService) updateSnapshotRetentionExecute(r UpdateSnapshotRetentionApiRequest) (*DiskBackupReplicaSet, *http.Response, error) {
+func (a *CloudBackupsApiService) UpdateSnapshotRetentionExecute(r UpdateSnapshotRetentionApiRequest) (*DiskBackupReplicaSet, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_cloud_migration_service.go
+++ b/admin/api_cloud_migration_service.go
@@ -33,7 +33,7 @@ type CloudMigrationServiceApi interface {
 	*/
 	CreateLinkTokenWithParams(ctx context.Context, args *CreateLinkTokenApiParams) CreateLinkTokenApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateLinkTokenExecute(r CreateLinkTokenApiRequest) (*TargetOrg, *http.Response, error)
 
 	/*
@@ -62,7 +62,7 @@ type CloudMigrationServiceApi interface {
 	*/
 	CreatePushMigrationWithParams(ctx context.Context, args *CreatePushMigrationApiParams) CreatePushMigrationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreatePushMigrationExecute(r CreatePushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error)
 
 	/*
@@ -86,7 +86,7 @@ type CloudMigrationServiceApi interface {
 	*/
 	CutoverMigrationWithParams(ctx context.Context, args *CutoverMigrationApiParams) CutoverMigrationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CutoverMigrationExecute(r CutoverMigrationApiRequest) (*http.Response, error)
 
 	/*
@@ -109,7 +109,7 @@ type CloudMigrationServiceApi interface {
 	*/
 	DeleteLinkTokenWithParams(ctx context.Context, args *DeleteLinkTokenApiParams) DeleteLinkTokenApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -133,7 +133,7 @@ type CloudMigrationServiceApi interface {
 	*/
 	GetPushMigrationWithParams(ctx context.Context, args *GetPushMigrationApiParams) GetPushMigrationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetPushMigrationExecute(r GetPushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error)
 
 	/*
@@ -157,7 +157,7 @@ type CloudMigrationServiceApi interface {
 	*/
 	GetValidationStatusWithParams(ctx context.Context, args *GetValidationStatusApiParams) GetValidationStatusApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetValidationStatusExecute(r GetValidationStatusApiRequest) (*LiveImportValidation, *http.Response, error)
 
 	/*
@@ -180,7 +180,7 @@ type CloudMigrationServiceApi interface {
 	*/
 	ListSourceProjectsWithParams(ctx context.Context, args *ListSourceProjectsApiParams) ListSourceProjectsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListSourceProjectsExecute(r ListSourceProjectsApiRequest) ([]LiveImportAvailableProject, *http.Response, error)
 
 	/*
@@ -203,7 +203,7 @@ type CloudMigrationServiceApi interface {
 	*/
 	ValidateMigrationWithParams(ctx context.Context, args *ValidateMigrationApiParams) ValidateMigrationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ValidateMigrationExecute(r ValidateMigrationApiRequest) (*LiveImportValidation, *http.Response, error)
 }
 

--- a/admin/api_cloud_migration_service.go
+++ b/admin/api_cloud_migration_service.go
@@ -34,7 +34,7 @@ type CloudMigrationServiceApi interface {
 	CreateLinkTokenWithParams(ctx context.Context, args *CreateLinkTokenApiParams) CreateLinkTokenApiRequest
 
 	// Interface only available internally
-	createLinkTokenExecute(r CreateLinkTokenApiRequest) (*TargetOrg, *http.Response, error)
+	CreateLinkTokenExecute(r CreateLinkTokenApiRequest) (*TargetOrg, *http.Response, error)
 
 	/*
 		CreatePushMigration Migrate One Local Managed Cluster to MongoDB Atlas
@@ -63,7 +63,7 @@ type CloudMigrationServiceApi interface {
 	CreatePushMigrationWithParams(ctx context.Context, args *CreatePushMigrationApiParams) CreatePushMigrationApiRequest
 
 	// Interface only available internally
-	createPushMigrationExecute(r CreatePushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error)
+	CreatePushMigrationExecute(r CreatePushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error)
 
 	/*
 		CutoverMigration Cut Over the Migrated Cluster
@@ -87,7 +87,7 @@ type CloudMigrationServiceApi interface {
 	CutoverMigrationWithParams(ctx context.Context, args *CutoverMigrationApiParams) CutoverMigrationApiRequest
 
 	// Interface only available internally
-	cutoverMigrationExecute(r CutoverMigrationApiRequest) (*http.Response, error)
+	CutoverMigrationExecute(r CutoverMigrationApiRequest) (*http.Response, error)
 
 	/*
 		DeleteLinkToken Remove One Link-Token
@@ -110,7 +110,7 @@ type CloudMigrationServiceApi interface {
 	DeleteLinkTokenWithParams(ctx context.Context, args *DeleteLinkTokenApiParams) DeleteLinkTokenApiRequest
 
 	// Interface only available internally
-	deleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetPushMigration Return One Migration Job
@@ -134,7 +134,7 @@ type CloudMigrationServiceApi interface {
 	GetPushMigrationWithParams(ctx context.Context, args *GetPushMigrationApiParams) GetPushMigrationApiRequest
 
 	// Interface only available internally
-	getPushMigrationExecute(r GetPushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error)
+	GetPushMigrationExecute(r GetPushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error)
 
 	/*
 		GetValidationStatus Return One Migration Validation Job
@@ -158,7 +158,7 @@ type CloudMigrationServiceApi interface {
 	GetValidationStatusWithParams(ctx context.Context, args *GetValidationStatusApiParams) GetValidationStatusApiRequest
 
 	// Interface only available internally
-	getValidationStatusExecute(r GetValidationStatusApiRequest) (*LiveImportValidation, *http.Response, error)
+	GetValidationStatusExecute(r GetValidationStatusApiRequest) (*LiveImportValidation, *http.Response, error)
 
 	/*
 		ListSourceProjects Return All Projects Available for Migration
@@ -181,7 +181,7 @@ type CloudMigrationServiceApi interface {
 	ListSourceProjectsWithParams(ctx context.Context, args *ListSourceProjectsApiParams) ListSourceProjectsApiRequest
 
 	// Interface only available internally
-	listSourceProjectsExecute(r ListSourceProjectsApiRequest) ([]LiveImportAvailableProject, *http.Response, error)
+	ListSourceProjectsExecute(r ListSourceProjectsApiRequest) ([]LiveImportAvailableProject, *http.Response, error)
 
 	/*
 		ValidateMigration Validate One Migration Request
@@ -204,7 +204,7 @@ type CloudMigrationServiceApi interface {
 	ValidateMigrationWithParams(ctx context.Context, args *ValidateMigrationApiParams) ValidateMigrationApiRequest
 
 	// Interface only available internally
-	validateMigrationExecute(r ValidateMigrationApiRequest) (*LiveImportValidation, *http.Response, error)
+	ValidateMigrationExecute(r ValidateMigrationApiRequest) (*LiveImportValidation, *http.Response, error)
 }
 
 // CloudMigrationServiceApiService CloudMigrationServiceApi service
@@ -232,7 +232,7 @@ func (a *CloudMigrationServiceApiService) CreateLinkTokenWithParams(ctx context.
 }
 
 func (r CreateLinkTokenApiRequest) Execute() (*TargetOrg, *http.Response, error) {
-	return r.ApiService.createLinkTokenExecute(r)
+	return r.ApiService.CreateLinkTokenExecute(r)
 }
 
 /*
@@ -256,7 +256,7 @@ func (a *CloudMigrationServiceApiService) CreateLinkToken(ctx context.Context, o
 // Execute executes the request
 //
 //	@return TargetOrg
-func (a *CloudMigrationServiceApiService) createLinkTokenExecute(r CreateLinkTokenApiRequest) (*TargetOrg, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) CreateLinkTokenExecute(r CreateLinkTokenApiRequest) (*TargetOrg, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -365,7 +365,7 @@ func (a *CloudMigrationServiceApiService) CreatePushMigrationWithParams(ctx cont
 }
 
 func (r CreatePushMigrationApiRequest) Execute() (*LiveMigrationResponse, *http.Response, error) {
-	return r.ApiService.createPushMigrationExecute(r)
+	return r.ApiService.CreatePushMigrationExecute(r)
 }
 
 /*
@@ -395,7 +395,7 @@ func (a *CloudMigrationServiceApiService) CreatePushMigration(ctx context.Contex
 // Execute executes the request
 //
 //	@return LiveMigrationResponse
-func (a *CloudMigrationServiceApiService) createPushMigrationExecute(r CreatePushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) CreatePushMigrationExecute(r CreatePushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -504,7 +504,7 @@ func (a *CloudMigrationServiceApiService) CutoverMigrationWithParams(ctx context
 }
 
 func (r CutoverMigrationApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.cutoverMigrationExecute(r)
+	return r.ApiService.CutoverMigrationExecute(r)
 }
 
 /*
@@ -527,7 +527,7 @@ func (a *CloudMigrationServiceApiService) CutoverMigration(ctx context.Context, 
 }
 
 // Execute executes the request
-func (a *CloudMigrationServiceApiService) cutoverMigrationExecute(r CutoverMigrationApiRequest) (*http.Response, error) {
+func (a *CloudMigrationServiceApiService) CutoverMigrationExecute(r CutoverMigrationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPut
 		localVarPostBody   interface{}
@@ -619,7 +619,7 @@ func (a *CloudMigrationServiceApiService) DeleteLinkTokenWithParams(ctx context.
 }
 
 func (r DeleteLinkTokenApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteLinkTokenExecute(r)
+	return r.ApiService.DeleteLinkTokenExecute(r)
 }
 
 /*
@@ -642,7 +642,7 @@ func (a *CloudMigrationServiceApiService) DeleteLinkToken(ctx context.Context, o
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *CloudMigrationServiceApiService) deleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) DeleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -746,7 +746,7 @@ func (a *CloudMigrationServiceApiService) GetPushMigrationWithParams(ctx context
 }
 
 func (r GetPushMigrationApiRequest) Execute() (*LiveMigrationResponse, *http.Response, error) {
-	return r.ApiService.getPushMigrationExecute(r)
+	return r.ApiService.GetPushMigrationExecute(r)
 }
 
 /*
@@ -771,7 +771,7 @@ func (a *CloudMigrationServiceApiService) GetPushMigration(ctx context.Context, 
 // Execute executes the request
 //
 //	@return LiveMigrationResponse
-func (a *CloudMigrationServiceApiService) getPushMigrationExecute(r GetPushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) GetPushMigrationExecute(r GetPushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -876,7 +876,7 @@ func (a *CloudMigrationServiceApiService) GetValidationStatusWithParams(ctx cont
 }
 
 func (r GetValidationStatusApiRequest) Execute() (*LiveImportValidation, *http.Response, error) {
-	return r.ApiService.getValidationStatusExecute(r)
+	return r.ApiService.GetValidationStatusExecute(r)
 }
 
 /*
@@ -901,7 +901,7 @@ func (a *CloudMigrationServiceApiService) GetValidationStatus(ctx context.Contex
 // Execute executes the request
 //
 //	@return LiveImportValidation
-func (a *CloudMigrationServiceApiService) getValidationStatusExecute(r GetValidationStatusApiRequest) (*LiveImportValidation, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) GetValidationStatusExecute(r GetValidationStatusApiRequest) (*LiveImportValidation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1003,7 +1003,7 @@ func (a *CloudMigrationServiceApiService) ListSourceProjectsWithParams(ctx conte
 }
 
 func (r ListSourceProjectsApiRequest) Execute() ([]LiveImportAvailableProject, *http.Response, error) {
-	return r.ApiService.listSourceProjectsExecute(r)
+	return r.ApiService.ListSourceProjectsExecute(r)
 }
 
 /*
@@ -1026,7 +1026,7 @@ func (a *CloudMigrationServiceApiService) ListSourceProjects(ctx context.Context
 // Execute executes the request
 //
 //	@return []LiveImportAvailableProject
-func (a *CloudMigrationServiceApiService) listSourceProjectsExecute(r ListSourceProjectsApiRequest) ([]LiveImportAvailableProject, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) ListSourceProjectsExecute(r ListSourceProjectsApiRequest) ([]LiveImportAvailableProject, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1130,7 +1130,7 @@ func (a *CloudMigrationServiceApiService) ValidateMigrationWithParams(ctx contex
 }
 
 func (r ValidateMigrationApiRequest) Execute() (*LiveImportValidation, *http.Response, error) {
-	return r.ApiService.validateMigrationExecute(r)
+	return r.ApiService.ValidateMigrationExecute(r)
 }
 
 /*
@@ -1154,7 +1154,7 @@ func (a *CloudMigrationServiceApiService) ValidateMigration(ctx context.Context,
 // Execute executes the request
 //
 //	@return LiveImportValidation
-func (a *CloudMigrationServiceApiService) validateMigrationExecute(r ValidateMigrationApiRequest) (*LiveImportValidation, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) ValidateMigrationExecute(r ValidateMigrationApiRequest) (*LiveImportValidation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}

--- a/admin/api_cloud_provider_access.go
+++ b/admin/api_cloud_provider_access.go
@@ -34,7 +34,7 @@ type CloudProviderAccessApi interface {
 	*/
 	AuthorizeCloudProviderAccessRoleWithParams(ctx context.Context, args *AuthorizeCloudProviderAccessRoleApiParams) AuthorizeCloudProviderAccessRoleApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	AuthorizeCloudProviderAccessRoleExecute(r AuthorizeCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
 
 	/*
@@ -57,7 +57,7 @@ type CloudProviderAccessApi interface {
 	*/
 	CreateCloudProviderAccessRoleWithParams(ctx context.Context, args *CreateCloudProviderAccessRoleApiParams) CreateCloudProviderAccessRoleApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateCloudProviderAccessRoleExecute(r CreateCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
 
 	/*
@@ -82,7 +82,7 @@ type CloudProviderAccessApi interface {
 	*/
 	DeauthorizeCloudProviderAccessRoleWithParams(ctx context.Context, args *DeauthorizeCloudProviderAccessRoleApiParams) DeauthorizeCloudProviderAccessRoleApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeauthorizeCloudProviderAccessRoleExecute(r DeauthorizeCloudProviderAccessRoleApiRequest) (*http.Response, error)
 
 	/*
@@ -106,7 +106,7 @@ type CloudProviderAccessApi interface {
 	*/
 	GetCloudProviderAccessRoleWithParams(ctx context.Context, args *GetCloudProviderAccessRoleApiParams) GetCloudProviderAccessRoleApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetCloudProviderAccessRoleExecute(r GetCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
 
 	/*
@@ -129,7 +129,7 @@ type CloudProviderAccessApi interface {
 	*/
 	ListCloudProviderAccessRolesWithParams(ctx context.Context, args *ListCloudProviderAccessRolesApiParams) ListCloudProviderAccessRolesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListCloudProviderAccessRolesExecute(r ListCloudProviderAccessRolesApiRequest) (*CloudProviderAccessRoles, *http.Response, error)
 }
 

--- a/admin/api_cloud_provider_access.go
+++ b/admin/api_cloud_provider_access.go
@@ -35,7 +35,7 @@ type CloudProviderAccessApi interface {
 	AuthorizeCloudProviderAccessRoleWithParams(ctx context.Context, args *AuthorizeCloudProviderAccessRoleApiParams) AuthorizeCloudProviderAccessRoleApiRequest
 
 	// Interface only available internally
-	authorizeCloudProviderAccessRoleExecute(r AuthorizeCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
+	AuthorizeCloudProviderAccessRoleExecute(r AuthorizeCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
 
 	/*
 		CreateCloudProviderAccessRole Create One Cloud Provider Access Role
@@ -58,7 +58,7 @@ type CloudProviderAccessApi interface {
 	CreateCloudProviderAccessRoleWithParams(ctx context.Context, args *CreateCloudProviderAccessRoleApiParams) CreateCloudProviderAccessRoleApiRequest
 
 	// Interface only available internally
-	createCloudProviderAccessRoleExecute(r CreateCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
+	CreateCloudProviderAccessRoleExecute(r CreateCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
 
 	/*
 		DeauthorizeCloudProviderAccessRole Deauthorize One Cloud Provider Access Role
@@ -83,7 +83,7 @@ type CloudProviderAccessApi interface {
 	DeauthorizeCloudProviderAccessRoleWithParams(ctx context.Context, args *DeauthorizeCloudProviderAccessRoleApiParams) DeauthorizeCloudProviderAccessRoleApiRequest
 
 	// Interface only available internally
-	deauthorizeCloudProviderAccessRoleExecute(r DeauthorizeCloudProviderAccessRoleApiRequest) (*http.Response, error)
+	DeauthorizeCloudProviderAccessRoleExecute(r DeauthorizeCloudProviderAccessRoleApiRequest) (*http.Response, error)
 
 	/*
 		GetCloudProviderAccessRole Return specified Cloud Provider Access Role
@@ -107,7 +107,7 @@ type CloudProviderAccessApi interface {
 	GetCloudProviderAccessRoleWithParams(ctx context.Context, args *GetCloudProviderAccessRoleApiParams) GetCloudProviderAccessRoleApiRequest
 
 	// Interface only available internally
-	getCloudProviderAccessRoleExecute(r GetCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
+	GetCloudProviderAccessRoleExecute(r GetCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
 
 	/*
 		ListCloudProviderAccessRoles Return All Cloud Provider Access Roles
@@ -130,7 +130,7 @@ type CloudProviderAccessApi interface {
 	ListCloudProviderAccessRolesWithParams(ctx context.Context, args *ListCloudProviderAccessRolesApiParams) ListCloudProviderAccessRolesApiRequest
 
 	// Interface only available internally
-	listCloudProviderAccessRolesExecute(r ListCloudProviderAccessRolesApiRequest) (*CloudProviderAccessRoles, *http.Response, error)
+	ListCloudProviderAccessRolesExecute(r ListCloudProviderAccessRolesApiRequest) (*CloudProviderAccessRoles, *http.Response, error)
 }
 
 // CloudProviderAccessApiService CloudProviderAccessApi service
@@ -161,7 +161,7 @@ func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRoleWithPara
 }
 
 func (r AuthorizeCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAccessRole, *http.Response, error) {
-	return r.ApiService.authorizeCloudProviderAccessRoleExecute(r)
+	return r.ApiService.AuthorizeCloudProviderAccessRoleExecute(r)
 }
 
 /*
@@ -187,7 +187,7 @@ func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRole(ctx con
 // Execute executes the request
 //
 //	@return CloudProviderAccessRole
-func (a *CloudProviderAccessApiService) authorizeCloudProviderAccessRoleExecute(r AuthorizeCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
+func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRoleExecute(r AuthorizeCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -297,7 +297,7 @@ func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRoleWithParams(
 }
 
 func (r CreateCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAccessRole, *http.Response, error) {
-	return r.ApiService.createCloudProviderAccessRoleExecute(r)
+	return r.ApiService.CreateCloudProviderAccessRoleExecute(r)
 }
 
 /*
@@ -321,7 +321,7 @@ func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRole(ctx contex
 // Execute executes the request
 //
 //	@return CloudProviderAccessRole
-func (a *CloudProviderAccessApiService) createCloudProviderAccessRoleExecute(r CreateCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
+func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRoleExecute(r CreateCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -433,7 +433,7 @@ func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRoleWithPa
 }
 
 func (r DeauthorizeCloudProviderAccessRoleApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.deauthorizeCloudProviderAccessRoleExecute(r)
+	return r.ApiService.DeauthorizeCloudProviderAccessRoleExecute(r)
 }
 
 /*
@@ -458,7 +458,7 @@ func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRole(ctx c
 }
 
 // Execute executes the request
-func (a *CloudProviderAccessApiService) deauthorizeCloudProviderAccessRoleExecute(r DeauthorizeCloudProviderAccessRoleApiRequest) (*http.Response, error) {
+func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRoleExecute(r DeauthorizeCloudProviderAccessRoleApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -554,7 +554,7 @@ func (a *CloudProviderAccessApiService) GetCloudProviderAccessRoleWithParams(ctx
 }
 
 func (r GetCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAccessRole, *http.Response, error) {
-	return r.ApiService.getCloudProviderAccessRoleExecute(r)
+	return r.ApiService.GetCloudProviderAccessRoleExecute(r)
 }
 
 /*
@@ -579,7 +579,7 @@ func (a *CloudProviderAccessApiService) GetCloudProviderAccessRole(ctx context.C
 // Execute executes the request
 //
 //	@return CloudProviderAccessRole
-func (a *CloudProviderAccessApiService) getCloudProviderAccessRoleExecute(r GetCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
+func (a *CloudProviderAccessApiService) GetCloudProviderAccessRoleExecute(r GetCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -681,7 +681,7 @@ func (a *CloudProviderAccessApiService) ListCloudProviderAccessRolesWithParams(c
 }
 
 func (r ListCloudProviderAccessRolesApiRequest) Execute() (*CloudProviderAccessRoles, *http.Response, error) {
-	return r.ApiService.listCloudProviderAccessRolesExecute(r)
+	return r.ApiService.ListCloudProviderAccessRolesExecute(r)
 }
 
 /*
@@ -704,7 +704,7 @@ func (a *CloudProviderAccessApiService) ListCloudProviderAccessRoles(ctx context
 // Execute executes the request
 //
 //	@return CloudProviderAccessRoles
-func (a *CloudProviderAccessApiService) listCloudProviderAccessRolesExecute(r ListCloudProviderAccessRolesApiRequest) (*CloudProviderAccessRoles, *http.Response, error) {
+func (a *CloudProviderAccessApiService) ListCloudProviderAccessRolesExecute(r ListCloudProviderAccessRolesApiRequest) (*CloudProviderAccessRoles, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_cluster_outage_simulation.go
+++ b/admin/api_cluster_outage_simulation.go
@@ -34,7 +34,7 @@ type ClusterOutageSimulationApi interface {
 	*/
 	EndOutageSimulationWithParams(ctx context.Context, args *EndOutageSimulationApiParams) EndOutageSimulationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	EndOutageSimulationExecute(r EndOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
 
 	/*
@@ -58,7 +58,7 @@ type ClusterOutageSimulationApi interface {
 	*/
 	GetOutageSimulationWithParams(ctx context.Context, args *GetOutageSimulationApiParams) GetOutageSimulationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetOutageSimulationExecute(r GetOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
 
 	/*
@@ -82,7 +82,7 @@ type ClusterOutageSimulationApi interface {
 	*/
 	StartOutageSimulationWithParams(ctx context.Context, args *StartOutageSimulationApiParams) StartOutageSimulationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	StartOutageSimulationExecute(r StartOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
 }
 

--- a/admin/api_cluster_outage_simulation.go
+++ b/admin/api_cluster_outage_simulation.go
@@ -35,7 +35,7 @@ type ClusterOutageSimulationApi interface {
 	EndOutageSimulationWithParams(ctx context.Context, args *EndOutageSimulationApiParams) EndOutageSimulationApiRequest
 
 	// Interface only available internally
-	endOutageSimulationExecute(r EndOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
+	EndOutageSimulationExecute(r EndOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
 
 	/*
 		GetOutageSimulation Return One Outage Simulation
@@ -59,7 +59,7 @@ type ClusterOutageSimulationApi interface {
 	GetOutageSimulationWithParams(ctx context.Context, args *GetOutageSimulationApiParams) GetOutageSimulationApiRequest
 
 	// Interface only available internally
-	getOutageSimulationExecute(r GetOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
+	GetOutageSimulationExecute(r GetOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
 
 	/*
 		StartOutageSimulation Start an Outage Simulation
@@ -83,7 +83,7 @@ type ClusterOutageSimulationApi interface {
 	StartOutageSimulationWithParams(ctx context.Context, args *StartOutageSimulationApiParams) StartOutageSimulationApiRequest
 
 	// Interface only available internally
-	startOutageSimulationExecute(r StartOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
+	StartOutageSimulationExecute(r StartOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
 }
 
 // ClusterOutageSimulationApiService ClusterOutageSimulationApi service
@@ -111,7 +111,7 @@ func (a *ClusterOutageSimulationApiService) EndOutageSimulationWithParams(ctx co
 }
 
 func (r EndOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
-	return r.ApiService.endOutageSimulationExecute(r)
+	return r.ApiService.EndOutageSimulationExecute(r)
 }
 
 /*
@@ -136,7 +136,7 @@ func (a *ClusterOutageSimulationApiService) EndOutageSimulation(ctx context.Cont
 // Execute executes the request
 //
 //	@return ClusterOutageSimulation
-func (a *ClusterOutageSimulationApiService) endOutageSimulationExecute(r EndOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
+func (a *ClusterOutageSimulationApiService) EndOutageSimulationExecute(r EndOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -241,7 +241,7 @@ func (a *ClusterOutageSimulationApiService) GetOutageSimulationWithParams(ctx co
 }
 
 func (r GetOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
-	return r.ApiService.getOutageSimulationExecute(r)
+	return r.ApiService.GetOutageSimulationExecute(r)
 }
 
 /*
@@ -266,7 +266,7 @@ func (a *ClusterOutageSimulationApiService) GetOutageSimulation(ctx context.Cont
 // Execute executes the request
 //
 //	@return ClusterOutageSimulation
-func (a *ClusterOutageSimulationApiService) getOutageSimulationExecute(r GetOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
+func (a *ClusterOutageSimulationApiService) GetOutageSimulationExecute(r GetOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -374,7 +374,7 @@ func (a *ClusterOutageSimulationApiService) StartOutageSimulationWithParams(ctx 
 }
 
 func (r StartOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
-	return r.ApiService.startOutageSimulationExecute(r)
+	return r.ApiService.StartOutageSimulationExecute(r)
 }
 
 /*
@@ -400,7 +400,7 @@ func (a *ClusterOutageSimulationApiService) StartOutageSimulation(ctx context.Co
 // Execute executes the request
 //
 //	@return ClusterOutageSimulation
-func (a *ClusterOutageSimulationApiService) startOutageSimulationExecute(r StartOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
+func (a *ClusterOutageSimulationApiService) StartOutageSimulationExecute(r StartOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}

--- a/admin/api_clusters.go
+++ b/admin/api_clusters.go
@@ -34,7 +34,7 @@ type ClustersApi interface {
 	*/
 	CreateClusterWithParams(ctx context.Context, args *CreateClusterApiParams) CreateClusterApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateClusterExecute(r CreateClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error)
 
 	/*
@@ -58,7 +58,7 @@ type ClustersApi interface {
 	*/
 	DeleteClusterWithParams(ctx context.Context, args *DeleteClusterApiParams) DeleteClusterApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteClusterExecute(r DeleteClusterApiRequest) (*http.Response, error)
 
 	/*
@@ -82,7 +82,7 @@ type ClustersApi interface {
 	*/
 	GetClusterWithParams(ctx context.Context, args *GetClusterApiParams) GetClusterApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetClusterExecute(r GetClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error)
 
 	/*
@@ -106,7 +106,7 @@ type ClustersApi interface {
 	*/
 	GetClusterAdvancedConfigurationWithParams(ctx context.Context, args *GetClusterAdvancedConfigurationApiParams) GetClusterAdvancedConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetClusterAdvancedConfigurationExecute(r GetClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
 
 	/*
@@ -130,7 +130,7 @@ type ClustersApi interface {
 	*/
 	GetClusterStatusWithParams(ctx context.Context, args *GetClusterStatusApiParams) GetClusterStatusApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetClusterStatusExecute(r GetClusterStatusApiRequest) (*ClusterStatus, *http.Response, error)
 
 	/*
@@ -154,7 +154,7 @@ type ClustersApi interface {
 	*/
 	GetSampleDatasetLoadStatusWithParams(ctx context.Context, args *GetSampleDatasetLoadStatusApiParams) GetSampleDatasetLoadStatusApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetSampleDatasetLoadStatusExecute(r GetSampleDatasetLoadStatusApiRequest) (*SampleDatasetStatus, *http.Response, error)
 
 	/*
@@ -177,7 +177,7 @@ type ClustersApi interface {
 	*/
 	ListCloudProviderRegionsWithParams(ctx context.Context, args *ListCloudProviderRegionsApiParams) ListCloudProviderRegionsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListCloudProviderRegionsExecute(r ListCloudProviderRegionsApiRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error)
 
 	/*
@@ -200,7 +200,7 @@ type ClustersApi interface {
 	*/
 	ListClustersWithParams(ctx context.Context, args *ListClustersApiParams) ListClustersApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListClustersExecute(r ListClustersApiRequest) (*PaginatedAdvancedClusterDescription, *http.Response, error)
 
 	/*
@@ -222,7 +222,7 @@ type ClustersApi interface {
 	*/
 	ListClustersForAllProjectsWithParams(ctx context.Context, args *ListClustersForAllProjectsApiParams) ListClustersForAllProjectsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListClustersForAllProjectsExecute(r ListClustersForAllProjectsApiRequest) (*PaginatedOrgGroup, *http.Response, error)
 
 	/*
@@ -246,7 +246,7 @@ type ClustersApi interface {
 	*/
 	LoadSampleDatasetWithParams(ctx context.Context, args *LoadSampleDatasetApiParams) LoadSampleDatasetApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	LoadSampleDatasetExecute(r LoadSampleDatasetApiRequest) (*SampleDatasetStatus, *http.Response, error)
 
 	/*
@@ -270,7 +270,7 @@ type ClustersApi interface {
 	*/
 	TestFailoverWithParams(ctx context.Context, args *TestFailoverApiParams) TestFailoverApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	TestFailoverExecute(r TestFailoverApiRequest) (*http.Response, error)
 
 	/*
@@ -294,7 +294,7 @@ type ClustersApi interface {
 	*/
 	UpdateClusterWithParams(ctx context.Context, args *UpdateClusterApiParams) UpdateClusterApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateClusterExecute(r UpdateClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error)
 
 	/*
@@ -318,7 +318,7 @@ type ClustersApi interface {
 	*/
 	UpdateClusterAdvancedConfigurationWithParams(ctx context.Context, args *UpdateClusterAdvancedConfigurationApiParams) UpdateClusterAdvancedConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateClusterAdvancedConfigurationExecute(r UpdateClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
 
 	/*
@@ -341,7 +341,7 @@ type ClustersApi interface {
 	*/
 	UpgradeSharedClusterWithParams(ctx context.Context, args *UpgradeSharedClusterApiParams) UpgradeSharedClusterApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpgradeSharedClusterExecute(r UpgradeSharedClusterApiRequest) (*LegacyAtlasCluster, *http.Response, error)
 
 	/*
@@ -364,7 +364,7 @@ type ClustersApi interface {
 	*/
 	UpgradeSharedClusterToServerlessWithParams(ctx context.Context, args *UpgradeSharedClusterToServerlessApiParams) UpgradeSharedClusterToServerlessApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpgradeSharedClusterToServerlessExecute(r UpgradeSharedClusterToServerlessApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 }
 

--- a/admin/api_clusters.go
+++ b/admin/api_clusters.go
@@ -35,7 +35,7 @@ type ClustersApi interface {
 	CreateClusterWithParams(ctx context.Context, args *CreateClusterApiParams) CreateClusterApiRequest
 
 	// Interface only available internally
-	createClusterExecute(r CreateClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error)
+	CreateClusterExecute(r CreateClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error)
 
 	/*
 		DeleteCluster Remove One Multi-Cloud Cluster from One Project
@@ -59,7 +59,7 @@ type ClustersApi interface {
 	DeleteClusterWithParams(ctx context.Context, args *DeleteClusterApiParams) DeleteClusterApiRequest
 
 	// Interface only available internally
-	deleteClusterExecute(r DeleteClusterApiRequest) (*http.Response, error)
+	DeleteClusterExecute(r DeleteClusterApiRequest) (*http.Response, error)
 
 	/*
 		GetCluster Return One Multi-Cloud Cluster from One Project
@@ -83,7 +83,7 @@ type ClustersApi interface {
 	GetClusterWithParams(ctx context.Context, args *GetClusterApiParams) GetClusterApiRequest
 
 	// Interface only available internally
-	getClusterExecute(r GetClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error)
+	GetClusterExecute(r GetClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error)
 
 	/*
 		GetClusterAdvancedConfiguration Return One Advanced Configuration Options for One Cluster
@@ -107,7 +107,7 @@ type ClustersApi interface {
 	GetClusterAdvancedConfigurationWithParams(ctx context.Context, args *GetClusterAdvancedConfigurationApiParams) GetClusterAdvancedConfigurationApiRequest
 
 	// Interface only available internally
-	getClusterAdvancedConfigurationExecute(r GetClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
+	GetClusterAdvancedConfigurationExecute(r GetClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
 
 	/*
 		GetClusterStatus Return Status of All Cluster Operations
@@ -131,7 +131,7 @@ type ClustersApi interface {
 	GetClusterStatusWithParams(ctx context.Context, args *GetClusterStatusApiParams) GetClusterStatusApiRequest
 
 	// Interface only available internally
-	getClusterStatusExecute(r GetClusterStatusApiRequest) (*ClusterStatus, *http.Response, error)
+	GetClusterStatusExecute(r GetClusterStatusApiRequest) (*ClusterStatus, *http.Response, error)
 
 	/*
 		GetSampleDatasetLoadStatus Check Status of Cluster Sample Dataset Request
@@ -155,7 +155,7 @@ type ClustersApi interface {
 	GetSampleDatasetLoadStatusWithParams(ctx context.Context, args *GetSampleDatasetLoadStatusApiParams) GetSampleDatasetLoadStatusApiRequest
 
 	// Interface only available internally
-	getSampleDatasetLoadStatusExecute(r GetSampleDatasetLoadStatusApiRequest) (*SampleDatasetStatus, *http.Response, error)
+	GetSampleDatasetLoadStatusExecute(r GetSampleDatasetLoadStatusApiRequest) (*SampleDatasetStatus, *http.Response, error)
 
 	/*
 		ListCloudProviderRegions Return All Cloud Provider Regions
@@ -178,7 +178,7 @@ type ClustersApi interface {
 	ListCloudProviderRegionsWithParams(ctx context.Context, args *ListCloudProviderRegionsApiParams) ListCloudProviderRegionsApiRequest
 
 	// Interface only available internally
-	listCloudProviderRegionsExecute(r ListCloudProviderRegionsApiRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error)
+	ListCloudProviderRegionsExecute(r ListCloudProviderRegionsApiRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error)
 
 	/*
 		ListClusters Return All Clusters in One Project
@@ -201,7 +201,7 @@ type ClustersApi interface {
 	ListClustersWithParams(ctx context.Context, args *ListClustersApiParams) ListClustersApiRequest
 
 	// Interface only available internally
-	listClustersExecute(r ListClustersApiRequest) (*PaginatedAdvancedClusterDescription, *http.Response, error)
+	ListClustersExecute(r ListClustersApiRequest) (*PaginatedAdvancedClusterDescription, *http.Response, error)
 
 	/*
 		ListClustersForAllProjects Return All Authorized Clusters in All Projects
@@ -223,7 +223,7 @@ type ClustersApi interface {
 	ListClustersForAllProjectsWithParams(ctx context.Context, args *ListClustersForAllProjectsApiParams) ListClustersForAllProjectsApiRequest
 
 	// Interface only available internally
-	listClustersForAllProjectsExecute(r ListClustersForAllProjectsApiRequest) (*PaginatedOrgGroup, *http.Response, error)
+	ListClustersForAllProjectsExecute(r ListClustersForAllProjectsApiRequest) (*PaginatedOrgGroup, *http.Response, error)
 
 	/*
 		LoadSampleDataset Load Sample Dataset Request into Cluster
@@ -247,7 +247,7 @@ type ClustersApi interface {
 	LoadSampleDatasetWithParams(ctx context.Context, args *LoadSampleDatasetApiParams) LoadSampleDatasetApiRequest
 
 	// Interface only available internally
-	loadSampleDatasetExecute(r LoadSampleDatasetApiRequest) (*SampleDatasetStatus, *http.Response, error)
+	LoadSampleDatasetExecute(r LoadSampleDatasetApiRequest) (*SampleDatasetStatus, *http.Response, error)
 
 	/*
 		TestFailover Test Failover for One Multi-Cloud Cluster
@@ -271,7 +271,7 @@ type ClustersApi interface {
 	TestFailoverWithParams(ctx context.Context, args *TestFailoverApiParams) TestFailoverApiRequest
 
 	// Interface only available internally
-	testFailoverExecute(r TestFailoverApiRequest) (*http.Response, error)
+	TestFailoverExecute(r TestFailoverApiRequest) (*http.Response, error)
 
 	/*
 		UpdateCluster Modify One Multi-Cloud Cluster from One Project
@@ -295,7 +295,7 @@ type ClustersApi interface {
 	UpdateClusterWithParams(ctx context.Context, args *UpdateClusterApiParams) UpdateClusterApiRequest
 
 	// Interface only available internally
-	updateClusterExecute(r UpdateClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error)
+	UpdateClusterExecute(r UpdateClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error)
 
 	/*
 		UpdateClusterAdvancedConfiguration Update Advanced Configuration Options for One Cluster
@@ -319,7 +319,7 @@ type ClustersApi interface {
 	UpdateClusterAdvancedConfigurationWithParams(ctx context.Context, args *UpdateClusterAdvancedConfigurationApiParams) UpdateClusterAdvancedConfigurationApiRequest
 
 	// Interface only available internally
-	updateClusterAdvancedConfigurationExecute(r UpdateClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
+	UpdateClusterAdvancedConfigurationExecute(r UpdateClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
 
 	/*
 		UpgradeSharedCluster Upgrade One Shared-tier Cluster
@@ -342,7 +342,7 @@ type ClustersApi interface {
 	UpgradeSharedClusterWithParams(ctx context.Context, args *UpgradeSharedClusterApiParams) UpgradeSharedClusterApiRequest
 
 	// Interface only available internally
-	upgradeSharedClusterExecute(r UpgradeSharedClusterApiRequest) (*LegacyAtlasCluster, *http.Response, error)
+	UpgradeSharedClusterExecute(r UpgradeSharedClusterApiRequest) (*LegacyAtlasCluster, *http.Response, error)
 
 	/*
 		UpgradeSharedClusterToServerless Upgrades One Shared-Tier Cluster to the Serverless Instance
@@ -365,7 +365,7 @@ type ClustersApi interface {
 	UpgradeSharedClusterToServerlessWithParams(ctx context.Context, args *UpgradeSharedClusterToServerlessApiParams) UpgradeSharedClusterToServerlessApiRequest
 
 	// Interface only available internally
-	upgradeSharedClusterToServerlessExecute(r UpgradeSharedClusterToServerlessApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
+	UpgradeSharedClusterToServerlessExecute(r UpgradeSharedClusterToServerlessApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 }
 
 // ClustersApiService ClustersApi service
@@ -393,7 +393,7 @@ func (a *ClustersApiService) CreateClusterWithParams(ctx context.Context, args *
 }
 
 func (r CreateClusterApiRequest) Execute() (*AdvancedClusterDescription, *http.Response, error) {
-	return r.ApiService.createClusterExecute(r)
+	return r.ApiService.CreateClusterExecute(r)
 }
 
 /*
@@ -417,7 +417,7 @@ func (a *ClustersApiService) CreateCluster(ctx context.Context, groupId string, 
 // Execute executes the request
 //
 //	@return AdvancedClusterDescription
-func (a *ClustersApiService) createClusterExecute(r CreateClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error) {
+func (a *ClustersApiService) CreateClusterExecute(r CreateClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -535,7 +535,7 @@ func (r DeleteClusterApiRequest) RetainBackups(retainBackups bool) DeleteCluster
 }
 
 func (r DeleteClusterApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.deleteClusterExecute(r)
+	return r.ApiService.DeleteClusterExecute(r)
 }
 
 /*
@@ -558,7 +558,7 @@ func (a *ClustersApiService) DeleteCluster(ctx context.Context, groupId string, 
 }
 
 // Execute executes the request
-func (a *ClustersApiService) deleteClusterExecute(r DeleteClusterApiRequest) (*http.Response, error) {
+func (a *ClustersApiService) DeleteClusterExecute(r DeleteClusterApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -656,7 +656,7 @@ func (a *ClustersApiService) GetClusterWithParams(ctx context.Context, args *Get
 }
 
 func (r GetClusterApiRequest) Execute() (*AdvancedClusterDescription, *http.Response, error) {
-	return r.ApiService.getClusterExecute(r)
+	return r.ApiService.GetClusterExecute(r)
 }
 
 /*
@@ -681,7 +681,7 @@ func (a *ClustersApiService) GetCluster(ctx context.Context, groupId string, clu
 // Execute executes the request
 //
 //	@return AdvancedClusterDescription
-func (a *ClustersApiService) getClusterExecute(r GetClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error) {
+func (a *ClustersApiService) GetClusterExecute(r GetClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -786,7 +786,7 @@ func (a *ClustersApiService) GetClusterAdvancedConfigurationWithParams(ctx conte
 }
 
 func (r GetClusterAdvancedConfigurationApiRequest) Execute() (*ClusterDescriptionProcessArgs, *http.Response, error) {
-	return r.ApiService.getClusterAdvancedConfigurationExecute(r)
+	return r.ApiService.GetClusterAdvancedConfigurationExecute(r)
 }
 
 /*
@@ -811,7 +811,7 @@ func (a *ClustersApiService) GetClusterAdvancedConfiguration(ctx context.Context
 // Execute executes the request
 //
 //	@return ClusterDescriptionProcessArgs
-func (a *ClustersApiService) getClusterAdvancedConfigurationExecute(r GetClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error) {
+func (a *ClustersApiService) GetClusterAdvancedConfigurationExecute(r GetClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -916,7 +916,7 @@ func (a *ClustersApiService) GetClusterStatusWithParams(ctx context.Context, arg
 }
 
 func (r GetClusterStatusApiRequest) Execute() (*ClusterStatus, *http.Response, error) {
-	return r.ApiService.getClusterStatusExecute(r)
+	return r.ApiService.GetClusterStatusExecute(r)
 }
 
 /*
@@ -941,7 +941,7 @@ func (a *ClustersApiService) GetClusterStatus(ctx context.Context, groupId strin
 // Execute executes the request
 //
 //	@return ClusterStatus
-func (a *ClustersApiService) getClusterStatusExecute(r GetClusterStatusApiRequest) (*ClusterStatus, *http.Response, error) {
+func (a *ClustersApiService) GetClusterStatusExecute(r GetClusterStatusApiRequest) (*ClusterStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1046,7 +1046,7 @@ func (a *ClustersApiService) GetSampleDatasetLoadStatusWithParams(ctx context.Co
 }
 
 func (r GetSampleDatasetLoadStatusApiRequest) Execute() (*SampleDatasetStatus, *http.Response, error) {
-	return r.ApiService.getSampleDatasetLoadStatusExecute(r)
+	return r.ApiService.GetSampleDatasetLoadStatusExecute(r)
 }
 
 /*
@@ -1071,7 +1071,7 @@ func (a *ClustersApiService) GetSampleDatasetLoadStatus(ctx context.Context, gro
 // Execute executes the request
 //
 //	@return SampleDatasetStatus
-func (a *ClustersApiService) getSampleDatasetLoadStatusExecute(r GetSampleDatasetLoadStatusApiRequest) (*SampleDatasetStatus, *http.Response, error) {
+func (a *ClustersApiService) GetSampleDatasetLoadStatusExecute(r GetSampleDatasetLoadStatusApiRequest) (*SampleDatasetStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1218,7 +1218,7 @@ func (r ListCloudProviderRegionsApiRequest) Tier(tier string) ListCloudProviderR
 }
 
 func (r ListCloudProviderRegionsApiRequest) Execute() (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
-	return r.ApiService.listCloudProviderRegionsExecute(r)
+	return r.ApiService.ListCloudProviderRegionsExecute(r)
 }
 
 /*
@@ -1241,7 +1241,7 @@ func (a *ClustersApiService) ListCloudProviderRegions(ctx context.Context, group
 // Execute executes the request
 //
 //	@return PaginatedApiAtlasProviderRegions
-func (a *ClustersApiService) listCloudProviderRegionsExecute(r ListCloudProviderRegionsApiRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
+func (a *ClustersApiService) ListCloudProviderRegionsExecute(r ListCloudProviderRegionsApiRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1409,7 +1409,7 @@ func (r ListClustersApiRequest) IncludeDeletedWithRetainedBackups(includeDeleted
 }
 
 func (r ListClustersApiRequest) Execute() (*PaginatedAdvancedClusterDescription, *http.Response, error) {
-	return r.ApiService.listClustersExecute(r)
+	return r.ApiService.ListClustersExecute(r)
 }
 
 /*
@@ -1432,7 +1432,7 @@ func (a *ClustersApiService) ListClusters(ctx context.Context, groupId string) L
 // Execute executes the request
 //
 //	@return PaginatedAdvancedClusterDescription
-func (a *ClustersApiService) listClustersExecute(r ListClustersApiRequest) (*PaginatedAdvancedClusterDescription, *http.Response, error) {
+func (a *ClustersApiService) ListClustersExecute(r ListClustersApiRequest) (*PaginatedAdvancedClusterDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1585,7 +1585,7 @@ func (r ListClustersForAllProjectsApiRequest) PageNum(pageNum int) ListClustersF
 }
 
 func (r ListClustersForAllProjectsApiRequest) Execute() (*PaginatedOrgGroup, *http.Response, error) {
-	return r.ApiService.listClustersForAllProjectsExecute(r)
+	return r.ApiService.ListClustersForAllProjectsExecute(r)
 }
 
 /*
@@ -1606,7 +1606,7 @@ func (a *ClustersApiService) ListClustersForAllProjects(ctx context.Context) Lis
 // Execute executes the request
 //
 //	@return PaginatedOrgGroup
-func (a *ClustersApiService) listClustersForAllProjectsExecute(r ListClustersForAllProjectsApiRequest) (*PaginatedOrgGroup, *http.Response, error) {
+func (a *ClustersApiService) ListClustersForAllProjectsExecute(r ListClustersForAllProjectsApiRequest) (*PaginatedOrgGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1730,7 +1730,7 @@ func (a *ClustersApiService) LoadSampleDatasetWithParams(ctx context.Context, ar
 }
 
 func (r LoadSampleDatasetApiRequest) Execute() (*SampleDatasetStatus, *http.Response, error) {
-	return r.ApiService.loadSampleDatasetExecute(r)
+	return r.ApiService.LoadSampleDatasetExecute(r)
 }
 
 /*
@@ -1755,7 +1755,7 @@ func (a *ClustersApiService) LoadSampleDataset(ctx context.Context, groupId stri
 // Execute executes the request
 //
 //	@return SampleDatasetStatus
-func (a *ClustersApiService) loadSampleDatasetExecute(r LoadSampleDatasetApiRequest) (*SampleDatasetStatus, *http.Response, error) {
+func (a *ClustersApiService) LoadSampleDatasetExecute(r LoadSampleDatasetApiRequest) (*SampleDatasetStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -1860,7 +1860,7 @@ func (a *ClustersApiService) TestFailoverWithParams(ctx context.Context, args *T
 }
 
 func (r TestFailoverApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.testFailoverExecute(r)
+	return r.ApiService.TestFailoverExecute(r)
 }
 
 /*
@@ -1883,7 +1883,7 @@ func (a *ClustersApiService) TestFailover(ctx context.Context, groupId string, c
 }
 
 // Execute executes the request
-func (a *ClustersApiService) testFailoverExecute(r TestFailoverApiRequest) (*http.Response, error) {
+func (a *ClustersApiService) TestFailoverExecute(r TestFailoverApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -1981,7 +1981,7 @@ func (a *ClustersApiService) UpdateClusterWithParams(ctx context.Context, args *
 }
 
 func (r UpdateClusterApiRequest) Execute() (*AdvancedClusterDescription, *http.Response, error) {
-	return r.ApiService.updateClusterExecute(r)
+	return r.ApiService.UpdateClusterExecute(r)
 }
 
 /*
@@ -2007,7 +2007,7 @@ func (a *ClustersApiService) UpdateCluster(ctx context.Context, groupId string, 
 // Execute executes the request
 //
 //	@return AdvancedClusterDescription
-func (a *ClustersApiService) updateClusterExecute(r UpdateClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error) {
+func (a *ClustersApiService) UpdateClusterExecute(r UpdateClusterApiRequest) (*AdvancedClusterDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -2120,7 +2120,7 @@ func (a *ClustersApiService) UpdateClusterAdvancedConfigurationWithParams(ctx co
 }
 
 func (r UpdateClusterAdvancedConfigurationApiRequest) Execute() (*ClusterDescriptionProcessArgs, *http.Response, error) {
-	return r.ApiService.updateClusterAdvancedConfigurationExecute(r)
+	return r.ApiService.UpdateClusterAdvancedConfigurationExecute(r)
 }
 
 /*
@@ -2146,7 +2146,7 @@ func (a *ClustersApiService) UpdateClusterAdvancedConfiguration(ctx context.Cont
 // Execute executes the request
 //
 //	@return ClusterDescriptionProcessArgs
-func (a *ClustersApiService) updateClusterAdvancedConfigurationExecute(r UpdateClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error) {
+func (a *ClustersApiService) UpdateClusterAdvancedConfigurationExecute(r UpdateClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -2256,7 +2256,7 @@ func (a *ClustersApiService) UpgradeSharedClusterWithParams(ctx context.Context,
 }
 
 func (r UpgradeSharedClusterApiRequest) Execute() (*LegacyAtlasCluster, *http.Response, error) {
-	return r.ApiService.upgradeSharedClusterExecute(r)
+	return r.ApiService.UpgradeSharedClusterExecute(r)
 }
 
 /*
@@ -2280,7 +2280,7 @@ func (a *ClustersApiService) UpgradeSharedCluster(ctx context.Context, groupId s
 // Execute executes the request
 //
 //	@return LegacyAtlasCluster
-func (a *ClustersApiService) upgradeSharedClusterExecute(r UpgradeSharedClusterApiRequest) (*LegacyAtlasCluster, *http.Response, error) {
+func (a *ClustersApiService) UpgradeSharedClusterExecute(r UpgradeSharedClusterApiRequest) (*LegacyAtlasCluster, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -2389,7 +2389,7 @@ func (a *ClustersApiService) UpgradeSharedClusterToServerlessWithParams(ctx cont
 }
 
 func (r UpgradeSharedClusterToServerlessApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
-	return r.ApiService.upgradeSharedClusterToServerlessExecute(r)
+	return r.ApiService.UpgradeSharedClusterToServerlessExecute(r)
 }
 
 /*
@@ -2413,7 +2413,7 @@ func (a *ClustersApiService) UpgradeSharedClusterToServerless(ctx context.Contex
 // Execute executes the request
 //
 //	@return ServerlessInstanceDescription
-func (a *ClustersApiService) upgradeSharedClusterToServerlessExecute(r UpgradeSharedClusterToServerlessApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
+func (a *ClustersApiService) UpgradeSharedClusterToServerlessExecute(r UpgradeSharedClusterToServerlessApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}

--- a/admin/api_custom_database_roles.go
+++ b/admin/api_custom_database_roles.go
@@ -33,7 +33,7 @@ type CustomDatabaseRolesApi interface {
 	*/
 	CreateCustomDatabaseRoleWithParams(ctx context.Context, args *CreateCustomDatabaseRoleApiParams) CreateCustomDatabaseRoleApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateCustomDatabaseRoleExecute(r CreateCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error)
 
 	/*
@@ -57,7 +57,7 @@ type CustomDatabaseRolesApi interface {
 	*/
 	DeleteCustomDatabaseRoleWithParams(ctx context.Context, args *DeleteCustomDatabaseRoleApiParams) DeleteCustomDatabaseRoleApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteCustomDatabaseRoleExecute(r DeleteCustomDatabaseRoleApiRequest) (*http.Response, error)
 
 	/*
@@ -81,7 +81,7 @@ type CustomDatabaseRolesApi interface {
 	*/
 	GetCustomDatabaseRoleWithParams(ctx context.Context, args *GetCustomDatabaseRoleApiParams) GetCustomDatabaseRoleApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetCustomDatabaseRoleExecute(r GetCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error)
 
 	/*
@@ -104,7 +104,7 @@ type CustomDatabaseRolesApi interface {
 	*/
 	ListCustomDatabaseRolesWithParams(ctx context.Context, args *ListCustomDatabaseRolesApiParams) ListCustomDatabaseRolesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListCustomDatabaseRolesExecute(r ListCustomDatabaseRolesApiRequest) ([]UserCustomDBRole, *http.Response, error)
 
 	/*
@@ -128,7 +128,7 @@ type CustomDatabaseRolesApi interface {
 	*/
 	UpdateCustomDatabaseRoleWithParams(ctx context.Context, args *UpdateCustomDatabaseRoleApiParams) UpdateCustomDatabaseRoleApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateCustomDatabaseRoleExecute(r UpdateCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error)
 }
 

--- a/admin/api_custom_database_roles.go
+++ b/admin/api_custom_database_roles.go
@@ -34,7 +34,7 @@ type CustomDatabaseRolesApi interface {
 	CreateCustomDatabaseRoleWithParams(ctx context.Context, args *CreateCustomDatabaseRoleApiParams) CreateCustomDatabaseRoleApiRequest
 
 	// Interface only available internally
-	createCustomDatabaseRoleExecute(r CreateCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error)
+	CreateCustomDatabaseRoleExecute(r CreateCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error)
 
 	/*
 		DeleteCustomDatabaseRole Remove One Custom Role from One Project
@@ -58,7 +58,7 @@ type CustomDatabaseRolesApi interface {
 	DeleteCustomDatabaseRoleWithParams(ctx context.Context, args *DeleteCustomDatabaseRoleApiParams) DeleteCustomDatabaseRoleApiRequest
 
 	// Interface only available internally
-	deleteCustomDatabaseRoleExecute(r DeleteCustomDatabaseRoleApiRequest) (*http.Response, error)
+	DeleteCustomDatabaseRoleExecute(r DeleteCustomDatabaseRoleApiRequest) (*http.Response, error)
 
 	/*
 		GetCustomDatabaseRole Return One Custom Role in One Project
@@ -82,7 +82,7 @@ type CustomDatabaseRolesApi interface {
 	GetCustomDatabaseRoleWithParams(ctx context.Context, args *GetCustomDatabaseRoleApiParams) GetCustomDatabaseRoleApiRequest
 
 	// Interface only available internally
-	getCustomDatabaseRoleExecute(r GetCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error)
+	GetCustomDatabaseRoleExecute(r GetCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error)
 
 	/*
 		ListCustomDatabaseRoles Return All Custom Roles in One Project
@@ -105,7 +105,7 @@ type CustomDatabaseRolesApi interface {
 	ListCustomDatabaseRolesWithParams(ctx context.Context, args *ListCustomDatabaseRolesApiParams) ListCustomDatabaseRolesApiRequest
 
 	// Interface only available internally
-	listCustomDatabaseRolesExecute(r ListCustomDatabaseRolesApiRequest) ([]UserCustomDBRole, *http.Response, error)
+	ListCustomDatabaseRolesExecute(r ListCustomDatabaseRolesApiRequest) ([]UserCustomDBRole, *http.Response, error)
 
 	/*
 		UpdateCustomDatabaseRole Update One Custom Role in One Project
@@ -129,7 +129,7 @@ type CustomDatabaseRolesApi interface {
 	UpdateCustomDatabaseRoleWithParams(ctx context.Context, args *UpdateCustomDatabaseRoleApiParams) UpdateCustomDatabaseRoleApiRequest
 
 	// Interface only available internally
-	updateCustomDatabaseRoleExecute(r UpdateCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error)
+	UpdateCustomDatabaseRoleExecute(r UpdateCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error)
 }
 
 // CustomDatabaseRolesApiService CustomDatabaseRolesApi service
@@ -157,7 +157,7 @@ func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRoleWithParams(ctx c
 }
 
 func (r CreateCustomDatabaseRoleApiRequest) Execute() (*UserCustomDBRole, *http.Response, error) {
-	return r.ApiService.createCustomDatabaseRoleExecute(r)
+	return r.ApiService.CreateCustomDatabaseRoleExecute(r)
 }
 
 /*
@@ -181,7 +181,7 @@ func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRole(ctx context.Con
 // Execute executes the request
 //
 //	@return UserCustomDBRole
-func (a *CustomDatabaseRolesApiService) createCustomDatabaseRoleExecute(r CreateCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error) {
+func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRoleExecute(r CreateCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -290,7 +290,7 @@ func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRoleWithParams(ctx c
 }
 
 func (r DeleteCustomDatabaseRoleApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.deleteCustomDatabaseRoleExecute(r)
+	return r.ApiService.DeleteCustomDatabaseRoleExecute(r)
 }
 
 /*
@@ -313,7 +313,7 @@ func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRole(ctx context.Con
 }
 
 // Execute executes the request
-func (a *CustomDatabaseRolesApiService) deleteCustomDatabaseRoleExecute(r DeleteCustomDatabaseRoleApiRequest) (*http.Response, error) {
+func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRoleExecute(r DeleteCustomDatabaseRoleApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -408,7 +408,7 @@ func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRoleWithParams(ctx cont
 }
 
 func (r GetCustomDatabaseRoleApiRequest) Execute() (*UserCustomDBRole, *http.Response, error) {
-	return r.ApiService.getCustomDatabaseRoleExecute(r)
+	return r.ApiService.GetCustomDatabaseRoleExecute(r)
 }
 
 /*
@@ -433,7 +433,7 @@ func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRole(ctx context.Contex
 // Execute executes the request
 //
 //	@return UserCustomDBRole
-func (a *CustomDatabaseRolesApiService) getCustomDatabaseRoleExecute(r GetCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error) {
+func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRoleExecute(r GetCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -535,7 +535,7 @@ func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRolesWithParams(ctx co
 }
 
 func (r ListCustomDatabaseRolesApiRequest) Execute() ([]UserCustomDBRole, *http.Response, error) {
-	return r.ApiService.listCustomDatabaseRolesExecute(r)
+	return r.ApiService.ListCustomDatabaseRolesExecute(r)
 }
 
 /*
@@ -558,7 +558,7 @@ func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRoles(ctx context.Cont
 // Execute executes the request
 //
 //	@return []UserCustomDBRole
-func (a *CustomDatabaseRolesApiService) listCustomDatabaseRolesExecute(r ListCustomDatabaseRolesApiRequest) ([]UserCustomDBRole, *http.Response, error) {
+func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRolesExecute(r ListCustomDatabaseRolesApiRequest) ([]UserCustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -665,7 +665,7 @@ func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRoleWithParams(ctx c
 }
 
 func (r UpdateCustomDatabaseRoleApiRequest) Execute() (*UserCustomDBRole, *http.Response, error) {
-	return r.ApiService.updateCustomDatabaseRoleExecute(r)
+	return r.ApiService.UpdateCustomDatabaseRoleExecute(r)
 }
 
 /*
@@ -691,7 +691,7 @@ func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRole(ctx context.Con
 // Execute executes the request
 //
 //	@return UserCustomDBRole
-func (a *CustomDatabaseRolesApiService) updateCustomDatabaseRoleExecute(r UpdateCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error) {
+func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRoleExecute(r UpdateCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_data_federation.go
+++ b/admin/api_data_federation.go
@@ -51,7 +51,7 @@ type DataFederationApi interface {
 	*/
 	CreateDataFederationPrivateEndpointWithParams(ctx context.Context, args *CreateDataFederationPrivateEndpointApiParams) CreateDataFederationPrivateEndpointApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateDataFederationPrivateEndpointExecute(r CreateDataFederationPrivateEndpointApiRequest) (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error)
 
 	/*
@@ -74,7 +74,7 @@ type DataFederationApi interface {
 	*/
 	CreateFederatedDatabaseWithParams(ctx context.Context, args *CreateFederatedDatabaseApiParams) CreateFederatedDatabaseApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateFederatedDatabaseExecute(r CreateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
 
 	/*
@@ -99,7 +99,7 @@ type DataFederationApi interface {
 	*/
 	CreateOneDataFederationQueryLimitWithParams(ctx context.Context, args *CreateOneDataFederationQueryLimitApiParams) CreateOneDataFederationQueryLimitApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateOneDataFederationQueryLimitExecute(r CreateOneDataFederationQueryLimitApiRequest) (*DataFederationTenantQueryLimit, *http.Response, error)
 
 	/*
@@ -123,7 +123,7 @@ type DataFederationApi interface {
 	*/
 	DeleteDataFederationPrivateEndpointWithParams(ctx context.Context, args *DeleteDataFederationPrivateEndpointApiParams) DeleteDataFederationPrivateEndpointApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -147,7 +147,7 @@ type DataFederationApi interface {
 	*/
 	DeleteFederatedDatabaseWithParams(ctx context.Context, args *DeleteFederatedDatabaseApiParams) DeleteFederatedDatabaseApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -172,7 +172,7 @@ type DataFederationApi interface {
 	*/
 	DeleteOneDataFederationInstanceQueryLimitWithParams(ctx context.Context, args *DeleteOneDataFederationInstanceQueryLimitApiParams) DeleteOneDataFederationInstanceQueryLimitApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -196,7 +196,7 @@ type DataFederationApi interface {
 	*/
 	DownloadFederatedDatabaseQueryLogsWithParams(ctx context.Context, args *DownloadFederatedDatabaseQueryLogsApiParams) DownloadFederatedDatabaseQueryLogsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DownloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (io.ReadCloser, *http.Response, error)
 
 	/*
@@ -220,7 +220,7 @@ type DataFederationApi interface {
 	*/
 	GetDataFederationPrivateEndpointWithParams(ctx context.Context, args *GetDataFederationPrivateEndpointApiParams) GetDataFederationPrivateEndpointApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetDataFederationPrivateEndpointExecute(r GetDataFederationPrivateEndpointApiRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error)
 
 	/*
@@ -244,7 +244,7 @@ type DataFederationApi interface {
 	*/
 	GetFederatedDatabaseWithParams(ctx context.Context, args *GetFederatedDatabaseApiParams) GetFederatedDatabaseApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetFederatedDatabaseExecute(r GetFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
 
 	/*
@@ -267,7 +267,7 @@ type DataFederationApi interface {
 	*/
 	ListDataFederationPrivateEndpointsWithParams(ctx context.Context, args *ListDataFederationPrivateEndpointsApiParams) ListDataFederationPrivateEndpointsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListDataFederationPrivateEndpointsExecute(r ListDataFederationPrivateEndpointsApiRequest) (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error)
 
 	/*
@@ -290,7 +290,7 @@ type DataFederationApi interface {
 	*/
 	ListFederatedDatabasesWithParams(ctx context.Context, args *ListFederatedDatabasesApiParams) ListFederatedDatabasesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListFederatedDatabasesExecute(r ListFederatedDatabasesApiRequest) ([]DataLakeTenant, *http.Response, error)
 
 	/*
@@ -315,7 +315,7 @@ type DataFederationApi interface {
 	*/
 	ReturnFederatedDatabaseQueryLimitWithParams(ctx context.Context, args *ReturnFederatedDatabaseQueryLimitApiParams) ReturnFederatedDatabaseQueryLimitApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ReturnFederatedDatabaseQueryLimitExecute(r ReturnFederatedDatabaseQueryLimitApiRequest) (*DataFederationTenantQueryLimit, *http.Response, error)
 
 	/*
@@ -339,7 +339,7 @@ type DataFederationApi interface {
 	*/
 	ReturnFederatedDatabaseQueryLimitsWithParams(ctx context.Context, args *ReturnFederatedDatabaseQueryLimitsApiParams) ReturnFederatedDatabaseQueryLimitsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ReturnFederatedDatabaseQueryLimitsExecute(r ReturnFederatedDatabaseQueryLimitsApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
 
 	/*
@@ -363,7 +363,7 @@ type DataFederationApi interface {
 	*/
 	UpdateFederatedDatabaseWithParams(ctx context.Context, args *UpdateFederatedDatabaseApiParams) UpdateFederatedDatabaseApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateFederatedDatabaseExecute(r UpdateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
 }
 

--- a/admin/api_data_federation.go
+++ b/admin/api_data_federation.go
@@ -52,7 +52,7 @@ type DataFederationApi interface {
 	CreateDataFederationPrivateEndpointWithParams(ctx context.Context, args *CreateDataFederationPrivateEndpointApiParams) CreateDataFederationPrivateEndpointApiRequest
 
 	// Interface only available internally
-	createDataFederationPrivateEndpointExecute(r CreateDataFederationPrivateEndpointApiRequest) (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error)
+	CreateDataFederationPrivateEndpointExecute(r CreateDataFederationPrivateEndpointApiRequest) (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error)
 
 	/*
 		CreateFederatedDatabase Create One Federated Database Instance in One Project
@@ -75,7 +75,7 @@ type DataFederationApi interface {
 	CreateFederatedDatabaseWithParams(ctx context.Context, args *CreateFederatedDatabaseApiParams) CreateFederatedDatabaseApiRequest
 
 	// Interface only available internally
-	createFederatedDatabaseExecute(r CreateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
+	CreateFederatedDatabaseExecute(r CreateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
 
 	/*
 		CreateOneDataFederationQueryLimit Configure One Query Limit for One Federated Database Instance
@@ -100,7 +100,7 @@ type DataFederationApi interface {
 	CreateOneDataFederationQueryLimitWithParams(ctx context.Context, args *CreateOneDataFederationQueryLimitApiParams) CreateOneDataFederationQueryLimitApiRequest
 
 	// Interface only available internally
-	createOneDataFederationQueryLimitExecute(r CreateOneDataFederationQueryLimitApiRequest) (*DataFederationTenantQueryLimit, *http.Response, error)
+	CreateOneDataFederationQueryLimitExecute(r CreateOneDataFederationQueryLimitApiRequest) (*DataFederationTenantQueryLimit, *http.Response, error)
 
 	/*
 		DeleteDataFederationPrivateEndpoint Remove One Federated Database Instance and Online Archive Private Endpoint from One Project
@@ -124,7 +124,7 @@ type DataFederationApi interface {
 	DeleteDataFederationPrivateEndpointWithParams(ctx context.Context, args *DeleteDataFederationPrivateEndpointApiParams) DeleteDataFederationPrivateEndpointApiRequest
 
 	// Interface only available internally
-	deleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DeleteFederatedDatabase Remove One Federated Database Instance from One Project
@@ -148,7 +148,7 @@ type DataFederationApi interface {
 	DeleteFederatedDatabaseWithParams(ctx context.Context, args *DeleteFederatedDatabaseApiParams) DeleteFederatedDatabaseApiRequest
 
 	// Interface only available internally
-	deleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DeleteOneDataFederationInstanceQueryLimit Delete One Query Limit For One Federated Database Instance
@@ -173,7 +173,7 @@ type DataFederationApi interface {
 	DeleteOneDataFederationInstanceQueryLimitWithParams(ctx context.Context, args *DeleteOneDataFederationInstanceQueryLimitApiParams) DeleteOneDataFederationInstanceQueryLimitApiRequest
 
 	// Interface only available internally
-	deleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DownloadFederatedDatabaseQueryLogs Download Query Logs for One Federated Database Instance
@@ -197,7 +197,7 @@ type DataFederationApi interface {
 	DownloadFederatedDatabaseQueryLogsWithParams(ctx context.Context, args *DownloadFederatedDatabaseQueryLogsApiParams) DownloadFederatedDatabaseQueryLogsApiRequest
 
 	// Interface only available internally
-	downloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (io.ReadCloser, *http.Response, error)
+	DownloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (io.ReadCloser, *http.Response, error)
 
 	/*
 		GetDataFederationPrivateEndpoint Return One Federated Database Instance and Online Archive Private Endpoint in One Project
@@ -221,7 +221,7 @@ type DataFederationApi interface {
 	GetDataFederationPrivateEndpointWithParams(ctx context.Context, args *GetDataFederationPrivateEndpointApiParams) GetDataFederationPrivateEndpointApiRequest
 
 	// Interface only available internally
-	getDataFederationPrivateEndpointExecute(r GetDataFederationPrivateEndpointApiRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error)
+	GetDataFederationPrivateEndpointExecute(r GetDataFederationPrivateEndpointApiRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error)
 
 	/*
 		GetFederatedDatabase Return One Federated Database Instance in One Project
@@ -245,7 +245,7 @@ type DataFederationApi interface {
 	GetFederatedDatabaseWithParams(ctx context.Context, args *GetFederatedDatabaseApiParams) GetFederatedDatabaseApiRequest
 
 	// Interface only available internally
-	getFederatedDatabaseExecute(r GetFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
+	GetFederatedDatabaseExecute(r GetFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
 
 	/*
 		ListDataFederationPrivateEndpoints Return All Federated Database Instance and Online Archive Private Endpoints in One Project
@@ -268,7 +268,7 @@ type DataFederationApi interface {
 	ListDataFederationPrivateEndpointsWithParams(ctx context.Context, args *ListDataFederationPrivateEndpointsApiParams) ListDataFederationPrivateEndpointsApiRequest
 
 	// Interface only available internally
-	listDataFederationPrivateEndpointsExecute(r ListDataFederationPrivateEndpointsApiRequest) (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error)
+	ListDataFederationPrivateEndpointsExecute(r ListDataFederationPrivateEndpointsApiRequest) (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error)
 
 	/*
 		ListFederatedDatabases Return All Federated Database Instances in One Project
@@ -291,7 +291,7 @@ type DataFederationApi interface {
 	ListFederatedDatabasesWithParams(ctx context.Context, args *ListFederatedDatabasesApiParams) ListFederatedDatabasesApiRequest
 
 	// Interface only available internally
-	listFederatedDatabasesExecute(r ListFederatedDatabasesApiRequest) ([]DataLakeTenant, *http.Response, error)
+	ListFederatedDatabasesExecute(r ListFederatedDatabasesApiRequest) ([]DataLakeTenant, *http.Response, error)
 
 	/*
 		ReturnFederatedDatabaseQueryLimit Return One Federated Database Instance Query Limit for One Project
@@ -316,7 +316,7 @@ type DataFederationApi interface {
 	ReturnFederatedDatabaseQueryLimitWithParams(ctx context.Context, args *ReturnFederatedDatabaseQueryLimitApiParams) ReturnFederatedDatabaseQueryLimitApiRequest
 
 	// Interface only available internally
-	returnFederatedDatabaseQueryLimitExecute(r ReturnFederatedDatabaseQueryLimitApiRequest) (*DataFederationTenantQueryLimit, *http.Response, error)
+	ReturnFederatedDatabaseQueryLimitExecute(r ReturnFederatedDatabaseQueryLimitApiRequest) (*DataFederationTenantQueryLimit, *http.Response, error)
 
 	/*
 		ReturnFederatedDatabaseQueryLimits Return All Query Limits for One Federated Database Instance
@@ -340,7 +340,7 @@ type DataFederationApi interface {
 	ReturnFederatedDatabaseQueryLimitsWithParams(ctx context.Context, args *ReturnFederatedDatabaseQueryLimitsApiParams) ReturnFederatedDatabaseQueryLimitsApiRequest
 
 	// Interface only available internally
-	returnFederatedDatabaseQueryLimitsExecute(r ReturnFederatedDatabaseQueryLimitsApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
+	ReturnFederatedDatabaseQueryLimitsExecute(r ReturnFederatedDatabaseQueryLimitsApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
 
 	/*
 		UpdateFederatedDatabase Update One Federated Database Instance in One Project
@@ -364,7 +364,7 @@ type DataFederationApi interface {
 	UpdateFederatedDatabaseWithParams(ctx context.Context, args *UpdateFederatedDatabaseApiParams) UpdateFederatedDatabaseApiRequest
 
 	// Interface only available internally
-	updateFederatedDatabaseExecute(r UpdateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
+	UpdateFederatedDatabaseExecute(r UpdateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
 }
 
 // DataFederationApiService DataFederationApi service
@@ -392,7 +392,7 @@ func (a *DataFederationApiService) CreateDataFederationPrivateEndpointWithParams
 }
 
 func (r CreateDataFederationPrivateEndpointApiRequest) Execute() (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error) {
-	return r.ApiService.createDataFederationPrivateEndpointExecute(r)
+	return r.ApiService.CreateDataFederationPrivateEndpointExecute(r)
 }
 
 /*
@@ -434,7 +434,7 @@ func (a *DataFederationApiService) CreateDataFederationPrivateEndpoint(ctx conte
 // Execute executes the request
 //
 //	@return PaginatedPrivateNetworkEndpointIdEntry
-func (a *DataFederationApiService) createDataFederationPrivateEndpointExecute(r CreateDataFederationPrivateEndpointApiRequest) (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error) {
+func (a *DataFederationApiService) CreateDataFederationPrivateEndpointExecute(r CreateDataFederationPrivateEndpointApiRequest) (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -552,7 +552,7 @@ func (r CreateFederatedDatabaseApiRequest) SkipRoleValidation(skipRoleValidation
 }
 
 func (r CreateFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Response, error) {
-	return r.ApiService.createFederatedDatabaseExecute(r)
+	return r.ApiService.CreateFederatedDatabaseExecute(r)
 }
 
 /*
@@ -576,7 +576,7 @@ func (a *DataFederationApiService) CreateFederatedDatabase(ctx context.Context, 
 // Execute executes the request
 //
 //	@return DataLakeTenant
-func (a *DataFederationApiService) createFederatedDatabaseExecute(r CreateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
+func (a *DataFederationApiService) CreateFederatedDatabaseExecute(r CreateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -698,7 +698,7 @@ func (a *DataFederationApiService) CreateOneDataFederationQueryLimitWithParams(c
 }
 
 func (r CreateOneDataFederationQueryLimitApiRequest) Execute() (*DataFederationTenantQueryLimit, *http.Response, error) {
-	return r.ApiService.createOneDataFederationQueryLimitExecute(r)
+	return r.ApiService.CreateOneDataFederationQueryLimitExecute(r)
 }
 
 /*
@@ -726,7 +726,7 @@ func (a *DataFederationApiService) CreateOneDataFederationQueryLimit(ctx context
 // Execute executes the request
 //
 //	@return DataFederationTenantQueryLimit
-func (a *DataFederationApiService) createOneDataFederationQueryLimitExecute(r CreateOneDataFederationQueryLimitApiRequest) (*DataFederationTenantQueryLimit, *http.Response, error) {
+func (a *DataFederationApiService) CreateOneDataFederationQueryLimitExecute(r CreateOneDataFederationQueryLimitApiRequest) (*DataFederationTenantQueryLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -837,7 +837,7 @@ func (a *DataFederationApiService) DeleteDataFederationPrivateEndpointWithParams
 }
 
 func (r DeleteDataFederationPrivateEndpointApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteDataFederationPrivateEndpointExecute(r)
+	return r.ApiService.DeleteDataFederationPrivateEndpointExecute(r)
 }
 
 /*
@@ -862,7 +862,7 @@ func (a *DataFederationApiService) DeleteDataFederationPrivateEndpoint(ctx conte
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *DataFederationApiService) deleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *DataFederationApiService) DeleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -967,7 +967,7 @@ func (a *DataFederationApiService) DeleteFederatedDatabaseWithParams(ctx context
 }
 
 func (r DeleteFederatedDatabaseApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteFederatedDatabaseExecute(r)
+	return r.ApiService.DeleteFederatedDatabaseExecute(r)
 }
 
 /*
@@ -992,7 +992,7 @@ func (a *DataFederationApiService) DeleteFederatedDatabase(ctx context.Context, 
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *DataFederationApiService) deleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *DataFederationApiService) DeleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -1100,7 +1100,7 @@ func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimitWith
 }
 
 func (r DeleteOneDataFederationInstanceQueryLimitApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteOneDataFederationInstanceQueryLimitExecute(r)
+	return r.ApiService.DeleteOneDataFederationInstanceQueryLimitExecute(r)
 }
 
 /*
@@ -1127,7 +1127,7 @@ func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimit(ctx
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *DataFederationApiService) deleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -1251,7 +1251,7 @@ func (r DownloadFederatedDatabaseQueryLogsApiRequest) StartDate(startDate int64)
 }
 
 func (r DownloadFederatedDatabaseQueryLogsApiRequest) Execute() (io.ReadCloser, *http.Response, error) {
-	return r.ApiService.downloadFederatedDatabaseQueryLogsExecute(r)
+	return r.ApiService.DownloadFederatedDatabaseQueryLogsExecute(r)
 }
 
 /*
@@ -1276,7 +1276,7 @@ func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogs(ctx contex
 // Execute executes the request
 //
 //	@return io.ReadCloser
-func (a *DataFederationApiService) downloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (io.ReadCloser, *http.Response, error) {
+func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (io.ReadCloser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1387,7 +1387,7 @@ func (a *DataFederationApiService) GetDataFederationPrivateEndpointWithParams(ct
 }
 
 func (r GetDataFederationPrivateEndpointApiRequest) Execute() (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
-	return r.ApiService.getDataFederationPrivateEndpointExecute(r)
+	return r.ApiService.GetDataFederationPrivateEndpointExecute(r)
 }
 
 /*
@@ -1412,7 +1412,7 @@ func (a *DataFederationApiService) GetDataFederationPrivateEndpoint(ctx context.
 // Execute executes the request
 //
 //	@return PrivateNetworkEndpointIdEntry
-func (a *DataFederationApiService) getDataFederationPrivateEndpointExecute(r GetDataFederationPrivateEndpointApiRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
+func (a *DataFederationApiService) GetDataFederationPrivateEndpointExecute(r GetDataFederationPrivateEndpointApiRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1517,7 +1517,7 @@ func (a *DataFederationApiService) GetFederatedDatabaseWithParams(ctx context.Co
 }
 
 func (r GetFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Response, error) {
-	return r.ApiService.getFederatedDatabaseExecute(r)
+	return r.ApiService.GetFederatedDatabaseExecute(r)
 }
 
 /*
@@ -1542,7 +1542,7 @@ func (a *DataFederationApiService) GetFederatedDatabase(ctx context.Context, gro
 // Execute executes the request
 //
 //	@return DataLakeTenant
-func (a *DataFederationApiService) getFederatedDatabaseExecute(r GetFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
+func (a *DataFederationApiService) GetFederatedDatabaseExecute(r GetFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1671,7 +1671,7 @@ func (r ListDataFederationPrivateEndpointsApiRequest) PageNum(pageNum int) ListD
 }
 
 func (r ListDataFederationPrivateEndpointsApiRequest) Execute() (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error) {
-	return r.ApiService.listDataFederationPrivateEndpointsExecute(r)
+	return r.ApiService.ListDataFederationPrivateEndpointsExecute(r)
 }
 
 /*
@@ -1694,7 +1694,7 @@ func (a *DataFederationApiService) ListDataFederationPrivateEndpoints(ctx contex
 // Execute executes the request
 //
 //	@return PaginatedPrivateNetworkEndpointIdEntry
-func (a *DataFederationApiService) listDataFederationPrivateEndpointsExecute(r ListDataFederationPrivateEndpointsApiRequest) (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error) {
+func (a *DataFederationApiService) ListDataFederationPrivateEndpointsExecute(r ListDataFederationPrivateEndpointsApiRequest) (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1825,7 +1825,7 @@ func (r ListFederatedDatabasesApiRequest) Type_(type_ string) ListFederatedDatab
 }
 
 func (r ListFederatedDatabasesApiRequest) Execute() ([]DataLakeTenant, *http.Response, error) {
-	return r.ApiService.listFederatedDatabasesExecute(r)
+	return r.ApiService.ListFederatedDatabasesExecute(r)
 }
 
 /*
@@ -1848,7 +1848,7 @@ func (a *DataFederationApiService) ListFederatedDatabases(ctx context.Context, g
 // Execute executes the request
 //
 //	@return []DataLakeTenant
-func (a *DataFederationApiService) listFederatedDatabasesExecute(r ListFederatedDatabasesApiRequest) ([]DataLakeTenant, *http.Response, error) {
+func (a *DataFederationApiService) ListFederatedDatabasesExecute(r ListFederatedDatabasesApiRequest) ([]DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1962,7 +1962,7 @@ func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitWithParams(c
 }
 
 func (r ReturnFederatedDatabaseQueryLimitApiRequest) Execute() (*DataFederationTenantQueryLimit, *http.Response, error) {
-	return r.ApiService.returnFederatedDatabaseQueryLimitExecute(r)
+	return r.ApiService.ReturnFederatedDatabaseQueryLimitExecute(r)
 }
 
 /*
@@ -1989,7 +1989,7 @@ func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimit(ctx context
 // Execute executes the request
 //
 //	@return DataFederationTenantQueryLimit
-func (a *DataFederationApiService) returnFederatedDatabaseQueryLimitExecute(r ReturnFederatedDatabaseQueryLimitApiRequest) (*DataFederationTenantQueryLimit, *http.Response, error) {
+func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitExecute(r ReturnFederatedDatabaseQueryLimitApiRequest) (*DataFederationTenantQueryLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2095,7 +2095,7 @@ func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitsWithParams(
 }
 
 func (r ReturnFederatedDatabaseQueryLimitsApiRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
-	return r.ApiService.returnFederatedDatabaseQueryLimitsExecute(r)
+	return r.ApiService.ReturnFederatedDatabaseQueryLimitsExecute(r)
 }
 
 /*
@@ -2120,7 +2120,7 @@ func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimits(ctx contex
 // Execute executes the request
 //
 //	@return []DataFederationTenantQueryLimit
-func (a *DataFederationApiService) returnFederatedDatabaseQueryLimitsExecute(r ReturnFederatedDatabaseQueryLimitsApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
+func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitsExecute(r ReturnFederatedDatabaseQueryLimitsApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2237,7 +2237,7 @@ func (r UpdateFederatedDatabaseApiRequest) SkipRoleValidation(skipRoleValidation
 }
 
 func (r UpdateFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Response, error) {
-	return r.ApiService.updateFederatedDatabaseExecute(r)
+	return r.ApiService.UpdateFederatedDatabaseExecute(r)
 }
 
 /*
@@ -2263,7 +2263,7 @@ func (a *DataFederationApiService) UpdateFederatedDatabase(ctx context.Context, 
 // Execute executes the request
 //
 //	@return DataLakeTenant
-func (a *DataFederationApiService) updateFederatedDatabaseExecute(r UpdateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
+func (a *DataFederationApiService) UpdateFederatedDatabaseExecute(r UpdateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_data_lake_pipelines.go
+++ b/admin/api_data_lake_pipelines.go
@@ -34,7 +34,7 @@ type DataLakePipelinesApi interface {
 	*/
 	CreatePipelineWithParams(ctx context.Context, args *CreatePipelineApiParams) CreatePipelineApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreatePipelineExecute(r CreatePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
 
 	/*
@@ -58,7 +58,7 @@ type DataLakePipelinesApi interface {
 	*/
 	DeletePipelineWithParams(ctx context.Context, args *DeletePipelineApiParams) DeletePipelineApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeletePipelineExecute(r DeletePipelineApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -83,7 +83,7 @@ type DataLakePipelinesApi interface {
 	*/
 	DeletePipelineRunDatasetWithParams(ctx context.Context, args *DeletePipelineRunDatasetApiParams) DeletePipelineRunDatasetApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -107,7 +107,7 @@ type DataLakePipelinesApi interface {
 	*/
 	GetPipelineWithParams(ctx context.Context, args *GetPipelineApiParams) GetPipelineApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetPipelineExecute(r GetPipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
 
 	/*
@@ -132,7 +132,7 @@ type DataLakePipelinesApi interface {
 	*/
 	GetPipelineRunWithParams(ctx context.Context, args *GetPipelineRunApiParams) GetPipelineRunApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetPipelineRunExecute(r GetPipelineRunApiRequest) (*IngestionPipelineRun, *http.Response, error)
 
 	/*
@@ -156,7 +156,7 @@ type DataLakePipelinesApi interface {
 	*/
 	ListPipelineRunsWithParams(ctx context.Context, args *ListPipelineRunsApiParams) ListPipelineRunsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListPipelineRunsExecute(r ListPipelineRunsApiRequest) (*PaginatedPipelineRun, *http.Response, error)
 
 	/*
@@ -180,7 +180,7 @@ type DataLakePipelinesApi interface {
 	*/
 	ListPipelineSchedulesWithParams(ctx context.Context, args *ListPipelineSchedulesApiParams) ListPipelineSchedulesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListPipelineSchedulesExecute(r ListPipelineSchedulesApiRequest) ([]DiskBackupApiPolicyItem, *http.Response, error)
 
 	/*
@@ -204,7 +204,7 @@ type DataLakePipelinesApi interface {
 	*/
 	ListPipelineSnapshotsWithParams(ctx context.Context, args *ListPipelineSnapshotsApiParams) ListPipelineSnapshotsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListPipelineSnapshotsExecute(r ListPipelineSnapshotsApiRequest) (*PaginatedBackupSnapshot, *http.Response, error)
 
 	/*
@@ -227,7 +227,7 @@ type DataLakePipelinesApi interface {
 	*/
 	ListPipelinesWithParams(ctx context.Context, args *ListPipelinesApiParams) ListPipelinesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListPipelinesExecute(r ListPipelinesApiRequest) ([]DataLakeIngestionPipeline, *http.Response, error)
 
 	/*
@@ -251,7 +251,7 @@ type DataLakePipelinesApi interface {
 	*/
 	PausePipelineWithParams(ctx context.Context, args *PausePipelineApiParams) PausePipelineApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	PausePipelineExecute(r PausePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
 
 	/*
@@ -275,7 +275,7 @@ type DataLakePipelinesApi interface {
 	*/
 	ResumePipelineWithParams(ctx context.Context, args *ResumePipelineApiParams) ResumePipelineApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ResumePipelineExecute(r ResumePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
 
 	/*
@@ -299,7 +299,7 @@ type DataLakePipelinesApi interface {
 	*/
 	TriggerSnapshotIngestionWithParams(ctx context.Context, args *TriggerSnapshotIngestionApiParams) TriggerSnapshotIngestionApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	TriggerSnapshotIngestionExecute(r TriggerSnapshotIngestionApiRequest) (*IngestionPipelineRun, *http.Response, error)
 
 	/*
@@ -323,7 +323,7 @@ type DataLakePipelinesApi interface {
 	*/
 	UpdatePipelineWithParams(ctx context.Context, args *UpdatePipelineApiParams) UpdatePipelineApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdatePipelineExecute(r UpdatePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
 }
 

--- a/admin/api_data_lake_pipelines.go
+++ b/admin/api_data_lake_pipelines.go
@@ -35,7 +35,7 @@ type DataLakePipelinesApi interface {
 	CreatePipelineWithParams(ctx context.Context, args *CreatePipelineApiParams) CreatePipelineApiRequest
 
 	// Interface only available internally
-	createPipelineExecute(r CreatePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
+	CreatePipelineExecute(r CreatePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
 
 	/*
 		DeletePipeline Remove One Data Lake Pipeline
@@ -59,7 +59,7 @@ type DataLakePipelinesApi interface {
 	DeletePipelineWithParams(ctx context.Context, args *DeletePipelineApiParams) DeletePipelineApiRequest
 
 	// Interface only available internally
-	deletePipelineExecute(r DeletePipelineApiRequest) (map[string]interface{}, *http.Response, error)
+	DeletePipelineExecute(r DeletePipelineApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DeletePipelineRunDataset Delete Pipeline Run Dataset
@@ -84,7 +84,7 @@ type DataLakePipelinesApi interface {
 	DeletePipelineRunDatasetWithParams(ctx context.Context, args *DeletePipelineRunDatasetApiParams) DeletePipelineRunDatasetApiRequest
 
 	// Interface only available internally
-	deletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (map[string]interface{}, *http.Response, error)
+	DeletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetPipeline Return One Data Lake Pipeline
@@ -108,7 +108,7 @@ type DataLakePipelinesApi interface {
 	GetPipelineWithParams(ctx context.Context, args *GetPipelineApiParams) GetPipelineApiRequest
 
 	// Interface only available internally
-	getPipelineExecute(r GetPipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
+	GetPipelineExecute(r GetPipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
 
 	/*
 		GetPipelineRun Return One Data Lake Pipeline Run
@@ -133,7 +133,7 @@ type DataLakePipelinesApi interface {
 	GetPipelineRunWithParams(ctx context.Context, args *GetPipelineRunApiParams) GetPipelineRunApiRequest
 
 	// Interface only available internally
-	getPipelineRunExecute(r GetPipelineRunApiRequest) (*IngestionPipelineRun, *http.Response, error)
+	GetPipelineRunExecute(r GetPipelineRunApiRequest) (*IngestionPipelineRun, *http.Response, error)
 
 	/*
 		ListPipelineRuns Return All Data Lake Pipeline Runs from One Project
@@ -157,7 +157,7 @@ type DataLakePipelinesApi interface {
 	ListPipelineRunsWithParams(ctx context.Context, args *ListPipelineRunsApiParams) ListPipelineRunsApiRequest
 
 	// Interface only available internally
-	listPipelineRunsExecute(r ListPipelineRunsApiRequest) (*PaginatedPipelineRun, *http.Response, error)
+	ListPipelineRunsExecute(r ListPipelineRunsApiRequest) (*PaginatedPipelineRun, *http.Response, error)
 
 	/*
 		ListPipelineSchedules Return Available Ingestion Schedules for One Data Lake Pipeline
@@ -181,7 +181,7 @@ type DataLakePipelinesApi interface {
 	ListPipelineSchedulesWithParams(ctx context.Context, args *ListPipelineSchedulesApiParams) ListPipelineSchedulesApiRequest
 
 	// Interface only available internally
-	listPipelineSchedulesExecute(r ListPipelineSchedulesApiRequest) ([]DiskBackupApiPolicyItem, *http.Response, error)
+	ListPipelineSchedulesExecute(r ListPipelineSchedulesApiRequest) ([]DiskBackupApiPolicyItem, *http.Response, error)
 
 	/*
 		ListPipelineSnapshots Return Available Backup Snapshots for One Data Lake Pipeline
@@ -205,7 +205,7 @@ type DataLakePipelinesApi interface {
 	ListPipelineSnapshotsWithParams(ctx context.Context, args *ListPipelineSnapshotsApiParams) ListPipelineSnapshotsApiRequest
 
 	// Interface only available internally
-	listPipelineSnapshotsExecute(r ListPipelineSnapshotsApiRequest) (*PaginatedBackupSnapshot, *http.Response, error)
+	ListPipelineSnapshotsExecute(r ListPipelineSnapshotsApiRequest) (*PaginatedBackupSnapshot, *http.Response, error)
 
 	/*
 		ListPipelines Return All Data Lake Pipelines from One Project
@@ -228,7 +228,7 @@ type DataLakePipelinesApi interface {
 	ListPipelinesWithParams(ctx context.Context, args *ListPipelinesApiParams) ListPipelinesApiRequest
 
 	// Interface only available internally
-	listPipelinesExecute(r ListPipelinesApiRequest) ([]DataLakeIngestionPipeline, *http.Response, error)
+	ListPipelinesExecute(r ListPipelinesApiRequest) ([]DataLakeIngestionPipeline, *http.Response, error)
 
 	/*
 		PausePipeline Pause One Data Lake Pipeline
@@ -252,7 +252,7 @@ type DataLakePipelinesApi interface {
 	PausePipelineWithParams(ctx context.Context, args *PausePipelineApiParams) PausePipelineApiRequest
 
 	// Interface only available internally
-	pausePipelineExecute(r PausePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
+	PausePipelineExecute(r PausePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
 
 	/*
 		ResumePipeline Resume One Data Lake Pipeline
@@ -276,7 +276,7 @@ type DataLakePipelinesApi interface {
 	ResumePipelineWithParams(ctx context.Context, args *ResumePipelineApiParams) ResumePipelineApiRequest
 
 	// Interface only available internally
-	resumePipelineExecute(r ResumePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
+	ResumePipelineExecute(r ResumePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
 
 	/*
 		TriggerSnapshotIngestion Trigger on demand snapshot ingestion
@@ -300,7 +300,7 @@ type DataLakePipelinesApi interface {
 	TriggerSnapshotIngestionWithParams(ctx context.Context, args *TriggerSnapshotIngestionApiParams) TriggerSnapshotIngestionApiRequest
 
 	// Interface only available internally
-	triggerSnapshotIngestionExecute(r TriggerSnapshotIngestionApiRequest) (*IngestionPipelineRun, *http.Response, error)
+	TriggerSnapshotIngestionExecute(r TriggerSnapshotIngestionApiRequest) (*IngestionPipelineRun, *http.Response, error)
 
 	/*
 		UpdatePipeline Update One Data Lake Pipeline
@@ -324,7 +324,7 @@ type DataLakePipelinesApi interface {
 	UpdatePipelineWithParams(ctx context.Context, args *UpdatePipelineApiParams) UpdatePipelineApiRequest
 
 	// Interface only available internally
-	updatePipelineExecute(r UpdatePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
+	UpdatePipelineExecute(r UpdatePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error)
 }
 
 // DataLakePipelinesApiService DataLakePipelinesApi service
@@ -352,7 +352,7 @@ func (a *DataLakePipelinesApiService) CreatePipelineWithParams(ctx context.Conte
 }
 
 func (r CreatePipelineApiRequest) Execute() (*DataLakeIngestionPipeline, *http.Response, error) {
-	return r.ApiService.createPipelineExecute(r)
+	return r.ApiService.CreatePipelineExecute(r)
 }
 
 /*
@@ -376,7 +376,7 @@ func (a *DataLakePipelinesApiService) CreatePipeline(ctx context.Context, groupI
 // Execute executes the request
 //
 //	@return DataLakeIngestionPipeline
-func (a *DataLakePipelinesApiService) createPipelineExecute(r CreatePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) CreatePipelineExecute(r CreatePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -485,7 +485,7 @@ func (a *DataLakePipelinesApiService) DeletePipelineWithParams(ctx context.Conte
 }
 
 func (r DeletePipelineApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deletePipelineExecute(r)
+	return r.ApiService.DeletePipelineExecute(r)
 }
 
 /*
@@ -510,7 +510,7 @@ func (a *DataLakePipelinesApiService) DeletePipeline(ctx context.Context, groupI
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *DataLakePipelinesApiService) deletePipelineExecute(r DeletePipelineApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *DataLakePipelinesApiService) DeletePipelineExecute(r DeletePipelineApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -618,7 +618,7 @@ func (a *DataLakePipelinesApiService) DeletePipelineRunDatasetWithParams(ctx con
 }
 
 func (r DeletePipelineRunDatasetApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deletePipelineRunDatasetExecute(r)
+	return r.ApiService.DeletePipelineRunDatasetExecute(r)
 }
 
 /*
@@ -645,7 +645,7 @@ func (a *DataLakePipelinesApiService) DeletePipelineRunDataset(ctx context.Conte
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *DataLakePipelinesApiService) deletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *DataLakePipelinesApiService) DeletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -751,7 +751,7 @@ func (a *DataLakePipelinesApiService) GetPipelineWithParams(ctx context.Context,
 }
 
 func (r GetPipelineApiRequest) Execute() (*DataLakeIngestionPipeline, *http.Response, error) {
-	return r.ApiService.getPipelineExecute(r)
+	return r.ApiService.GetPipelineExecute(r)
 }
 
 /*
@@ -776,7 +776,7 @@ func (a *DataLakePipelinesApiService) GetPipeline(ctx context.Context, groupId s
 // Execute executes the request
 //
 //	@return DataLakeIngestionPipeline
-func (a *DataLakePipelinesApiService) getPipelineExecute(r GetPipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) GetPipelineExecute(r GetPipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -884,7 +884,7 @@ func (a *DataLakePipelinesApiService) GetPipelineRunWithParams(ctx context.Conte
 }
 
 func (r GetPipelineRunApiRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
-	return r.ApiService.getPipelineRunExecute(r)
+	return r.ApiService.GetPipelineRunExecute(r)
 }
 
 /*
@@ -911,7 +911,7 @@ func (a *DataLakePipelinesApiService) GetPipelineRun(ctx context.Context, groupI
 // Execute executes the request
 //
 //	@return IngestionPipelineRun
-func (a *DataLakePipelinesApiService) getPipelineRunExecute(r GetPipelineRunApiRequest) (*IngestionPipelineRun, *http.Response, error) {
+func (a *DataLakePipelinesApiService) GetPipelineRunExecute(r GetPipelineRunApiRequest) (*IngestionPipelineRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1053,7 +1053,7 @@ func (r ListPipelineRunsApiRequest) CreatedBefore(createdBefore time.Time) ListP
 }
 
 func (r ListPipelineRunsApiRequest) Execute() (*PaginatedPipelineRun, *http.Response, error) {
-	return r.ApiService.listPipelineRunsExecute(r)
+	return r.ApiService.ListPipelineRunsExecute(r)
 }
 
 /*
@@ -1078,7 +1078,7 @@ func (a *DataLakePipelinesApiService) ListPipelineRuns(ctx context.Context, grou
 // Execute executes the request
 //
 //	@return PaginatedPipelineRun
-func (a *DataLakePipelinesApiService) listPipelineRunsExecute(r ListPipelineRunsApiRequest) (*PaginatedPipelineRun, *http.Response, error) {
+func (a *DataLakePipelinesApiService) ListPipelineRunsExecute(r ListPipelineRunsApiRequest) (*PaginatedPipelineRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1207,7 +1207,7 @@ func (a *DataLakePipelinesApiService) ListPipelineSchedulesWithParams(ctx contex
 }
 
 func (r ListPipelineSchedulesApiRequest) Execute() ([]DiskBackupApiPolicyItem, *http.Response, error) {
-	return r.ApiService.listPipelineSchedulesExecute(r)
+	return r.ApiService.ListPipelineSchedulesExecute(r)
 }
 
 /*
@@ -1232,7 +1232,7 @@ func (a *DataLakePipelinesApiService) ListPipelineSchedules(ctx context.Context,
 // Execute executes the request
 //
 //	@return []DiskBackupApiPolicyItem
-func (a *DataLakePipelinesApiService) listPipelineSchedulesExecute(r ListPipelineSchedulesApiRequest) ([]DiskBackupApiPolicyItem, *http.Response, error) {
+func (a *DataLakePipelinesApiService) ListPipelineSchedulesExecute(r ListPipelineSchedulesApiRequest) ([]DiskBackupApiPolicyItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1373,7 +1373,7 @@ func (r ListPipelineSnapshotsApiRequest) CompletedAfter(completedAfter time.Time
 }
 
 func (r ListPipelineSnapshotsApiRequest) Execute() (*PaginatedBackupSnapshot, *http.Response, error) {
-	return r.ApiService.listPipelineSnapshotsExecute(r)
+	return r.ApiService.ListPipelineSnapshotsExecute(r)
 }
 
 /*
@@ -1398,7 +1398,7 @@ func (a *DataLakePipelinesApiService) ListPipelineSnapshots(ctx context.Context,
 // Execute executes the request
 //
 //	@return PaginatedBackupSnapshot
-func (a *DataLakePipelinesApiService) listPipelineSnapshotsExecute(r ListPipelineSnapshotsApiRequest) (*PaginatedBackupSnapshot, *http.Response, error) {
+func (a *DataLakePipelinesApiService) ListPipelineSnapshotsExecute(r ListPipelineSnapshotsApiRequest) (*PaginatedBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1524,7 +1524,7 @@ func (a *DataLakePipelinesApiService) ListPipelinesWithParams(ctx context.Contex
 }
 
 func (r ListPipelinesApiRequest) Execute() ([]DataLakeIngestionPipeline, *http.Response, error) {
-	return r.ApiService.listPipelinesExecute(r)
+	return r.ApiService.ListPipelinesExecute(r)
 }
 
 /*
@@ -1547,7 +1547,7 @@ func (a *DataLakePipelinesApiService) ListPipelines(ctx context.Context, groupId
 // Execute executes the request
 //
 //	@return []DataLakeIngestionPipeline
-func (a *DataLakePipelinesApiService) listPipelinesExecute(r ListPipelinesApiRequest) ([]DataLakeIngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) ListPipelinesExecute(r ListPipelinesApiRequest) ([]DataLakeIngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1651,7 +1651,7 @@ func (a *DataLakePipelinesApiService) PausePipelineWithParams(ctx context.Contex
 }
 
 func (r PausePipelineApiRequest) Execute() (*DataLakeIngestionPipeline, *http.Response, error) {
-	return r.ApiService.pausePipelineExecute(r)
+	return r.ApiService.PausePipelineExecute(r)
 }
 
 /*
@@ -1676,7 +1676,7 @@ func (a *DataLakePipelinesApiService) PausePipeline(ctx context.Context, groupId
 // Execute executes the request
 //
 //	@return DataLakeIngestionPipeline
-func (a *DataLakePipelinesApiService) pausePipelineExecute(r PausePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) PausePipelineExecute(r PausePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -1781,7 +1781,7 @@ func (a *DataLakePipelinesApiService) ResumePipelineWithParams(ctx context.Conte
 }
 
 func (r ResumePipelineApiRequest) Execute() (*DataLakeIngestionPipeline, *http.Response, error) {
-	return r.ApiService.resumePipelineExecute(r)
+	return r.ApiService.ResumePipelineExecute(r)
 }
 
 /*
@@ -1806,7 +1806,7 @@ func (a *DataLakePipelinesApiService) ResumePipeline(ctx context.Context, groupI
 // Execute executes the request
 //
 //	@return DataLakeIngestionPipeline
-func (a *DataLakePipelinesApiService) resumePipelineExecute(r ResumePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) ResumePipelineExecute(r ResumePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -1914,7 +1914,7 @@ func (a *DataLakePipelinesApiService) TriggerSnapshotIngestionWithParams(ctx con
 }
 
 func (r TriggerSnapshotIngestionApiRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
-	return r.ApiService.triggerSnapshotIngestionExecute(r)
+	return r.ApiService.TriggerSnapshotIngestionExecute(r)
 }
 
 /*
@@ -1940,7 +1940,7 @@ func (a *DataLakePipelinesApiService) TriggerSnapshotIngestion(ctx context.Conte
 // Execute executes the request
 //
 //	@return IngestionPipelineRun
-func (a *DataLakePipelinesApiService) triggerSnapshotIngestionExecute(r TriggerSnapshotIngestionApiRequest) (*IngestionPipelineRun, *http.Response, error) {
+func (a *DataLakePipelinesApiService) TriggerSnapshotIngestionExecute(r TriggerSnapshotIngestionApiRequest) (*IngestionPipelineRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -2053,7 +2053,7 @@ func (a *DataLakePipelinesApiService) UpdatePipelineWithParams(ctx context.Conte
 }
 
 func (r UpdatePipelineApiRequest) Execute() (*DataLakeIngestionPipeline, *http.Response, error) {
-	return r.ApiService.updatePipelineExecute(r)
+	return r.ApiService.UpdatePipelineExecute(r)
 }
 
 /*
@@ -2079,7 +2079,7 @@ func (a *DataLakePipelinesApiService) UpdatePipeline(ctx context.Context, groupI
 // Execute executes the request
 //
 //	@return DataLakeIngestionPipeline
-func (a *DataLakePipelinesApiService) updatePipelineExecute(r UpdatePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) UpdatePipelineExecute(r UpdatePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_database_users.go
+++ b/admin/api_database_users.go
@@ -34,7 +34,7 @@ type DatabaseUsersApi interface {
 	CreateDatabaseUserWithParams(ctx context.Context, args *CreateDatabaseUserApiParams) CreateDatabaseUserApiRequest
 
 	// Interface only available internally
-	createDatabaseUserExecute(r CreateDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error)
+	CreateDatabaseUserExecute(r CreateDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error)
 
 	/*
 		DeleteDatabaseUser Remove One Database User from One Project
@@ -59,7 +59,7 @@ type DatabaseUsersApi interface {
 	DeleteDatabaseUserWithParams(ctx context.Context, args *DeleteDatabaseUserApiParams) DeleteDatabaseUserApiRequest
 
 	// Interface only available internally
-	deleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetDatabaseUser Return One Database User from One Project
@@ -84,7 +84,7 @@ type DatabaseUsersApi interface {
 	GetDatabaseUserWithParams(ctx context.Context, args *GetDatabaseUserApiParams) GetDatabaseUserApiRequest
 
 	// Interface only available internally
-	getDatabaseUserExecute(r GetDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error)
+	GetDatabaseUserExecute(r GetDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error)
 
 	/*
 		ListDatabaseUsers Return All Database Users from One Project
@@ -107,7 +107,7 @@ type DatabaseUsersApi interface {
 	ListDatabaseUsersWithParams(ctx context.Context, args *ListDatabaseUsersApiParams) ListDatabaseUsersApiRequest
 
 	// Interface only available internally
-	listDatabaseUsersExecute(r ListDatabaseUsersApiRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error)
+	ListDatabaseUsersExecute(r ListDatabaseUsersApiRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error)
 
 	/*
 		UpdateDatabaseUser Update One Database User in One Project
@@ -132,7 +132,7 @@ type DatabaseUsersApi interface {
 	UpdateDatabaseUserWithParams(ctx context.Context, args *UpdateDatabaseUserApiParams) UpdateDatabaseUserApiRequest
 
 	// Interface only available internally
-	updateDatabaseUserExecute(r UpdateDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error)
+	UpdateDatabaseUserExecute(r UpdateDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error)
 }
 
 // DatabaseUsersApiService DatabaseUsersApi service
@@ -160,7 +160,7 @@ func (a *DatabaseUsersApiService) CreateDatabaseUserWithParams(ctx context.Conte
 }
 
 func (r CreateDatabaseUserApiRequest) Execute() (*CloudDatabaseUser, *http.Response, error) {
-	return r.ApiService.createDatabaseUserExecute(r)
+	return r.ApiService.CreateDatabaseUserExecute(r)
 }
 
 /*
@@ -184,7 +184,7 @@ func (a *DatabaseUsersApiService) CreateDatabaseUser(ctx context.Context, groupI
 // Execute executes the request
 //
 //	@return CloudDatabaseUser
-func (a *DatabaseUsersApiService) createDatabaseUserExecute(r CreateDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error) {
+func (a *DatabaseUsersApiService) CreateDatabaseUserExecute(r CreateDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -296,7 +296,7 @@ func (a *DatabaseUsersApiService) DeleteDatabaseUserWithParams(ctx context.Conte
 }
 
 func (r DeleteDatabaseUserApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteDatabaseUserExecute(r)
+	return r.ApiService.DeleteDatabaseUserExecute(r)
 }
 
 /*
@@ -323,7 +323,7 @@ func (a *DatabaseUsersApiService) DeleteDatabaseUser(ctx context.Context, groupI
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *DatabaseUsersApiService) deleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *DatabaseUsersApiService) DeleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -432,7 +432,7 @@ func (a *DatabaseUsersApiService) GetDatabaseUserWithParams(ctx context.Context,
 }
 
 func (r GetDatabaseUserApiRequest) Execute() (*CloudDatabaseUser, *http.Response, error) {
-	return r.ApiService.getDatabaseUserExecute(r)
+	return r.ApiService.GetDatabaseUserExecute(r)
 }
 
 /*
@@ -459,7 +459,7 @@ func (a *DatabaseUsersApiService) GetDatabaseUser(ctx context.Context, groupId s
 // Execute executes the request
 //
 //	@return CloudDatabaseUser
-func (a *DatabaseUsersApiService) getDatabaseUserExecute(r GetDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error) {
+func (a *DatabaseUsersApiService) GetDatabaseUserExecute(r GetDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -589,7 +589,7 @@ func (r ListDatabaseUsersApiRequest) PageNum(pageNum int) ListDatabaseUsersApiRe
 }
 
 func (r ListDatabaseUsersApiRequest) Execute() (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
-	return r.ApiService.listDatabaseUsersExecute(r)
+	return r.ApiService.ListDatabaseUsersExecute(r)
 }
 
 /*
@@ -612,7 +612,7 @@ func (a *DatabaseUsersApiService) ListDatabaseUsers(ctx context.Context, groupId
 // Execute executes the request
 //
 //	@return PaginatedApiAtlasDatabaseUser
-func (a *DatabaseUsersApiService) listDatabaseUsersExecute(r ListDatabaseUsersApiRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
+func (a *DatabaseUsersApiService) ListDatabaseUsersExecute(r ListDatabaseUsersApiRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -743,7 +743,7 @@ func (a *DatabaseUsersApiService) UpdateDatabaseUserWithParams(ctx context.Conte
 }
 
 func (r UpdateDatabaseUserApiRequest) Execute() (*CloudDatabaseUser, *http.Response, error) {
-	return r.ApiService.updateDatabaseUserExecute(r)
+	return r.ApiService.UpdateDatabaseUserExecute(r)
 }
 
 /*
@@ -771,7 +771,7 @@ func (a *DatabaseUsersApiService) UpdateDatabaseUser(ctx context.Context, groupI
 // Execute executes the request
 //
 //	@return CloudDatabaseUser
-func (a *DatabaseUsersApiService) updateDatabaseUserExecute(r UpdateDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error) {
+func (a *DatabaseUsersApiService) UpdateDatabaseUserExecute(r UpdateDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_database_users.go
+++ b/admin/api_database_users.go
@@ -33,7 +33,7 @@ type DatabaseUsersApi interface {
 	*/
 	CreateDatabaseUserWithParams(ctx context.Context, args *CreateDatabaseUserApiParams) CreateDatabaseUserApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateDatabaseUserExecute(r CreateDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error)
 
 	/*
@@ -58,7 +58,7 @@ type DatabaseUsersApi interface {
 	*/
 	DeleteDatabaseUserWithParams(ctx context.Context, args *DeleteDatabaseUserApiParams) DeleteDatabaseUserApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -83,7 +83,7 @@ type DatabaseUsersApi interface {
 	*/
 	GetDatabaseUserWithParams(ctx context.Context, args *GetDatabaseUserApiParams) GetDatabaseUserApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetDatabaseUserExecute(r GetDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error)
 
 	/*
@@ -106,7 +106,7 @@ type DatabaseUsersApi interface {
 	*/
 	ListDatabaseUsersWithParams(ctx context.Context, args *ListDatabaseUsersApiParams) ListDatabaseUsersApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListDatabaseUsersExecute(r ListDatabaseUsersApiRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error)
 
 	/*
@@ -131,7 +131,7 @@ type DatabaseUsersApi interface {
 	*/
 	UpdateDatabaseUserWithParams(ctx context.Context, args *UpdateDatabaseUserApiParams) UpdateDatabaseUserApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateDatabaseUserExecute(r UpdateDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error)
 }
 

--- a/admin/api_default.go
+++ b/admin/api_default.go
@@ -31,7 +31,7 @@ type DefaultApi interface {
 	*/
 	ReturnAllControlPlaneIPAddressesWithParams(ctx context.Context, args *ReturnAllControlPlaneIPAddressesApiParams) ReturnAllControlPlaneIPAddressesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ReturnAllControlPlaneIPAddressesExecute(r ReturnAllControlPlaneIPAddressesApiRequest) (*ControlPlaneIPAddresses, *http.Response, error)
 }
 

--- a/admin/api_default.go
+++ b/admin/api_default.go
@@ -32,7 +32,7 @@ type DefaultApi interface {
 	ReturnAllControlPlaneIPAddressesWithParams(ctx context.Context, args *ReturnAllControlPlaneIPAddressesApiParams) ReturnAllControlPlaneIPAddressesApiRequest
 
 	// Interface only available internally
-	returnAllControlPlaneIPAddressesExecute(r ReturnAllControlPlaneIPAddressesApiRequest) (*ControlPlaneIPAddresses, *http.Response, error)
+	ReturnAllControlPlaneIPAddressesExecute(r ReturnAllControlPlaneIPAddressesApiRequest) (*ControlPlaneIPAddresses, *http.Response, error)
 }
 
 // DefaultApiService DefaultApi service
@@ -54,7 +54,7 @@ func (a *DefaultApiService) ReturnAllControlPlaneIPAddressesWithParams(ctx conte
 }
 
 func (r ReturnAllControlPlaneIPAddressesApiRequest) Execute() (*ControlPlaneIPAddresses, *http.Response, error) {
-	return r.ApiService.returnAllControlPlaneIPAddressesExecute(r)
+	return r.ApiService.ReturnAllControlPlaneIPAddressesExecute(r)
 }
 
 /*
@@ -75,7 +75,7 @@ func (a *DefaultApiService) ReturnAllControlPlaneIPAddresses(ctx context.Context
 // Execute executes the request
 //
 //	@return ControlPlaneIPAddresses
-func (a *DefaultApiService) returnAllControlPlaneIPAddressesExecute(r ReturnAllControlPlaneIPAddressesApiRequest) (*ControlPlaneIPAddresses, *http.Response, error) {
+func (a *DefaultApiService) ReturnAllControlPlaneIPAddressesExecute(r ReturnAllControlPlaneIPAddressesApiRequest) (*ControlPlaneIPAddresses, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_encryption_at_rest_using_customer_key_management.go
+++ b/admin/api_encryption_at_rest_using_customer_key_management.go
@@ -36,7 +36,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi interface {
 	GetEncryptionAtRestWithParams(ctx context.Context, args *GetEncryptionAtRestApiParams) GetEncryptionAtRestApiRequest
 
 	// Interface only available internally
-	getEncryptionAtRestExecute(r GetEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error)
+	GetEncryptionAtRestExecute(r GetEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error)
 
 	/*
 		UpdateEncryptionAtRest Update Configuration for Encryption at Rest using Customer-Managed Keys for One Project
@@ -61,7 +61,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi interface {
 	UpdateEncryptionAtRestWithParams(ctx context.Context, args *UpdateEncryptionAtRestApiParams) UpdateEncryptionAtRestApiRequest
 
 	// Interface only available internally
-	updateEncryptionAtRestExecute(r UpdateEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error)
+	UpdateEncryptionAtRestExecute(r UpdateEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error)
 }
 
 // EncryptionAtRestUsingCustomerKeyManagementApiService EncryptionAtRestUsingCustomerKeyManagementApi service
@@ -86,7 +86,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRe
 }
 
 func (r GetEncryptionAtRestApiRequest) Execute() (*EncryptionAtRest, *http.Response, error) {
-	return r.ApiService.getEncryptionAtRestExecute(r)
+	return r.ApiService.GetEncryptionAtRestExecute(r)
 }
 
 /*
@@ -111,7 +111,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRe
 // Execute executes the request
 //
 //	@return EncryptionAtRest
-func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) getEncryptionAtRestExecute(r GetEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error) {
+func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRestExecute(r GetEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -215,7 +215,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionA
 }
 
 func (r UpdateEncryptionAtRestApiRequest) Execute() (*EncryptionAtRest, *http.Response, error) {
-	return r.ApiService.updateEncryptionAtRestExecute(r)
+	return r.ApiService.UpdateEncryptionAtRestExecute(r)
 }
 
 /*
@@ -241,7 +241,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionA
 // Execute executes the request
 //
 //	@return EncryptionAtRest
-func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) updateEncryptionAtRestExecute(r UpdateEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error) {
+func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionAtRestExecute(r UpdateEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_encryption_at_rest_using_customer_key_management.go
+++ b/admin/api_encryption_at_rest_using_customer_key_management.go
@@ -35,7 +35,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi interface {
 	*/
 	GetEncryptionAtRestWithParams(ctx context.Context, args *GetEncryptionAtRestApiParams) GetEncryptionAtRestApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetEncryptionAtRestExecute(r GetEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error)
 
 	/*
@@ -60,7 +60,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi interface {
 	*/
 	UpdateEncryptionAtRestWithParams(ctx context.Context, args *UpdateEncryptionAtRestApiParams) UpdateEncryptionAtRestApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateEncryptionAtRestExecute(r UpdateEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error)
 }
 

--- a/admin/api_events.go
+++ b/admin/api_events.go
@@ -39,7 +39,7 @@ type EventsApi interface {
 	GetOrganizationEventWithParams(ctx context.Context, args *GetOrganizationEventApiParams) GetOrganizationEventApiRequest
 
 	// Interface only available internally
-	getOrganizationEventExecute(r GetOrganizationEventApiRequest) (*EventViewForOrg, *http.Response, error)
+	GetOrganizationEventExecute(r GetOrganizationEventApiRequest) (*EventViewForOrg, *http.Response, error)
 
 	/*
 		GetProjectEvent Return One Event from One Project
@@ -65,7 +65,7 @@ type EventsApi interface {
 	GetProjectEventWithParams(ctx context.Context, args *GetProjectEventApiParams) GetProjectEventApiRequest
 
 	// Interface only available internally
-	getProjectEventExecute(r GetProjectEventApiRequest) (*EventViewForNdsGroup, *http.Response, error)
+	GetProjectEventExecute(r GetProjectEventApiRequest) (*EventViewForNdsGroup, *http.Response, error)
 
 	/*
 		ListOrganizationEvents Return All Events from One Organization
@@ -90,7 +90,7 @@ type EventsApi interface {
 	ListOrganizationEventsWithParams(ctx context.Context, args *ListOrganizationEventsApiParams) ListOrganizationEventsApiRequest
 
 	// Interface only available internally
-	listOrganizationEventsExecute(r ListOrganizationEventsApiRequest) (*OrgPaginatedEvent, *http.Response, error)
+	ListOrganizationEventsExecute(r ListOrganizationEventsApiRequest) (*OrgPaginatedEvent, *http.Response, error)
 
 	/*
 		ListProjectEvents Return All Events from One Project
@@ -115,7 +115,7 @@ type EventsApi interface {
 	ListProjectEventsWithParams(ctx context.Context, args *ListProjectEventsApiParams) ListProjectEventsApiRequest
 
 	// Interface only available internally
-	listProjectEventsExecute(r ListProjectEventsApiRequest) (*GroupPaginatedEvent, *http.Response, error)
+	ListProjectEventsExecute(r ListProjectEventsApiRequest) (*GroupPaginatedEvent, *http.Response, error)
 }
 
 // EventsApiService EventsApi service
@@ -152,7 +152,7 @@ func (r GetOrganizationEventApiRequest) IncludeRaw(includeRaw bool) GetOrganizat
 }
 
 func (r GetOrganizationEventApiRequest) Execute() (*EventViewForOrg, *http.Response, error) {
-	return r.ApiService.getOrganizationEventExecute(r)
+	return r.ApiService.GetOrganizationEventExecute(r)
 }
 
 /*
@@ -179,7 +179,7 @@ func (a *EventsApiService) GetOrganizationEvent(ctx context.Context, orgId strin
 // Execute executes the request
 //
 //	@return EventViewForOrg
-func (a *EventsApiService) getOrganizationEventExecute(r GetOrganizationEventApiRequest) (*EventViewForOrg, *http.Response, error) {
+func (a *EventsApiService) GetOrganizationEventExecute(r GetOrganizationEventApiRequest) (*EventViewForOrg, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -300,7 +300,7 @@ func (r GetProjectEventApiRequest) IncludeRaw(includeRaw bool) GetProjectEventAp
 }
 
 func (r GetProjectEventApiRequest) Execute() (*EventViewForNdsGroup, *http.Response, error) {
-	return r.ApiService.getProjectEventExecute(r)
+	return r.ApiService.GetProjectEventExecute(r)
 }
 
 /*
@@ -327,7 +327,7 @@ func (a *EventsApiService) GetProjectEvent(ctx context.Context, groupId string, 
 // Execute executes the request
 //
 //	@return EventViewForNdsGroup
-func (a *EventsApiService) getProjectEventExecute(r GetProjectEventApiRequest) (*EventViewForNdsGroup, *http.Response, error) {
+func (a *EventsApiService) GetProjectEventExecute(r GetProjectEventApiRequest) (*EventViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -499,7 +499,7 @@ func (r ListOrganizationEventsApiRequest) MinDate(minDate time.Time) ListOrganiz
 }
 
 func (r ListOrganizationEventsApiRequest) Execute() (*OrgPaginatedEvent, *http.Response, error) {
-	return r.ApiService.listOrganizationEventsExecute(r)
+	return r.ApiService.ListOrganizationEventsExecute(r)
 }
 
 /*
@@ -524,7 +524,7 @@ func (a *EventsApiService) ListOrganizationEvents(ctx context.Context, orgId str
 // Execute executes the request
 //
 //	@return OrgPaginatedEvent
-func (a *EventsApiService) listOrganizationEventsExecute(r ListOrganizationEventsApiRequest) (*OrgPaginatedEvent, *http.Response, error) {
+func (a *EventsApiService) ListOrganizationEventsExecute(r ListOrganizationEventsApiRequest) (*OrgPaginatedEvent, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -747,7 +747,7 @@ func (r ListProjectEventsApiRequest) MinDate(minDate time.Time) ListProjectEvent
 }
 
 func (r ListProjectEventsApiRequest) Execute() (*GroupPaginatedEvent, *http.Response, error) {
-	return r.ApiService.listProjectEventsExecute(r)
+	return r.ApiService.ListProjectEventsExecute(r)
 }
 
 /*
@@ -772,7 +772,7 @@ func (a *EventsApiService) ListProjectEvents(ctx context.Context, groupId string
 // Execute executes the request
 //
 //	@return GroupPaginatedEvent
-func (a *EventsApiService) listProjectEventsExecute(r ListProjectEventsApiRequest) (*GroupPaginatedEvent, *http.Response, error) {
+func (a *EventsApiService) ListProjectEventsExecute(r ListProjectEventsApiRequest) (*GroupPaginatedEvent, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_events.go
+++ b/admin/api_events.go
@@ -38,7 +38,7 @@ type EventsApi interface {
 	*/
 	GetOrganizationEventWithParams(ctx context.Context, args *GetOrganizationEventApiParams) GetOrganizationEventApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetOrganizationEventExecute(r GetOrganizationEventApiRequest) (*EventViewForOrg, *http.Response, error)
 
 	/*
@@ -64,7 +64,7 @@ type EventsApi interface {
 	*/
 	GetProjectEventWithParams(ctx context.Context, args *GetProjectEventApiParams) GetProjectEventApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetProjectEventExecute(r GetProjectEventApiRequest) (*EventViewForNdsGroup, *http.Response, error)
 
 	/*
@@ -89,7 +89,7 @@ type EventsApi interface {
 	*/
 	ListOrganizationEventsWithParams(ctx context.Context, args *ListOrganizationEventsApiParams) ListOrganizationEventsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListOrganizationEventsExecute(r ListOrganizationEventsApiRequest) (*OrgPaginatedEvent, *http.Response, error)
 
 	/*
@@ -114,7 +114,7 @@ type EventsApi interface {
 	*/
 	ListProjectEventsWithParams(ctx context.Context, args *ListProjectEventsApiParams) ListProjectEventsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListProjectEventsExecute(r ListProjectEventsApiRequest) (*GroupPaginatedEvent, *http.Response, error)
 }
 

--- a/admin/api_federated_authentication.go
+++ b/admin/api_federated_authentication.go
@@ -34,7 +34,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	CreateRoleMappingWithParams(ctx context.Context, args *CreateRoleMappingApiParams) CreateRoleMappingApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateRoleMappingExecute(r CreateRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error)
 
 	/*
@@ -57,7 +57,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	DeleteFederationAppWithParams(ctx context.Context, args *DeleteFederationAppApiParams) DeleteFederationAppApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteFederationAppExecute(r DeleteFederationAppApiRequest) (*http.Response, error)
 
 	/*
@@ -82,7 +82,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	DeleteRoleMappingWithParams(ctx context.Context, args *DeleteRoleMappingApiParams) DeleteRoleMappingApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteRoleMappingExecute(r DeleteRoleMappingApiRequest) (*http.Response, error)
 
 	/*
@@ -106,7 +106,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	GetConnectedOrgConfigWithParams(ctx context.Context, args *GetConnectedOrgConfigApiParams) GetConnectedOrgConfigApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetConnectedOrgConfigExecute(r GetConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error)
 
 	/*
@@ -129,7 +129,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	GetFederationSettingsWithParams(ctx context.Context, args *GetFederationSettingsApiParams) GetFederationSettingsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetFederationSettingsExecute(r GetFederationSettingsApiRequest) (*OrgFederationSettings, *http.Response, error)
 
 	/*
@@ -153,7 +153,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	GetIdentityProviderWithParams(ctx context.Context, args *GetIdentityProviderApiParams) GetIdentityProviderApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetIdentityProviderExecute(r GetIdentityProviderApiRequest) (*FederationIdentityProvider, *http.Response, error)
 
 	/*
@@ -177,7 +177,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	GetIdentityProviderMetadataWithParams(ctx context.Context, args *GetIdentityProviderMetadataApiParams) GetIdentityProviderMetadataApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetIdentityProviderMetadataExecute(r GetIdentityProviderMetadataApiRequest) (string, *http.Response, error)
 
 	/*
@@ -202,7 +202,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	GetRoleMappingWithParams(ctx context.Context, args *GetRoleMappingApiParams) GetRoleMappingApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetRoleMappingExecute(r GetRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error)
 
 	/*
@@ -225,7 +225,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	ListConnectedOrgConfigsWithParams(ctx context.Context, args *ListConnectedOrgConfigsApiParams) ListConnectedOrgConfigsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListConnectedOrgConfigsExecute(r ListConnectedOrgConfigsApiRequest) ([]ConnectedOrgConfig, *http.Response, error)
 
 	/*
@@ -248,7 +248,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	ListIdentityProvidersWithParams(ctx context.Context, args *ListIdentityProvidersApiParams) ListIdentityProvidersApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListIdentityProvidersExecute(r ListIdentityProvidersApiRequest) (*PaginatedFederationIdentityProvider, *http.Response, error)
 
 	/*
@@ -272,7 +272,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	ListRoleMappingsWithParams(ctx context.Context, args *ListRoleMappingsApiParams) ListRoleMappingsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListRoleMappingsExecute(r ListRoleMappingsApiRequest) (*PaginatedRoleMapping, *http.Response, error)
 
 	/*
@@ -296,7 +296,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	RemoveConnectedOrgConfigWithParams(ctx context.Context, args *RemoveConnectedOrgConfigApiParams) RemoveConnectedOrgConfigApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	RemoveConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -326,7 +326,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	UpdateConnectedOrgConfigWithParams(ctx context.Context, args *UpdateConnectedOrgConfigApiParams) UpdateConnectedOrgConfigApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateConnectedOrgConfigExecute(r UpdateConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error)
 
 	/*
@@ -350,7 +350,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	UpdateIdentityProviderWithParams(ctx context.Context, args *UpdateIdentityProviderApiParams) UpdateIdentityProviderApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateIdentityProviderExecute(r UpdateIdentityProviderApiRequest) (*FederationIdentityProvider, *http.Response, error)
 
 	/*
@@ -375,7 +375,7 @@ type FederatedAuthenticationApi interface {
 	*/
 	UpdateRoleMappingWithParams(ctx context.Context, args *UpdateRoleMappingApiParams) UpdateRoleMappingApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateRoleMappingExecute(r UpdateRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error)
 }
 

--- a/admin/api_federated_authentication.go
+++ b/admin/api_federated_authentication.go
@@ -35,7 +35,7 @@ type FederatedAuthenticationApi interface {
 	CreateRoleMappingWithParams(ctx context.Context, args *CreateRoleMappingApiParams) CreateRoleMappingApiRequest
 
 	// Interface only available internally
-	createRoleMappingExecute(r CreateRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error)
+	CreateRoleMappingExecute(r CreateRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error)
 
 	/*
 		DeleteFederationApp Delete the federation settings instance.
@@ -58,7 +58,7 @@ type FederatedAuthenticationApi interface {
 	DeleteFederationAppWithParams(ctx context.Context, args *DeleteFederationAppApiParams) DeleteFederationAppApiRequest
 
 	// Interface only available internally
-	deleteFederationAppExecute(r DeleteFederationAppApiRequest) (*http.Response, error)
+	DeleteFederationAppExecute(r DeleteFederationAppApiRequest) (*http.Response, error)
 
 	/*
 		DeleteRoleMapping Remove One Role Mapping from One Organization
@@ -83,7 +83,7 @@ type FederatedAuthenticationApi interface {
 	DeleteRoleMappingWithParams(ctx context.Context, args *DeleteRoleMappingApiParams) DeleteRoleMappingApiRequest
 
 	// Interface only available internally
-	deleteRoleMappingExecute(r DeleteRoleMappingApiRequest) (*http.Response, error)
+	DeleteRoleMappingExecute(r DeleteRoleMappingApiRequest) (*http.Response, error)
 
 	/*
 		GetConnectedOrgConfig Return One Org Config Connected to One Federation
@@ -107,7 +107,7 @@ type FederatedAuthenticationApi interface {
 	GetConnectedOrgConfigWithParams(ctx context.Context, args *GetConnectedOrgConfigApiParams) GetConnectedOrgConfigApiRequest
 
 	// Interface only available internally
-	getConnectedOrgConfigExecute(r GetConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error)
+	GetConnectedOrgConfigExecute(r GetConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error)
 
 	/*
 		GetFederationSettings Return Federation Settings for One Organization
@@ -130,7 +130,7 @@ type FederatedAuthenticationApi interface {
 	GetFederationSettingsWithParams(ctx context.Context, args *GetFederationSettingsApiParams) GetFederationSettingsApiRequest
 
 	// Interface only available internally
-	getFederationSettingsExecute(r GetFederationSettingsApiRequest) (*OrgFederationSettings, *http.Response, error)
+	GetFederationSettingsExecute(r GetFederationSettingsApiRequest) (*OrgFederationSettings, *http.Response, error)
 
 	/*
 		GetIdentityProvider Return one identity provider from the specified federation by id.
@@ -154,7 +154,7 @@ type FederatedAuthenticationApi interface {
 	GetIdentityProviderWithParams(ctx context.Context, args *GetIdentityProviderApiParams) GetIdentityProviderApiRequest
 
 	// Interface only available internally
-	getIdentityProviderExecute(r GetIdentityProviderApiRequest) (*FederationIdentityProvider, *http.Response, error)
+	GetIdentityProviderExecute(r GetIdentityProviderApiRequest) (*FederationIdentityProvider, *http.Response, error)
 
 	/*
 		GetIdentityProviderMetadata Return the metadata of one identity provider in the specified federation.
@@ -178,7 +178,7 @@ type FederatedAuthenticationApi interface {
 	GetIdentityProviderMetadataWithParams(ctx context.Context, args *GetIdentityProviderMetadataApiParams) GetIdentityProviderMetadataApiRequest
 
 	// Interface only available internally
-	getIdentityProviderMetadataExecute(r GetIdentityProviderMetadataApiRequest) (string, *http.Response, error)
+	GetIdentityProviderMetadataExecute(r GetIdentityProviderMetadataApiRequest) (string, *http.Response, error)
 
 	/*
 		GetRoleMapping Return One Role Mapping from One Organization
@@ -203,7 +203,7 @@ type FederatedAuthenticationApi interface {
 	GetRoleMappingWithParams(ctx context.Context, args *GetRoleMappingApiParams) GetRoleMappingApiRequest
 
 	// Interface only available internally
-	getRoleMappingExecute(r GetRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error)
+	GetRoleMappingExecute(r GetRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error)
 
 	/*
 		ListConnectedOrgConfigs Return All Connected Org Configs from the Federation
@@ -226,7 +226,7 @@ type FederatedAuthenticationApi interface {
 	ListConnectedOrgConfigsWithParams(ctx context.Context, args *ListConnectedOrgConfigsApiParams) ListConnectedOrgConfigsApiRequest
 
 	// Interface only available internally
-	listConnectedOrgConfigsExecute(r ListConnectedOrgConfigsApiRequest) ([]ConnectedOrgConfig, *http.Response, error)
+	ListConnectedOrgConfigsExecute(r ListConnectedOrgConfigsApiRequest) ([]ConnectedOrgConfig, *http.Response, error)
 
 	/*
 		ListIdentityProviders Return all identity providers from the specified federation.
@@ -249,7 +249,7 @@ type FederatedAuthenticationApi interface {
 	ListIdentityProvidersWithParams(ctx context.Context, args *ListIdentityProvidersApiParams) ListIdentityProvidersApiRequest
 
 	// Interface only available internally
-	listIdentityProvidersExecute(r ListIdentityProvidersApiRequest) (*PaginatedFederationIdentityProvider, *http.Response, error)
+	ListIdentityProvidersExecute(r ListIdentityProvidersApiRequest) (*PaginatedFederationIdentityProvider, *http.Response, error)
 
 	/*
 		ListRoleMappings Return All Role Mappings from One Organization
@@ -273,7 +273,7 @@ type FederatedAuthenticationApi interface {
 	ListRoleMappingsWithParams(ctx context.Context, args *ListRoleMappingsApiParams) ListRoleMappingsApiRequest
 
 	// Interface only available internally
-	listRoleMappingsExecute(r ListRoleMappingsApiRequest) (*PaginatedRoleMapping, *http.Response, error)
+	ListRoleMappingsExecute(r ListRoleMappingsApiRequest) (*PaginatedRoleMapping, *http.Response, error)
 
 	/*
 		RemoveConnectedOrgConfig Remove One Org Config Connected to One Federation
@@ -297,7 +297,7 @@ type FederatedAuthenticationApi interface {
 	RemoveConnectedOrgConfigWithParams(ctx context.Context, args *RemoveConnectedOrgConfigApiParams) RemoveConnectedOrgConfigApiRequest
 
 	// Interface only available internally
-	removeConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (map[string]interface{}, *http.Response, error)
+	RemoveConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		UpdateConnectedOrgConfig Update One Org Config Connected to One Federation
@@ -327,7 +327,7 @@ type FederatedAuthenticationApi interface {
 	UpdateConnectedOrgConfigWithParams(ctx context.Context, args *UpdateConnectedOrgConfigApiParams) UpdateConnectedOrgConfigApiRequest
 
 	// Interface only available internally
-	updateConnectedOrgConfigExecute(r UpdateConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error)
+	UpdateConnectedOrgConfigExecute(r UpdateConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error)
 
 	/*
 		UpdateIdentityProvider Update the identity provider.
@@ -351,7 +351,7 @@ type FederatedAuthenticationApi interface {
 	UpdateIdentityProviderWithParams(ctx context.Context, args *UpdateIdentityProviderApiParams) UpdateIdentityProviderApiRequest
 
 	// Interface only available internally
-	updateIdentityProviderExecute(r UpdateIdentityProviderApiRequest) (*FederationIdentityProvider, *http.Response, error)
+	UpdateIdentityProviderExecute(r UpdateIdentityProviderApiRequest) (*FederationIdentityProvider, *http.Response, error)
 
 	/*
 		UpdateRoleMapping Update One Role Mapping in One Organization
@@ -376,7 +376,7 @@ type FederatedAuthenticationApi interface {
 	UpdateRoleMappingWithParams(ctx context.Context, args *UpdateRoleMappingApiParams) UpdateRoleMappingApiRequest
 
 	// Interface only available internally
-	updateRoleMappingExecute(r UpdateRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error)
+	UpdateRoleMappingExecute(r UpdateRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error)
 }
 
 // FederatedAuthenticationApiService FederatedAuthenticationApi service
@@ -407,7 +407,7 @@ func (a *FederatedAuthenticationApiService) CreateRoleMappingWithParams(ctx cont
 }
 
 func (r CreateRoleMappingApiRequest) Execute() (*AuthFederationRoleMapping, *http.Response, error) {
-	return r.ApiService.createRoleMappingExecute(r)
+	return r.ApiService.CreateRoleMappingExecute(r)
 }
 
 /*
@@ -433,7 +433,7 @@ func (a *FederatedAuthenticationApiService) CreateRoleMapping(ctx context.Contex
 // Execute executes the request
 //
 //	@return AuthFederationRoleMapping
-func (a *FederatedAuthenticationApiService) createRoleMappingExecute(r CreateRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) CreateRoleMappingExecute(r CreateRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -540,7 +540,7 @@ func (a *FederatedAuthenticationApiService) DeleteFederationAppWithParams(ctx co
 }
 
 func (r DeleteFederationAppApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.deleteFederationAppExecute(r)
+	return r.ApiService.DeleteFederationAppExecute(r)
 }
 
 /*
@@ -561,7 +561,7 @@ func (a *FederatedAuthenticationApiService) DeleteFederationApp(ctx context.Cont
 }
 
 // Execute executes the request
-func (a *FederatedAuthenticationApiService) deleteFederationAppExecute(r DeleteFederationAppApiRequest) (*http.Response, error) {
+func (a *FederatedAuthenticationApiService) DeleteFederationAppExecute(r DeleteFederationAppApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -658,7 +658,7 @@ func (a *FederatedAuthenticationApiService) DeleteRoleMappingWithParams(ctx cont
 }
 
 func (r DeleteRoleMappingApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.deleteRoleMappingExecute(r)
+	return r.ApiService.DeleteRoleMappingExecute(r)
 }
 
 /*
@@ -683,7 +683,7 @@ func (a *FederatedAuthenticationApiService) DeleteRoleMapping(ctx context.Contex
 }
 
 // Execute executes the request
-func (a *FederatedAuthenticationApiService) deleteRoleMappingExecute(r DeleteRoleMappingApiRequest) (*http.Response, error) {
+func (a *FederatedAuthenticationApiService) DeleteRoleMappingExecute(r DeleteRoleMappingApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -779,7 +779,7 @@ func (a *FederatedAuthenticationApiService) GetConnectedOrgConfigWithParams(ctx 
 }
 
 func (r GetConnectedOrgConfigApiRequest) Execute() (*ConnectedOrgConfig, *http.Response, error) {
-	return r.ApiService.getConnectedOrgConfigExecute(r)
+	return r.ApiService.GetConnectedOrgConfigExecute(r)
 }
 
 /*
@@ -804,7 +804,7 @@ func (a *FederatedAuthenticationApiService) GetConnectedOrgConfig(ctx context.Co
 // Execute executes the request
 //
 //	@return ConnectedOrgConfig
-func (a *FederatedAuthenticationApiService) getConnectedOrgConfigExecute(r GetConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) GetConnectedOrgConfigExecute(r GetConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -906,7 +906,7 @@ func (a *FederatedAuthenticationApiService) GetFederationSettingsWithParams(ctx 
 }
 
 func (r GetFederationSettingsApiRequest) Execute() (*OrgFederationSettings, *http.Response, error) {
-	return r.ApiService.getFederationSettingsExecute(r)
+	return r.ApiService.GetFederationSettingsExecute(r)
 }
 
 /*
@@ -929,7 +929,7 @@ func (a *FederatedAuthenticationApiService) GetFederationSettings(ctx context.Co
 // Execute executes the request
 //
 //	@return OrgFederationSettings
-func (a *FederatedAuthenticationApiService) getFederationSettingsExecute(r GetFederationSettingsApiRequest) (*OrgFederationSettings, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) GetFederationSettingsExecute(r GetFederationSettingsApiRequest) (*OrgFederationSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1033,7 +1033,7 @@ func (a *FederatedAuthenticationApiService) GetIdentityProviderWithParams(ctx co
 }
 
 func (r GetIdentityProviderApiRequest) Execute() (*FederationIdentityProvider, *http.Response, error) {
-	return r.ApiService.getIdentityProviderExecute(r)
+	return r.ApiService.GetIdentityProviderExecute(r)
 }
 
 /*
@@ -1058,7 +1058,7 @@ func (a *FederatedAuthenticationApiService) GetIdentityProvider(ctx context.Cont
 // Execute executes the request
 //
 //	@return FederationIdentityProvider
-func (a *FederatedAuthenticationApiService) getIdentityProviderExecute(r GetIdentityProviderApiRequest) (*FederationIdentityProvider, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) GetIdentityProviderExecute(r GetIdentityProviderApiRequest) (*FederationIdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1163,7 +1163,7 @@ func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadataWithParam
 }
 
 func (r GetIdentityProviderMetadataApiRequest) Execute() (string, *http.Response, error) {
-	return r.ApiService.getIdentityProviderMetadataExecute(r)
+	return r.ApiService.GetIdentityProviderMetadataExecute(r)
 }
 
 /*
@@ -1188,7 +1188,7 @@ func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadata(ctx cont
 // Execute executes the request
 //
 //	@return string
-func (a *FederatedAuthenticationApiService) getIdentityProviderMetadataExecute(r GetIdentityProviderMetadataApiRequest) (string, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadataExecute(r GetIdentityProviderMetadataApiRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1296,7 +1296,7 @@ func (a *FederatedAuthenticationApiService) GetRoleMappingWithParams(ctx context
 }
 
 func (r GetRoleMappingApiRequest) Execute() (*AuthFederationRoleMapping, *http.Response, error) {
-	return r.ApiService.getRoleMappingExecute(r)
+	return r.ApiService.GetRoleMappingExecute(r)
 }
 
 /*
@@ -1323,7 +1323,7 @@ func (a *FederatedAuthenticationApiService) GetRoleMapping(ctx context.Context, 
 // Execute executes the request
 //
 //	@return AuthFederationRoleMapping
-func (a *FederatedAuthenticationApiService) getRoleMappingExecute(r GetRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) GetRoleMappingExecute(r GetRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1426,7 +1426,7 @@ func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigsWithParams(ct
 }
 
 func (r ListConnectedOrgConfigsApiRequest) Execute() ([]ConnectedOrgConfig, *http.Response, error) {
-	return r.ApiService.listConnectedOrgConfigsExecute(r)
+	return r.ApiService.ListConnectedOrgConfigsExecute(r)
 }
 
 /*
@@ -1449,7 +1449,7 @@ func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigs(ctx context.
 // Execute executes the request
 //
 //	@return []ConnectedOrgConfig
-func (a *FederatedAuthenticationApiService) listConnectedOrgConfigsExecute(r ListConnectedOrgConfigsApiRequest) ([]ConnectedOrgConfig, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigsExecute(r ListConnectedOrgConfigsApiRequest) ([]ConnectedOrgConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1559,7 +1559,7 @@ func (r ListIdentityProvidersApiRequest) Protocol(protocol string) ListIdentityP
 }
 
 func (r ListIdentityProvidersApiRequest) Execute() (*PaginatedFederationIdentityProvider, *http.Response, error) {
-	return r.ApiService.listIdentityProvidersExecute(r)
+	return r.ApiService.ListIdentityProvidersExecute(r)
 }
 
 /*
@@ -1582,7 +1582,7 @@ func (a *FederatedAuthenticationApiService) ListIdentityProviders(ctx context.Co
 // Execute executes the request
 //
 //	@return PaginatedFederationIdentityProvider
-func (a *FederatedAuthenticationApiService) listIdentityProvidersExecute(r ListIdentityProvidersApiRequest) (*PaginatedFederationIdentityProvider, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) ListIdentityProvidersExecute(r ListIdentityProvidersApiRequest) (*PaginatedFederationIdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1689,7 +1689,7 @@ func (a *FederatedAuthenticationApiService) ListRoleMappingsWithParams(ctx conte
 }
 
 func (r ListRoleMappingsApiRequest) Execute() (*PaginatedRoleMapping, *http.Response, error) {
-	return r.ApiService.listRoleMappingsExecute(r)
+	return r.ApiService.ListRoleMappingsExecute(r)
 }
 
 /*
@@ -1714,7 +1714,7 @@ func (a *FederatedAuthenticationApiService) ListRoleMappings(ctx context.Context
 // Execute executes the request
 //
 //	@return PaginatedRoleMapping
-func (a *FederatedAuthenticationApiService) listRoleMappingsExecute(r ListRoleMappingsApiRequest) (*PaginatedRoleMapping, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) ListRoleMappingsExecute(r ListRoleMappingsApiRequest) (*PaginatedRoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1819,7 +1819,7 @@ func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfigWithParams(c
 }
 
 func (r RemoveConnectedOrgConfigApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.removeConnectedOrgConfigExecute(r)
+	return r.ApiService.RemoveConnectedOrgConfigExecute(r)
 }
 
 /*
@@ -1844,7 +1844,7 @@ func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfig(ctx context
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *FederatedAuthenticationApiService) removeConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -1952,7 +1952,7 @@ func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfigWithParams(c
 }
 
 func (r UpdateConnectedOrgConfigApiRequest) Execute() (*ConnectedOrgConfig, *http.Response, error) {
-	return r.ApiService.updateConnectedOrgConfigExecute(r)
+	return r.ApiService.UpdateConnectedOrgConfigExecute(r)
 }
 
 /*
@@ -1984,7 +1984,7 @@ func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfig(ctx context
 // Execute executes the request
 //
 //	@return ConnectedOrgConfig
-func (a *FederatedAuthenticationApiService) updateConnectedOrgConfigExecute(r UpdateConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfigExecute(r UpdateConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -2097,7 +2097,7 @@ func (a *FederatedAuthenticationApiService) UpdateIdentityProviderWithParams(ctx
 }
 
 func (r UpdateIdentityProviderApiRequest) Execute() (*FederationIdentityProvider, *http.Response, error) {
-	return r.ApiService.updateIdentityProviderExecute(r)
+	return r.ApiService.UpdateIdentityProviderExecute(r)
 }
 
 /*
@@ -2123,7 +2123,7 @@ func (a *FederatedAuthenticationApiService) UpdateIdentityProvider(ctx context.C
 // Execute executes the request
 //
 //	@return FederationIdentityProvider
-func (a *FederatedAuthenticationApiService) updateIdentityProviderExecute(r UpdateIdentityProviderApiRequest) (*FederationIdentityProvider, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) UpdateIdentityProviderExecute(r UpdateIdentityProviderApiRequest) (*FederationIdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -2239,7 +2239,7 @@ func (a *FederatedAuthenticationApiService) UpdateRoleMappingWithParams(ctx cont
 }
 
 func (r UpdateRoleMappingApiRequest) Execute() (*AuthFederationRoleMapping, *http.Response, error) {
-	return r.ApiService.updateRoleMappingExecute(r)
+	return r.ApiService.UpdateRoleMappingExecute(r)
 }
 
 /*
@@ -2267,7 +2267,7 @@ func (a *FederatedAuthenticationApiService) UpdateRoleMapping(ctx context.Contex
 // Execute executes the request
 //
 //	@return AuthFederationRoleMapping
-func (a *FederatedAuthenticationApiService) updateRoleMappingExecute(r UpdateRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) UpdateRoleMappingExecute(r UpdateRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
 		localVarPostBody    interface{}

--- a/admin/api_global_clusters.go
+++ b/admin/api_global_clusters.go
@@ -34,7 +34,7 @@ type GlobalClustersApi interface {
 	*/
 	CreateCustomZoneMappingWithParams(ctx context.Context, args *CreateCustomZoneMappingApiParams) CreateCustomZoneMappingApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateCustomZoneMappingExecute(r CreateCustomZoneMappingApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
@@ -58,7 +58,7 @@ type GlobalClustersApi interface {
 	*/
 	CreateManagedNamespaceWithParams(ctx context.Context, args *CreateManagedNamespaceApiParams) CreateManagedNamespaceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateManagedNamespaceExecute(r CreateManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
@@ -82,7 +82,7 @@ type GlobalClustersApi interface {
 	*/
 	DeleteAllCustomZoneMappingsWithParams(ctx context.Context, args *DeleteAllCustomZoneMappingsApiParams) DeleteAllCustomZoneMappingsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteAllCustomZoneMappingsExecute(r DeleteAllCustomZoneMappingsApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
@@ -106,7 +106,7 @@ type GlobalClustersApi interface {
 	*/
 	DeleteManagedNamespaceWithParams(ctx context.Context, args *DeleteManagedNamespaceApiParams) DeleteManagedNamespaceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteManagedNamespaceExecute(r DeleteManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
@@ -130,7 +130,7 @@ type GlobalClustersApi interface {
 	*/
 	GetManagedNamespaceWithParams(ctx context.Context, args *GetManagedNamespaceApiParams) GetManagedNamespaceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetManagedNamespaceExecute(r GetManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
 }
 

--- a/admin/api_global_clusters.go
+++ b/admin/api_global_clusters.go
@@ -35,7 +35,7 @@ type GlobalClustersApi interface {
 	CreateCustomZoneMappingWithParams(ctx context.Context, args *CreateCustomZoneMappingApiParams) CreateCustomZoneMappingApiRequest
 
 	// Interface only available internally
-	createCustomZoneMappingExecute(r CreateCustomZoneMappingApiRequest) (*GeoSharding, *http.Response, error)
+	CreateCustomZoneMappingExecute(r CreateCustomZoneMappingApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
 		CreateManagedNamespace Create One Managed Namespace in One Global Multi-Cloud Cluster
@@ -59,7 +59,7 @@ type GlobalClustersApi interface {
 	CreateManagedNamespaceWithParams(ctx context.Context, args *CreateManagedNamespaceApiParams) CreateManagedNamespaceApiRequest
 
 	// Interface only available internally
-	createManagedNamespaceExecute(r CreateManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
+	CreateManagedNamespaceExecute(r CreateManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
 		DeleteAllCustomZoneMappings Remove All Custom Zone Mappings from One Global Multi-Cloud Cluster
@@ -83,7 +83,7 @@ type GlobalClustersApi interface {
 	DeleteAllCustomZoneMappingsWithParams(ctx context.Context, args *DeleteAllCustomZoneMappingsApiParams) DeleteAllCustomZoneMappingsApiRequest
 
 	// Interface only available internally
-	deleteAllCustomZoneMappingsExecute(r DeleteAllCustomZoneMappingsApiRequest) (*GeoSharding, *http.Response, error)
+	DeleteAllCustomZoneMappingsExecute(r DeleteAllCustomZoneMappingsApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
 		DeleteManagedNamespace Remove One Managed Namespace from One Global Multi-Cloud Cluster
@@ -107,7 +107,7 @@ type GlobalClustersApi interface {
 	DeleteManagedNamespaceWithParams(ctx context.Context, args *DeleteManagedNamespaceApiParams) DeleteManagedNamespaceApiRequest
 
 	// Interface only available internally
-	deleteManagedNamespaceExecute(r DeleteManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
+	DeleteManagedNamespaceExecute(r DeleteManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
 		GetManagedNamespace Return One Managed Namespace in One Global Multi-Cloud Cluster
@@ -131,7 +131,7 @@ type GlobalClustersApi interface {
 	GetManagedNamespaceWithParams(ctx context.Context, args *GetManagedNamespaceApiParams) GetManagedNamespaceApiRequest
 
 	// Interface only available internally
-	getManagedNamespaceExecute(r GetManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
+	GetManagedNamespaceExecute(r GetManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
 }
 
 // GlobalClustersApiService GlobalClustersApi service
@@ -162,7 +162,7 @@ func (a *GlobalClustersApiService) CreateCustomZoneMappingWithParams(ctx context
 }
 
 func (r CreateCustomZoneMappingApiRequest) Execute() (*GeoSharding, *http.Response, error) {
-	return r.ApiService.createCustomZoneMappingExecute(r)
+	return r.ApiService.CreateCustomZoneMappingExecute(r)
 }
 
 /*
@@ -188,7 +188,7 @@ func (a *GlobalClustersApiService) CreateCustomZoneMapping(ctx context.Context, 
 // Execute executes the request
 //
 //	@return GeoSharding
-func (a *GlobalClustersApiService) createCustomZoneMappingExecute(r CreateCustomZoneMappingApiRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) CreateCustomZoneMappingExecute(r CreateCustomZoneMappingApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -301,7 +301,7 @@ func (a *GlobalClustersApiService) CreateManagedNamespaceWithParams(ctx context.
 }
 
 func (r CreateManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Response, error) {
-	return r.ApiService.createManagedNamespaceExecute(r)
+	return r.ApiService.CreateManagedNamespaceExecute(r)
 }
 
 /*
@@ -327,7 +327,7 @@ func (a *GlobalClustersApiService) CreateManagedNamespace(ctx context.Context, g
 // Execute executes the request
 //
 //	@return GeoSharding
-func (a *GlobalClustersApiService) createManagedNamespaceExecute(r CreateManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) CreateManagedNamespaceExecute(r CreateManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -437,7 +437,7 @@ func (a *GlobalClustersApiService) DeleteAllCustomZoneMappingsWithParams(ctx con
 }
 
 func (r DeleteAllCustomZoneMappingsApiRequest) Execute() (*GeoSharding, *http.Response, error) {
-	return r.ApiService.deleteAllCustomZoneMappingsExecute(r)
+	return r.ApiService.DeleteAllCustomZoneMappingsExecute(r)
 }
 
 /*
@@ -462,7 +462,7 @@ func (a *GlobalClustersApiService) DeleteAllCustomZoneMappings(ctx context.Conte
 // Execute executes the request
 //
 //	@return GeoSharding
-func (a *GlobalClustersApiService) deleteAllCustomZoneMappingsExecute(r DeleteAllCustomZoneMappingsApiRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) DeleteAllCustomZoneMappingsExecute(r DeleteAllCustomZoneMappingsApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -585,7 +585,7 @@ func (r DeleteManagedNamespaceApiRequest) Collection(collection string) DeleteMa
 }
 
 func (r DeleteManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Response, error) {
-	return r.ApiService.deleteManagedNamespaceExecute(r)
+	return r.ApiService.DeleteManagedNamespaceExecute(r)
 }
 
 /*
@@ -610,7 +610,7 @@ func (a *GlobalClustersApiService) DeleteManagedNamespace(ctx context.Context, c
 // Execute executes the request
 //
 //	@return GeoSharding
-func (a *GlobalClustersApiService) deleteManagedNamespaceExecute(r DeleteManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) DeleteManagedNamespaceExecute(r DeleteManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -721,7 +721,7 @@ func (a *GlobalClustersApiService) GetManagedNamespaceWithParams(ctx context.Con
 }
 
 func (r GetManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Response, error) {
-	return r.ApiService.getManagedNamespaceExecute(r)
+	return r.ApiService.GetManagedNamespaceExecute(r)
 }
 
 /*
@@ -746,7 +746,7 @@ func (a *GlobalClustersApiService) GetManagedNamespace(ctx context.Context, grou
 // Execute executes the request
 //
 //	@return GeoSharding
-func (a *GlobalClustersApiService) getManagedNamespaceExecute(r GetManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) GetManagedNamespaceExecute(r GetManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_invoices.go
+++ b/admin/api_invoices.go
@@ -33,7 +33,7 @@ type InvoicesApi interface {
 	*/
 	CreateCostExplorerQueryProcessWithParams(ctx context.Context, args *CreateCostExplorerQueryProcessApiParams) CreateCostExplorerQueryProcessApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateCostExplorerQueryProcessExecute(r CreateCostExplorerQueryProcessApiRequest) (*CostExplorerFilterResponse, *http.Response, error)
 
 	/*
@@ -57,7 +57,7 @@ type InvoicesApi interface {
 	*/
 	CreateCostExplorerQueryProcess1WithParams(ctx context.Context, args *CreateCostExplorerQueryProcess1ApiParams) CreateCostExplorerQueryProcess1ApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateCostExplorerQueryProcess1Execute(r CreateCostExplorerQueryProcess1ApiRequest) (string, *http.Response, error)
 
 	/*
@@ -81,7 +81,7 @@ type InvoicesApi interface {
 	*/
 	DownloadInvoiceCSVWithParams(ctx context.Context, args *DownloadInvoiceCSVApiParams) DownloadInvoiceCSVApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DownloadInvoiceCSVExecute(r DownloadInvoiceCSVApiRequest) (string, *http.Response, error)
 
 	/*
@@ -105,7 +105,7 @@ type InvoicesApi interface {
 	*/
 	GetInvoiceWithParams(ctx context.Context, args *GetInvoiceApiParams) GetInvoiceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetInvoiceExecute(r GetInvoiceApiRequest) (string, *http.Response, error)
 
 	/*
@@ -128,7 +128,7 @@ type InvoicesApi interface {
 	*/
 	ListInvoicesWithParams(ctx context.Context, args *ListInvoicesApiParams) ListInvoicesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListInvoicesExecute(r ListInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error)
 
 	/*
@@ -151,7 +151,7 @@ type InvoicesApi interface {
 	*/
 	ListPendingInvoicesWithParams(ctx context.Context, args *ListPendingInvoicesApiParams) ListPendingInvoicesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListPendingInvoicesExecute(r ListPendingInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error)
 }
 

--- a/admin/api_invoices.go
+++ b/admin/api_invoices.go
@@ -34,7 +34,7 @@ type InvoicesApi interface {
 	CreateCostExplorerQueryProcessWithParams(ctx context.Context, args *CreateCostExplorerQueryProcessApiParams) CreateCostExplorerQueryProcessApiRequest
 
 	// Interface only available internally
-	createCostExplorerQueryProcessExecute(r CreateCostExplorerQueryProcessApiRequest) (*CostExplorerFilterResponse, *http.Response, error)
+	CreateCostExplorerQueryProcessExecute(r CreateCostExplorerQueryProcessApiRequest) (*CostExplorerFilterResponse, *http.Response, error)
 
 	/*
 		CreateCostExplorerQueryProcess1 Return results from a given Cost Explorer query, or notify that the results are not ready yet.
@@ -58,7 +58,7 @@ type InvoicesApi interface {
 	CreateCostExplorerQueryProcess1WithParams(ctx context.Context, args *CreateCostExplorerQueryProcess1ApiParams) CreateCostExplorerQueryProcess1ApiRequest
 
 	// Interface only available internally
-	createCostExplorerQueryProcess1Execute(r CreateCostExplorerQueryProcess1ApiRequest) (string, *http.Response, error)
+	CreateCostExplorerQueryProcess1Execute(r CreateCostExplorerQueryProcess1ApiRequest) (string, *http.Response, error)
 
 	/*
 		DownloadInvoiceCSV Return One Organization Invoice as CSV
@@ -82,7 +82,7 @@ type InvoicesApi interface {
 	DownloadInvoiceCSVWithParams(ctx context.Context, args *DownloadInvoiceCSVApiParams) DownloadInvoiceCSVApiRequest
 
 	// Interface only available internally
-	downloadInvoiceCSVExecute(r DownloadInvoiceCSVApiRequest) (string, *http.Response, error)
+	DownloadInvoiceCSVExecute(r DownloadInvoiceCSVApiRequest) (string, *http.Response, error)
 
 	/*
 		GetInvoice Return One Organization Invoice
@@ -106,7 +106,7 @@ type InvoicesApi interface {
 	GetInvoiceWithParams(ctx context.Context, args *GetInvoiceApiParams) GetInvoiceApiRequest
 
 	// Interface only available internally
-	getInvoiceExecute(r GetInvoiceApiRequest) (string, *http.Response, error)
+	GetInvoiceExecute(r GetInvoiceApiRequest) (string, *http.Response, error)
 
 	/*
 		ListInvoices Return All Invoices for One Organization
@@ -129,7 +129,7 @@ type InvoicesApi interface {
 	ListInvoicesWithParams(ctx context.Context, args *ListInvoicesApiParams) ListInvoicesApiRequest
 
 	// Interface only available internally
-	listInvoicesExecute(r ListInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error)
+	ListInvoicesExecute(r ListInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error)
 
 	/*
 		ListPendingInvoices Return All Pending Invoices for One Organization
@@ -152,7 +152,7 @@ type InvoicesApi interface {
 	ListPendingInvoicesWithParams(ctx context.Context, args *ListPendingInvoicesApiParams) ListPendingInvoicesApiRequest
 
 	// Interface only available internally
-	listPendingInvoicesExecute(r ListPendingInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error)
+	ListPendingInvoicesExecute(r ListPendingInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error)
 }
 
 // InvoicesApiService InvoicesApi service
@@ -180,7 +180,7 @@ func (a *InvoicesApiService) CreateCostExplorerQueryProcessWithParams(ctx contex
 }
 
 func (r CreateCostExplorerQueryProcessApiRequest) Execute() (*CostExplorerFilterResponse, *http.Response, error) {
-	return r.ApiService.createCostExplorerQueryProcessExecute(r)
+	return r.ApiService.CreateCostExplorerQueryProcessExecute(r)
 }
 
 /*
@@ -204,7 +204,7 @@ func (a *InvoicesApiService) CreateCostExplorerQueryProcess(ctx context.Context,
 // Execute executes the request
 //
 //	@return CostExplorerFilterResponse
-func (a *InvoicesApiService) createCostExplorerQueryProcessExecute(r CreateCostExplorerQueryProcessApiRequest) (*CostExplorerFilterResponse, *http.Response, error) {
+func (a *InvoicesApiService) CreateCostExplorerQueryProcessExecute(r CreateCostExplorerQueryProcessApiRequest) (*CostExplorerFilterResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -313,7 +313,7 @@ func (a *InvoicesApiService) CreateCostExplorerQueryProcess1WithParams(ctx conte
 }
 
 func (r CreateCostExplorerQueryProcess1ApiRequest) Execute() (string, *http.Response, error) {
-	return r.ApiService.createCostExplorerQueryProcess1Execute(r)
+	return r.ApiService.CreateCostExplorerQueryProcess1Execute(r)
 }
 
 /*
@@ -338,7 +338,7 @@ func (a *InvoicesApiService) CreateCostExplorerQueryProcess1(ctx context.Context
 // Execute executes the request
 //
 //	@return string
-func (a *InvoicesApiService) createCostExplorerQueryProcess1Execute(r CreateCostExplorerQueryProcess1ApiRequest) (string, *http.Response, error) {
+func (a *InvoicesApiService) CreateCostExplorerQueryProcess1Execute(r CreateCostExplorerQueryProcess1ApiRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -443,7 +443,7 @@ func (a *InvoicesApiService) DownloadInvoiceCSVWithParams(ctx context.Context, a
 }
 
 func (r DownloadInvoiceCSVApiRequest) Execute() (string, *http.Response, error) {
-	return r.ApiService.downloadInvoiceCSVExecute(r)
+	return r.ApiService.DownloadInvoiceCSVExecute(r)
 }
 
 /*
@@ -468,7 +468,7 @@ func (a *InvoicesApiService) DownloadInvoiceCSV(ctx context.Context, orgId strin
 // Execute executes the request
 //
 //	@return string
-func (a *InvoicesApiService) downloadInvoiceCSVExecute(r DownloadInvoiceCSVApiRequest) (string, *http.Response, error) {
+func (a *InvoicesApiService) DownloadInvoiceCSVExecute(r DownloadInvoiceCSVApiRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -573,7 +573,7 @@ func (a *InvoicesApiService) GetInvoiceWithParams(ctx context.Context, args *Get
 }
 
 func (r GetInvoiceApiRequest) Execute() (string, *http.Response, error) {
-	return r.ApiService.getInvoiceExecute(r)
+	return r.ApiService.GetInvoiceExecute(r)
 }
 
 /*
@@ -598,7 +598,7 @@ func (a *InvoicesApiService) GetInvoice(ctx context.Context, orgId string, invoi
 // Execute executes the request
 //
 //	@return string
-func (a *InvoicesApiService) getInvoiceExecute(r GetInvoiceApiRequest) (string, *http.Response, error) {
+func (a *InvoicesApiService) GetInvoiceExecute(r GetInvoiceApiRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -727,7 +727,7 @@ func (r ListInvoicesApiRequest) PageNum(pageNum int) ListInvoicesApiRequest {
 }
 
 func (r ListInvoicesApiRequest) Execute() (*PaginatedApiInvoice, *http.Response, error) {
-	return r.ApiService.listInvoicesExecute(r)
+	return r.ApiService.ListInvoicesExecute(r)
 }
 
 /*
@@ -750,7 +750,7 @@ func (a *InvoicesApiService) ListInvoices(ctx context.Context, orgId string) Lis
 // Execute executes the request
 //
 //	@return PaginatedApiInvoice
-func (a *InvoicesApiService) listInvoicesExecute(r ListInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error) {
+func (a *InvoicesApiService) ListInvoicesExecute(r ListInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -872,7 +872,7 @@ func (a *InvoicesApiService) ListPendingInvoicesWithParams(ctx context.Context, 
 }
 
 func (r ListPendingInvoicesApiRequest) Execute() (*PaginatedApiInvoice, *http.Response, error) {
-	return r.ApiService.listPendingInvoicesExecute(r)
+	return r.ApiService.ListPendingInvoicesExecute(r)
 }
 
 /*
@@ -895,7 +895,7 @@ func (a *InvoicesApiService) ListPendingInvoices(ctx context.Context, orgId stri
 // Execute executes the request
 //
 //	@return PaginatedApiInvoice
-func (a *InvoicesApiService) listPendingInvoicesExecute(r ListPendingInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error) {
+func (a *InvoicesApiService) ListPendingInvoicesExecute(r ListPendingInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_ldap_configuration.go
+++ b/admin/api_ldap_configuration.go
@@ -33,7 +33,7 @@ type LDAPConfigurationApi interface {
 	*/
 	DeleteLDAPConfigurationWithParams(ctx context.Context, args *DeleteLDAPConfigurationApiParams) DeleteLDAPConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteLDAPConfigurationExecute(r DeleteLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
@@ -56,7 +56,7 @@ type LDAPConfigurationApi interface {
 	*/
 	GetLDAPConfigurationWithParams(ctx context.Context, args *GetLDAPConfigurationApiParams) GetLDAPConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetLDAPConfigurationExecute(r GetLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
@@ -80,7 +80,7 @@ type LDAPConfigurationApi interface {
 	*/
 	GetLDAPConfigurationStatusWithParams(ctx context.Context, args *GetLDAPConfigurationStatusApiParams) GetLDAPConfigurationStatusApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetLDAPConfigurationStatusExecute(r GetLDAPConfigurationStatusApiRequest) (*LDAPVerifyConnectivityJobRequest, *http.Response, error)
 
 	/*
@@ -105,7 +105,7 @@ type LDAPConfigurationApi interface {
 	*/
 	SaveLDAPConfigurationWithParams(ctx context.Context, args *SaveLDAPConfigurationApiParams) SaveLDAPConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	SaveLDAPConfigurationExecute(r SaveLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
@@ -128,7 +128,7 @@ type LDAPConfigurationApi interface {
 	*/
 	VerifyLDAPConfigurationWithParams(ctx context.Context, args *VerifyLDAPConfigurationApiParams) VerifyLDAPConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	VerifyLDAPConfigurationExecute(r VerifyLDAPConfigurationApiRequest) (*LDAPVerifyConnectivityJobRequest, *http.Response, error)
 }
 

--- a/admin/api_ldap_configuration.go
+++ b/admin/api_ldap_configuration.go
@@ -34,7 +34,7 @@ type LDAPConfigurationApi interface {
 	DeleteLDAPConfigurationWithParams(ctx context.Context, args *DeleteLDAPConfigurationApiParams) DeleteLDAPConfigurationApiRequest
 
 	// Interface only available internally
-	deleteLDAPConfigurationExecute(r DeleteLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
+	DeleteLDAPConfigurationExecute(r DeleteLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
 		GetLDAPConfiguration Return the Current LDAP or X.509 Configuration
@@ -57,7 +57,7 @@ type LDAPConfigurationApi interface {
 	GetLDAPConfigurationWithParams(ctx context.Context, args *GetLDAPConfigurationApiParams) GetLDAPConfigurationApiRequest
 
 	// Interface only available internally
-	getLDAPConfigurationExecute(r GetLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
+	GetLDAPConfigurationExecute(r GetLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
 		GetLDAPConfigurationStatus Return the Status of One Verify LDAP Configuration Request
@@ -81,7 +81,7 @@ type LDAPConfigurationApi interface {
 	GetLDAPConfigurationStatusWithParams(ctx context.Context, args *GetLDAPConfigurationStatusApiParams) GetLDAPConfigurationStatusApiRequest
 
 	// Interface only available internally
-	getLDAPConfigurationStatusExecute(r GetLDAPConfigurationStatusApiRequest) (*LDAPVerifyConnectivityJobRequest, *http.Response, error)
+	GetLDAPConfigurationStatusExecute(r GetLDAPConfigurationStatusApiRequest) (*LDAPVerifyConnectivityJobRequest, *http.Response, error)
 
 	/*
 		SaveLDAPConfiguration Edit the LDAP or X.509 Configuration
@@ -106,7 +106,7 @@ type LDAPConfigurationApi interface {
 	SaveLDAPConfigurationWithParams(ctx context.Context, args *SaveLDAPConfigurationApiParams) SaveLDAPConfigurationApiRequest
 
 	// Interface only available internally
-	saveLDAPConfigurationExecute(r SaveLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
+	SaveLDAPConfigurationExecute(r SaveLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
 		VerifyLDAPConfiguration Verify the LDAP Configuration in One Project
@@ -129,7 +129,7 @@ type LDAPConfigurationApi interface {
 	VerifyLDAPConfigurationWithParams(ctx context.Context, args *VerifyLDAPConfigurationApiParams) VerifyLDAPConfigurationApiRequest
 
 	// Interface only available internally
-	verifyLDAPConfigurationExecute(r VerifyLDAPConfigurationApiRequest) (*LDAPVerifyConnectivityJobRequest, *http.Response, error)
+	VerifyLDAPConfigurationExecute(r VerifyLDAPConfigurationApiRequest) (*LDAPVerifyConnectivityJobRequest, *http.Response, error)
 }
 
 // LDAPConfigurationApiService LDAPConfigurationApi service
@@ -154,7 +154,7 @@ func (a *LDAPConfigurationApiService) DeleteLDAPConfigurationWithParams(ctx cont
 }
 
 func (r DeleteLDAPConfigurationApiRequest) Execute() (*UserSecurity, *http.Response, error) {
-	return r.ApiService.deleteLDAPConfigurationExecute(r)
+	return r.ApiService.DeleteLDAPConfigurationExecute(r)
 }
 
 /*
@@ -177,7 +177,7 @@ func (a *LDAPConfigurationApiService) DeleteLDAPConfiguration(ctx context.Contex
 // Execute executes the request
 //
 //	@return UserSecurity
-func (a *LDAPConfigurationApiService) deleteLDAPConfigurationExecute(r DeleteLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
+func (a *LDAPConfigurationApiService) DeleteLDAPConfigurationExecute(r DeleteLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -278,7 +278,7 @@ func (a *LDAPConfigurationApiService) GetLDAPConfigurationWithParams(ctx context
 }
 
 func (r GetLDAPConfigurationApiRequest) Execute() (*UserSecurity, *http.Response, error) {
-	return r.ApiService.getLDAPConfigurationExecute(r)
+	return r.ApiService.GetLDAPConfigurationExecute(r)
 }
 
 /*
@@ -301,7 +301,7 @@ func (a *LDAPConfigurationApiService) GetLDAPConfiguration(ctx context.Context, 
 // Execute executes the request
 //
 //	@return UserSecurity
-func (a *LDAPConfigurationApiService) getLDAPConfigurationExecute(r GetLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
+func (a *LDAPConfigurationApiService) GetLDAPConfigurationExecute(r GetLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -405,7 +405,7 @@ func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatusWithParams(ctx c
 }
 
 func (r GetLDAPConfigurationStatusApiRequest) Execute() (*LDAPVerifyConnectivityJobRequest, *http.Response, error) {
-	return r.ApiService.getLDAPConfigurationStatusExecute(r)
+	return r.ApiService.GetLDAPConfigurationStatusExecute(r)
 }
 
 /*
@@ -430,7 +430,7 @@ func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatus(ctx context.Con
 // Execute executes the request
 //
 //	@return LDAPVerifyConnectivityJobRequest
-func (a *LDAPConfigurationApiService) getLDAPConfigurationStatusExecute(r GetLDAPConfigurationStatusApiRequest) (*LDAPVerifyConnectivityJobRequest, *http.Response, error) {
+func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatusExecute(r GetLDAPConfigurationStatusApiRequest) (*LDAPVerifyConnectivityJobRequest, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -535,7 +535,7 @@ func (a *LDAPConfigurationApiService) SaveLDAPConfigurationWithParams(ctx contex
 }
 
 func (r SaveLDAPConfigurationApiRequest) Execute() (*UserSecurity, *http.Response, error) {
-	return r.ApiService.saveLDAPConfigurationExecute(r)
+	return r.ApiService.SaveLDAPConfigurationExecute(r)
 }
 
 /*
@@ -561,7 +561,7 @@ func (a *LDAPConfigurationApiService) SaveLDAPConfiguration(ctx context.Context,
 // Execute executes the request
 //
 //	@return UserSecurity
-func (a *LDAPConfigurationApiService) saveLDAPConfigurationExecute(r SaveLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
+func (a *LDAPConfigurationApiService) SaveLDAPConfigurationExecute(r SaveLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -670,7 +670,7 @@ func (a *LDAPConfigurationApiService) VerifyLDAPConfigurationWithParams(ctx cont
 }
 
 func (r VerifyLDAPConfigurationApiRequest) Execute() (*LDAPVerifyConnectivityJobRequest, *http.Response, error) {
-	return r.ApiService.verifyLDAPConfigurationExecute(r)
+	return r.ApiService.VerifyLDAPConfigurationExecute(r)
 }
 
 /*
@@ -694,7 +694,7 @@ func (a *LDAPConfigurationApiService) VerifyLDAPConfiguration(ctx context.Contex
 // Execute executes the request
 //
 //	@return LDAPVerifyConnectivityJobRequest
-func (a *LDAPConfigurationApiService) verifyLDAPConfigurationExecute(r VerifyLDAPConfigurationApiRequest) (*LDAPVerifyConnectivityJobRequest, *http.Response, error) {
+func (a *LDAPConfigurationApiService) VerifyLDAPConfigurationExecute(r VerifyLDAPConfigurationApiRequest) (*LDAPVerifyConnectivityJobRequest, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}

--- a/admin/api_legacy_backup.go
+++ b/admin/api_legacy_backup.go
@@ -40,7 +40,7 @@ type LegacyBackupApi interface {
 	DeleteLegacySnapshotWithParams(ctx context.Context, args *DeleteLegacySnapshotApiParams) DeleteLegacySnapshotApiRequest
 
 	// Interface only available internally
-	deleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetLegacyBackupCheckpoint Return One Legacy Backup Checkpoint
@@ -69,7 +69,7 @@ type LegacyBackupApi interface {
 	GetLegacyBackupCheckpointWithParams(ctx context.Context, args *GetLegacyBackupCheckpointApiParams) GetLegacyBackupCheckpointApiRequest
 
 	// Interface only available internally
-	getLegacyBackupCheckpointExecute(r GetLegacyBackupCheckpointApiRequest) (*ApiAtlasCheckpoint, *http.Response, error)
+	GetLegacyBackupCheckpointExecute(r GetLegacyBackupCheckpointApiRequest) (*ApiAtlasCheckpoint, *http.Response, error)
 
 	/*
 		GetLegacyBackupRestoreJob Return One Legacy Backup Restore Job
@@ -100,7 +100,7 @@ type LegacyBackupApi interface {
 	GetLegacyBackupRestoreJobWithParams(ctx context.Context, args *GetLegacyBackupRestoreJobApiParams) GetLegacyBackupRestoreJobApiRequest
 
 	// Interface only available internally
-	getLegacyBackupRestoreJobExecute(r GetLegacyBackupRestoreJobApiRequest) (*BackupRestoreJob, *http.Response, error)
+	GetLegacyBackupRestoreJobExecute(r GetLegacyBackupRestoreJobApiRequest) (*BackupRestoreJob, *http.Response, error)
 
 	/*
 		GetLegacySnapshot Return One Legacy Backup Snapshot
@@ -129,7 +129,7 @@ type LegacyBackupApi interface {
 	GetLegacySnapshotWithParams(ctx context.Context, args *GetLegacySnapshotApiParams) GetLegacySnapshotApiRequest
 
 	// Interface only available internally
-	getLegacySnapshotExecute(r GetLegacySnapshotApiRequest) (*BackupSnapshot, *http.Response, error)
+	GetLegacySnapshotExecute(r GetLegacySnapshotApiRequest) (*BackupSnapshot, *http.Response, error)
 
 	/*
 		GetLegacySnapshotSchedule Return One Snapshot Schedule
@@ -159,7 +159,7 @@ type LegacyBackupApi interface {
 	GetLegacySnapshotScheduleWithParams(ctx context.Context, args *GetLegacySnapshotScheduleApiParams) GetLegacySnapshotScheduleApiRequest
 
 	// Interface only available internally
-	getLegacySnapshotScheduleExecute(r GetLegacySnapshotScheduleApiRequest) (*ApiAtlasSnapshotSchedule, *http.Response, error)
+	GetLegacySnapshotScheduleExecute(r GetLegacySnapshotScheduleApiRequest) (*ApiAtlasSnapshotSchedule, *http.Response, error)
 
 	/*
 		ListLegacyBackupCheckpoints Return All Legacy Backup Checkpoints
@@ -187,7 +187,7 @@ type LegacyBackupApi interface {
 	ListLegacyBackupCheckpointsWithParams(ctx context.Context, args *ListLegacyBackupCheckpointsApiParams) ListLegacyBackupCheckpointsApiRequest
 
 	// Interface only available internally
-	listLegacyBackupCheckpointsExecute(r ListLegacyBackupCheckpointsApiRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error)
+	ListLegacyBackupCheckpointsExecute(r ListLegacyBackupCheckpointsApiRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error)
 
 	/*
 		ListLegacyBackupRestoreJobs Return All Legacy Backup Restore Jobs
@@ -217,7 +217,7 @@ type LegacyBackupApi interface {
 	ListLegacyBackupRestoreJobsWithParams(ctx context.Context, args *ListLegacyBackupRestoreJobsApiParams) ListLegacyBackupRestoreJobsApiRequest
 
 	// Interface only available internally
-	listLegacyBackupRestoreJobsExecute(r ListLegacyBackupRestoreJobsApiRequest) (*PaginatedRestoreJob, *http.Response, error)
+	ListLegacyBackupRestoreJobsExecute(r ListLegacyBackupRestoreJobsApiRequest) (*PaginatedRestoreJob, *http.Response, error)
 
 	/*
 		ListLegacySnapshots Return All Legacy Backup Snapshots
@@ -245,7 +245,7 @@ type LegacyBackupApi interface {
 	ListLegacySnapshotsWithParams(ctx context.Context, args *ListLegacySnapshotsApiParams) ListLegacySnapshotsApiRequest
 
 	// Interface only available internally
-	listLegacySnapshotsExecute(r ListLegacySnapshotsApiRequest) (*PaginatedSnapshot, *http.Response, error)
+	ListLegacySnapshotsExecute(r ListLegacySnapshotsApiRequest) (*PaginatedSnapshot, *http.Response, error)
 
 	/*
 		UpdateLegacySnapshotRetention Change One Legacy Backup Snapshot Expiration
@@ -274,7 +274,7 @@ type LegacyBackupApi interface {
 	UpdateLegacySnapshotRetentionWithParams(ctx context.Context, args *UpdateLegacySnapshotRetentionApiParams) UpdateLegacySnapshotRetentionApiRequest
 
 	// Interface only available internally
-	updateLegacySnapshotRetentionExecute(r UpdateLegacySnapshotRetentionApiRequest) (*BackupSnapshot, *http.Response, error)
+	UpdateLegacySnapshotRetentionExecute(r UpdateLegacySnapshotRetentionApiRequest) (*BackupSnapshot, *http.Response, error)
 
 	/*
 		UpdateLegacySnapshotSchedule Update Snapshot Schedule for One Cluster
@@ -304,7 +304,7 @@ type LegacyBackupApi interface {
 	UpdateLegacySnapshotScheduleWithParams(ctx context.Context, args *UpdateLegacySnapshotScheduleApiParams) UpdateLegacySnapshotScheduleApiRequest
 
 	// Interface only available internally
-	updateLegacySnapshotScheduleExecute(r UpdateLegacySnapshotScheduleApiRequest) (*ApiAtlasSnapshotSchedule, *http.Response, error)
+	UpdateLegacySnapshotScheduleExecute(r UpdateLegacySnapshotScheduleApiRequest) (*ApiAtlasSnapshotSchedule, *http.Response, error)
 }
 
 // LegacyBackupApiService LegacyBackupApi service
@@ -335,7 +335,7 @@ func (a *LegacyBackupApiService) DeleteLegacySnapshotWithParams(ctx context.Cont
 }
 
 func (r DeleteLegacySnapshotApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteLegacySnapshotExecute(r)
+	return r.ApiService.DeleteLegacySnapshotExecute(r)
 }
 
 /*
@@ -366,7 +366,7 @@ func (a *LegacyBackupApiService) DeleteLegacySnapshot(ctx context.Context, group
 //	@return map[string]interface{}
 //
 // Deprecated
-func (a *LegacyBackupApiService) deleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *LegacyBackupApiService) DeleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -475,7 +475,7 @@ func (a *LegacyBackupApiService) GetLegacyBackupCheckpointWithParams(ctx context
 }
 
 func (r GetLegacyBackupCheckpointApiRequest) Execute() (*ApiAtlasCheckpoint, *http.Response, error) {
-	return r.ApiService.getLegacyBackupCheckpointExecute(r)
+	return r.ApiService.GetLegacyBackupCheckpointExecute(r)
 }
 
 /*
@@ -506,7 +506,7 @@ func (a *LegacyBackupApiService) GetLegacyBackupCheckpoint(ctx context.Context, 
 //	@return ApiAtlasCheckpoint
 //
 // Deprecated
-func (a *LegacyBackupApiService) getLegacyBackupCheckpointExecute(r GetLegacyBackupCheckpointApiRequest) (*ApiAtlasCheckpoint, *http.Response, error) {
+func (a *LegacyBackupApiService) GetLegacyBackupCheckpointExecute(r GetLegacyBackupCheckpointApiRequest) (*ApiAtlasCheckpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -615,7 +615,7 @@ func (a *LegacyBackupApiService) GetLegacyBackupRestoreJobWithParams(ctx context
 }
 
 func (r GetLegacyBackupRestoreJobApiRequest) Execute() (*BackupRestoreJob, *http.Response, error) {
-	return r.ApiService.getLegacyBackupRestoreJobExecute(r)
+	return r.ApiService.GetLegacyBackupRestoreJobExecute(r)
 }
 
 /*
@@ -648,7 +648,7 @@ func (a *LegacyBackupApiService) GetLegacyBackupRestoreJob(ctx context.Context, 
 //	@return BackupRestoreJob
 //
 // Deprecated
-func (a *LegacyBackupApiService) getLegacyBackupRestoreJobExecute(r GetLegacyBackupRestoreJobApiRequest) (*BackupRestoreJob, *http.Response, error) {
+func (a *LegacyBackupApiService) GetLegacyBackupRestoreJobExecute(r GetLegacyBackupRestoreJobApiRequest) (*BackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -757,7 +757,7 @@ func (a *LegacyBackupApiService) GetLegacySnapshotWithParams(ctx context.Context
 }
 
 func (r GetLegacySnapshotApiRequest) Execute() (*BackupSnapshot, *http.Response, error) {
-	return r.ApiService.getLegacySnapshotExecute(r)
+	return r.ApiService.GetLegacySnapshotExecute(r)
 }
 
 /*
@@ -788,7 +788,7 @@ func (a *LegacyBackupApiService) GetLegacySnapshot(ctx context.Context, groupId 
 //	@return BackupSnapshot
 //
 // Deprecated
-func (a *LegacyBackupApiService) getLegacySnapshotExecute(r GetLegacySnapshotApiRequest) (*BackupSnapshot, *http.Response, error) {
+func (a *LegacyBackupApiService) GetLegacySnapshotExecute(r GetLegacySnapshotApiRequest) (*BackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -894,7 +894,7 @@ func (a *LegacyBackupApiService) GetLegacySnapshotScheduleWithParams(ctx context
 }
 
 func (r GetLegacySnapshotScheduleApiRequest) Execute() (*ApiAtlasSnapshotSchedule, *http.Response, error) {
-	return r.ApiService.getLegacySnapshotScheduleExecute(r)
+	return r.ApiService.GetLegacySnapshotScheduleExecute(r)
 }
 
 /*
@@ -925,7 +925,7 @@ func (a *LegacyBackupApiService) GetLegacySnapshotSchedule(ctx context.Context, 
 //	@return ApiAtlasSnapshotSchedule
 //
 // Deprecated
-func (a *LegacyBackupApiService) getLegacySnapshotScheduleExecute(r GetLegacySnapshotScheduleApiRequest) (*ApiAtlasSnapshotSchedule, *http.Response, error) {
+func (a *LegacyBackupApiService) GetLegacySnapshotScheduleExecute(r GetLegacySnapshotScheduleApiRequest) (*ApiAtlasSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1057,7 +1057,7 @@ func (r ListLegacyBackupCheckpointsApiRequest) PageNum(pageNum int) ListLegacyBa
 }
 
 func (r ListLegacyBackupCheckpointsApiRequest) Execute() (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
-	return r.ApiService.listLegacyBackupCheckpointsExecute(r)
+	return r.ApiService.ListLegacyBackupCheckpointsExecute(r)
 }
 
 /*
@@ -1086,7 +1086,7 @@ func (a *LegacyBackupApiService) ListLegacyBackupCheckpoints(ctx context.Context
 //	@return PaginatedApiAtlasCheckpoint
 //
 // Deprecated
-func (a *LegacyBackupApiService) listLegacyBackupCheckpointsExecute(r ListLegacyBackupCheckpointsApiRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
+func (a *LegacyBackupApiService) ListLegacyBackupCheckpointsExecute(r ListLegacyBackupCheckpointsApiRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1248,7 +1248,7 @@ func (r ListLegacyBackupRestoreJobsApiRequest) BatchId(batchId string) ListLegac
 }
 
 func (r ListLegacyBackupRestoreJobsApiRequest) Execute() (*PaginatedRestoreJob, *http.Response, error) {
-	return r.ApiService.listLegacyBackupRestoreJobsExecute(r)
+	return r.ApiService.ListLegacyBackupRestoreJobsExecute(r)
 }
 
 /*
@@ -1279,7 +1279,7 @@ func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobs(ctx context.Context
 //	@return PaginatedRestoreJob
 //
 // Deprecated
-func (a *LegacyBackupApiService) listLegacyBackupRestoreJobsExecute(r ListLegacyBackupRestoreJobsApiRequest) (*PaginatedRestoreJob, *http.Response, error) {
+func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobsExecute(r ListLegacyBackupRestoreJobsApiRequest) (*PaginatedRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1444,7 +1444,7 @@ func (r ListLegacySnapshotsApiRequest) Completed(completed string) ListLegacySna
 }
 
 func (r ListLegacySnapshotsApiRequest) Execute() (*PaginatedSnapshot, *http.Response, error) {
-	return r.ApiService.listLegacySnapshotsExecute(r)
+	return r.ApiService.ListLegacySnapshotsExecute(r)
 }
 
 /*
@@ -1473,7 +1473,7 @@ func (a *LegacyBackupApiService) ListLegacySnapshots(ctx context.Context, groupI
 //	@return PaginatedSnapshot
 //
 // Deprecated
-func (a *LegacyBackupApiService) listLegacySnapshotsExecute(r ListLegacySnapshotsApiRequest) (*PaginatedSnapshot, *http.Response, error) {
+func (a *LegacyBackupApiService) ListLegacySnapshotsExecute(r ListLegacySnapshotsApiRequest) (*PaginatedSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1612,7 +1612,7 @@ func (a *LegacyBackupApiService) UpdateLegacySnapshotRetentionWithParams(ctx con
 }
 
 func (r UpdateLegacySnapshotRetentionApiRequest) Execute() (*BackupSnapshot, *http.Response, error) {
-	return r.ApiService.updateLegacySnapshotRetentionExecute(r)
+	return r.ApiService.UpdateLegacySnapshotRetentionExecute(r)
 }
 
 /*
@@ -1644,7 +1644,7 @@ func (a *LegacyBackupApiService) UpdateLegacySnapshotRetention(ctx context.Conte
 //	@return BackupSnapshot
 //
 // Deprecated
-func (a *LegacyBackupApiService) updateLegacySnapshotRetentionExecute(r UpdateLegacySnapshotRetentionApiRequest) (*BackupSnapshot, *http.Response, error) {
+func (a *LegacyBackupApiService) UpdateLegacySnapshotRetentionExecute(r UpdateLegacySnapshotRetentionApiRequest) (*BackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -1758,7 +1758,7 @@ func (a *LegacyBackupApiService) UpdateLegacySnapshotScheduleWithParams(ctx cont
 }
 
 func (r UpdateLegacySnapshotScheduleApiRequest) Execute() (*ApiAtlasSnapshotSchedule, *http.Response, error) {
-	return r.ApiService.updateLegacySnapshotScheduleExecute(r)
+	return r.ApiService.UpdateLegacySnapshotScheduleExecute(r)
 }
 
 /*
@@ -1790,7 +1790,7 @@ func (a *LegacyBackupApiService) UpdateLegacySnapshotSchedule(ctx context.Contex
 //	@return ApiAtlasSnapshotSchedule
 //
 // Deprecated
-func (a *LegacyBackupApiService) updateLegacySnapshotScheduleExecute(r UpdateLegacySnapshotScheduleApiRequest) (*ApiAtlasSnapshotSchedule, *http.Response, error) {
+func (a *LegacyBackupApiService) UpdateLegacySnapshotScheduleExecute(r UpdateLegacySnapshotScheduleApiRequest) (*ApiAtlasSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_legacy_backup.go
+++ b/admin/api_legacy_backup.go
@@ -39,7 +39,7 @@ type LegacyBackupApi interface {
 	*/
 	DeleteLegacySnapshotWithParams(ctx context.Context, args *DeleteLegacySnapshotApiParams) DeleteLegacySnapshotApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -68,7 +68,7 @@ type LegacyBackupApi interface {
 	*/
 	GetLegacyBackupCheckpointWithParams(ctx context.Context, args *GetLegacyBackupCheckpointApiParams) GetLegacyBackupCheckpointApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetLegacyBackupCheckpointExecute(r GetLegacyBackupCheckpointApiRequest) (*ApiAtlasCheckpoint, *http.Response, error)
 
 	/*
@@ -99,7 +99,7 @@ type LegacyBackupApi interface {
 	*/
 	GetLegacyBackupRestoreJobWithParams(ctx context.Context, args *GetLegacyBackupRestoreJobApiParams) GetLegacyBackupRestoreJobApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetLegacyBackupRestoreJobExecute(r GetLegacyBackupRestoreJobApiRequest) (*BackupRestoreJob, *http.Response, error)
 
 	/*
@@ -128,7 +128,7 @@ type LegacyBackupApi interface {
 	*/
 	GetLegacySnapshotWithParams(ctx context.Context, args *GetLegacySnapshotApiParams) GetLegacySnapshotApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetLegacySnapshotExecute(r GetLegacySnapshotApiRequest) (*BackupSnapshot, *http.Response, error)
 
 	/*
@@ -158,7 +158,7 @@ type LegacyBackupApi interface {
 	*/
 	GetLegacySnapshotScheduleWithParams(ctx context.Context, args *GetLegacySnapshotScheduleApiParams) GetLegacySnapshotScheduleApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetLegacySnapshotScheduleExecute(r GetLegacySnapshotScheduleApiRequest) (*ApiAtlasSnapshotSchedule, *http.Response, error)
 
 	/*
@@ -186,7 +186,7 @@ type LegacyBackupApi interface {
 	*/
 	ListLegacyBackupCheckpointsWithParams(ctx context.Context, args *ListLegacyBackupCheckpointsApiParams) ListLegacyBackupCheckpointsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListLegacyBackupCheckpointsExecute(r ListLegacyBackupCheckpointsApiRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error)
 
 	/*
@@ -216,7 +216,7 @@ type LegacyBackupApi interface {
 	*/
 	ListLegacyBackupRestoreJobsWithParams(ctx context.Context, args *ListLegacyBackupRestoreJobsApiParams) ListLegacyBackupRestoreJobsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListLegacyBackupRestoreJobsExecute(r ListLegacyBackupRestoreJobsApiRequest) (*PaginatedRestoreJob, *http.Response, error)
 
 	/*
@@ -244,7 +244,7 @@ type LegacyBackupApi interface {
 	*/
 	ListLegacySnapshotsWithParams(ctx context.Context, args *ListLegacySnapshotsApiParams) ListLegacySnapshotsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListLegacySnapshotsExecute(r ListLegacySnapshotsApiRequest) (*PaginatedSnapshot, *http.Response, error)
 
 	/*
@@ -273,7 +273,7 @@ type LegacyBackupApi interface {
 	*/
 	UpdateLegacySnapshotRetentionWithParams(ctx context.Context, args *UpdateLegacySnapshotRetentionApiParams) UpdateLegacySnapshotRetentionApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateLegacySnapshotRetentionExecute(r UpdateLegacySnapshotRetentionApiRequest) (*BackupSnapshot, *http.Response, error)
 
 	/*
@@ -303,7 +303,7 @@ type LegacyBackupApi interface {
 	*/
 	UpdateLegacySnapshotScheduleWithParams(ctx context.Context, args *UpdateLegacySnapshotScheduleApiParams) UpdateLegacySnapshotScheduleApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateLegacySnapshotScheduleExecute(r UpdateLegacySnapshotScheduleApiRequest) (*ApiAtlasSnapshotSchedule, *http.Response, error)
 }
 

--- a/admin/api_legacy_backup_restore_jobs.go
+++ b/admin/api_legacy_backup_restore_jobs.go
@@ -38,7 +38,7 @@ type LegacyBackupRestoreJobsApi interface {
 	*/
 	CreateLegacyBackupRestoreJobWithParams(ctx context.Context, args *CreateLegacyBackupRestoreJobApiParams) CreateLegacyBackupRestoreJobApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateLegacyBackupRestoreJobExecute(r CreateLegacyBackupRestoreJobApiRequest) (*PaginatedRestoreJob, *http.Response, error)
 }
 

--- a/admin/api_legacy_backup_restore_jobs.go
+++ b/admin/api_legacy_backup_restore_jobs.go
@@ -39,7 +39,7 @@ type LegacyBackupRestoreJobsApi interface {
 	CreateLegacyBackupRestoreJobWithParams(ctx context.Context, args *CreateLegacyBackupRestoreJobApiParams) CreateLegacyBackupRestoreJobApiRequest
 
 	// Interface only available internally
-	createLegacyBackupRestoreJobExecute(r CreateLegacyBackupRestoreJobApiRequest) (*PaginatedRestoreJob, *http.Response, error)
+	CreateLegacyBackupRestoreJobExecute(r CreateLegacyBackupRestoreJobApiRequest) (*PaginatedRestoreJob, *http.Response, error)
 }
 
 // LegacyBackupRestoreJobsApiService LegacyBackupRestoreJobsApi service
@@ -70,7 +70,7 @@ func (a *LegacyBackupRestoreJobsApiService) CreateLegacyBackupRestoreJobWithPara
 }
 
 func (r CreateLegacyBackupRestoreJobApiRequest) Execute() (*PaginatedRestoreJob, *http.Response, error) {
-	return r.ApiService.createLegacyBackupRestoreJobExecute(r)
+	return r.ApiService.CreateLegacyBackupRestoreJobExecute(r)
 }
 
 /*
@@ -100,7 +100,7 @@ func (a *LegacyBackupRestoreJobsApiService) CreateLegacyBackupRestoreJob(ctx con
 //	@return PaginatedRestoreJob
 //
 // Deprecated
-func (a *LegacyBackupRestoreJobsApiService) createLegacyBackupRestoreJobExecute(r CreateLegacyBackupRestoreJobApiRequest) (*PaginatedRestoreJob, *http.Response, error) {
+func (a *LegacyBackupRestoreJobsApiService) CreateLegacyBackupRestoreJobExecute(r CreateLegacyBackupRestoreJobApiRequest) (*PaginatedRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}

--- a/admin/api_maintenance_windows_.go
+++ b/admin/api_maintenance_windows_.go
@@ -33,7 +33,7 @@ type MaintenanceWindowsApi interface {
 	*/
 	DeferMaintenanceWindowWithParams(ctx context.Context, args *DeferMaintenanceWindowApiParams) DeferMaintenanceWindowApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeferMaintenanceWindowExecute(r DeferMaintenanceWindowApiRequest) (*http.Response, error)
 
 	/*
@@ -56,7 +56,7 @@ type MaintenanceWindowsApi interface {
 	*/
 	GetMaintenanceWindowWithParams(ctx context.Context, args *GetMaintenanceWindowApiParams) GetMaintenanceWindowApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetMaintenanceWindowExecute(r GetMaintenanceWindowApiRequest) (*GroupMaintenanceWindow, *http.Response, error)
 
 	/*
@@ -79,7 +79,7 @@ type MaintenanceWindowsApi interface {
 	*/
 	ResetMaintenanceWindowWithParams(ctx context.Context, args *ResetMaintenanceWindowApiParams) ResetMaintenanceWindowApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ResetMaintenanceWindowExecute(r ResetMaintenanceWindowApiRequest) (*http.Response, error)
 
 	/*
@@ -102,7 +102,7 @@ type MaintenanceWindowsApi interface {
 	*/
 	ToggleMaintenanceAutoDeferWithParams(ctx context.Context, args *ToggleMaintenanceAutoDeferApiParams) ToggleMaintenanceAutoDeferApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ToggleMaintenanceAutoDeferExecute(r ToggleMaintenanceAutoDeferApiRequest) (*http.Response, error)
 
 	/*
@@ -125,7 +125,7 @@ type MaintenanceWindowsApi interface {
 	*/
 	UpdateMaintenanceWindowWithParams(ctx context.Context, args *UpdateMaintenanceWindowApiParams) UpdateMaintenanceWindowApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (map[string]interface{}, *http.Response, error)
 }
 

--- a/admin/api_maintenance_windows_.go
+++ b/admin/api_maintenance_windows_.go
@@ -34,7 +34,7 @@ type MaintenanceWindowsApi interface {
 	DeferMaintenanceWindowWithParams(ctx context.Context, args *DeferMaintenanceWindowApiParams) DeferMaintenanceWindowApiRequest
 
 	// Interface only available internally
-	deferMaintenanceWindowExecute(r DeferMaintenanceWindowApiRequest) (*http.Response, error)
+	DeferMaintenanceWindowExecute(r DeferMaintenanceWindowApiRequest) (*http.Response, error)
 
 	/*
 		GetMaintenanceWindow Return One Maintenance Window for One Project
@@ -57,7 +57,7 @@ type MaintenanceWindowsApi interface {
 	GetMaintenanceWindowWithParams(ctx context.Context, args *GetMaintenanceWindowApiParams) GetMaintenanceWindowApiRequest
 
 	// Interface only available internally
-	getMaintenanceWindowExecute(r GetMaintenanceWindowApiRequest) (*GroupMaintenanceWindow, *http.Response, error)
+	GetMaintenanceWindowExecute(r GetMaintenanceWindowApiRequest) (*GroupMaintenanceWindow, *http.Response, error)
 
 	/*
 		ResetMaintenanceWindow Reset One Maintenance Window for One Project
@@ -80,7 +80,7 @@ type MaintenanceWindowsApi interface {
 	ResetMaintenanceWindowWithParams(ctx context.Context, args *ResetMaintenanceWindowApiParams) ResetMaintenanceWindowApiRequest
 
 	// Interface only available internally
-	resetMaintenanceWindowExecute(r ResetMaintenanceWindowApiRequest) (*http.Response, error)
+	ResetMaintenanceWindowExecute(r ResetMaintenanceWindowApiRequest) (*http.Response, error)
 
 	/*
 		ToggleMaintenanceAutoDefer Toggle Automatic Deferral of Maintenance for One Project
@@ -103,7 +103,7 @@ type MaintenanceWindowsApi interface {
 	ToggleMaintenanceAutoDeferWithParams(ctx context.Context, args *ToggleMaintenanceAutoDeferApiParams) ToggleMaintenanceAutoDeferApiRequest
 
 	// Interface only available internally
-	toggleMaintenanceAutoDeferExecute(r ToggleMaintenanceAutoDeferApiRequest) (*http.Response, error)
+	ToggleMaintenanceAutoDeferExecute(r ToggleMaintenanceAutoDeferApiRequest) (*http.Response, error)
 
 	/*
 		UpdateMaintenanceWindow Update Maintenance Window for One Project
@@ -126,7 +126,7 @@ type MaintenanceWindowsApi interface {
 	UpdateMaintenanceWindowWithParams(ctx context.Context, args *UpdateMaintenanceWindowApiParams) UpdateMaintenanceWindowApiRequest
 
 	// Interface only available internally
-	updateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (map[string]interface{}, *http.Response, error)
+	UpdateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (map[string]interface{}, *http.Response, error)
 }
 
 // MaintenanceWindowsApiService MaintenanceWindowsApi service
@@ -151,7 +151,7 @@ func (a *MaintenanceWindowsApiService) DeferMaintenanceWindowWithParams(ctx cont
 }
 
 func (r DeferMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.deferMaintenanceWindowExecute(r)
+	return r.ApiService.DeferMaintenanceWindowExecute(r)
 }
 
 /*
@@ -172,7 +172,7 @@ func (a *MaintenanceWindowsApiService) DeferMaintenanceWindow(ctx context.Contex
 }
 
 // Execute executes the request
-func (a *MaintenanceWindowsApiService) deferMaintenanceWindowExecute(r DeferMaintenanceWindowApiRequest) (*http.Response, error) {
+func (a *MaintenanceWindowsApiService) DeferMaintenanceWindowExecute(r DeferMaintenanceWindowApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -263,7 +263,7 @@ func (a *MaintenanceWindowsApiService) GetMaintenanceWindowWithParams(ctx contex
 }
 
 func (r GetMaintenanceWindowApiRequest) Execute() (*GroupMaintenanceWindow, *http.Response, error) {
-	return r.ApiService.getMaintenanceWindowExecute(r)
+	return r.ApiService.GetMaintenanceWindowExecute(r)
 }
 
 /*
@@ -286,7 +286,7 @@ func (a *MaintenanceWindowsApiService) GetMaintenanceWindow(ctx context.Context,
 // Execute executes the request
 //
 //	@return GroupMaintenanceWindow
-func (a *MaintenanceWindowsApiService) getMaintenanceWindowExecute(r GetMaintenanceWindowApiRequest) (*GroupMaintenanceWindow, *http.Response, error) {
+func (a *MaintenanceWindowsApiService) GetMaintenanceWindowExecute(r GetMaintenanceWindowApiRequest) (*GroupMaintenanceWindow, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -387,7 +387,7 @@ func (a *MaintenanceWindowsApiService) ResetMaintenanceWindowWithParams(ctx cont
 }
 
 func (r ResetMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.resetMaintenanceWindowExecute(r)
+	return r.ApiService.ResetMaintenanceWindowExecute(r)
 }
 
 /*
@@ -408,7 +408,7 @@ func (a *MaintenanceWindowsApiService) ResetMaintenanceWindow(ctx context.Contex
 }
 
 // Execute executes the request
-func (a *MaintenanceWindowsApiService) resetMaintenanceWindowExecute(r ResetMaintenanceWindowApiRequest) (*http.Response, error) {
+func (a *MaintenanceWindowsApiService) ResetMaintenanceWindowExecute(r ResetMaintenanceWindowApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -499,7 +499,7 @@ func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDeferWithParams(ctx 
 }
 
 func (r ToggleMaintenanceAutoDeferApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.toggleMaintenanceAutoDeferExecute(r)
+	return r.ApiService.ToggleMaintenanceAutoDeferExecute(r)
 }
 
 /*
@@ -520,7 +520,7 @@ func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDefer(ctx context.Co
 }
 
 // Execute executes the request
-func (a *MaintenanceWindowsApiService) toggleMaintenanceAutoDeferExecute(r ToggleMaintenanceAutoDeferApiRequest) (*http.Response, error) {
+func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDeferExecute(r ToggleMaintenanceAutoDeferApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -614,7 +614,7 @@ func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindowWithParams(ctx con
 }
 
 func (r UpdateMaintenanceWindowApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.updateMaintenanceWindowExecute(r)
+	return r.ApiService.UpdateMaintenanceWindowExecute(r)
 }
 
 /*
@@ -638,7 +638,7 @@ func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindow(ctx context.Conte
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *MaintenanceWindowsApiService) updateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_mongo_db_cloud_users.go
+++ b/admin/api_mongo_db_cloud_users.go
@@ -37,7 +37,7 @@ type MongoDBCloudUsersApi interface {
 	CreateUserWithParams(ctx context.Context, args *CreateUserApiParams) CreateUserApiRequest
 
 	// Interface only available internally
-	createUserExecute(r CreateUserApiRequest) (*CloudAppUser, *http.Response, error)
+	CreateUserExecute(r CreateUserApiRequest) (*CloudAppUser, *http.Response, error)
 
 	/*
 		GetUser Return One MongoDB Cloud User using Its ID
@@ -60,7 +60,7 @@ type MongoDBCloudUsersApi interface {
 	GetUserWithParams(ctx context.Context, args *GetUserApiParams) GetUserApiRequest
 
 	// Interface only available internally
-	getUserExecute(r GetUserApiRequest) (*CloudAppUser, *http.Response, error)
+	GetUserExecute(r GetUserApiRequest) (*CloudAppUser, *http.Response, error)
 
 	/*
 		GetUserByUsername Return One MongoDB Cloud User using Their Username
@@ -83,7 +83,7 @@ type MongoDBCloudUsersApi interface {
 	GetUserByUsernameWithParams(ctx context.Context, args *GetUserByUsernameApiParams) GetUserByUsernameApiRequest
 
 	// Interface only available internally
-	getUserByUsernameExecute(r GetUserByUsernameApiRequest) (*CloudAppUser, *http.Response, error)
+	GetUserByUsernameExecute(r GetUserByUsernameApiRequest) (*CloudAppUser, *http.Response, error)
 }
 
 // MongoDBCloudUsersApiService MongoDBCloudUsersApi service
@@ -108,7 +108,7 @@ func (a *MongoDBCloudUsersApiService) CreateUserWithParams(ctx context.Context, 
 }
 
 func (r CreateUserApiRequest) Execute() (*CloudAppUser, *http.Response, error) {
-	return r.ApiService.createUserExecute(r)
+	return r.ApiService.CreateUserExecute(r)
 }
 
 /*
@@ -134,7 +134,7 @@ func (a *MongoDBCloudUsersApiService) CreateUser(ctx context.Context, cloudAppUs
 // Execute executes the request
 //
 //	@return CloudAppUser
-func (a *MongoDBCloudUsersApiService) createUserExecute(r CreateUserApiRequest) (*CloudAppUser, *http.Response, error) {
+func (a *MongoDBCloudUsersApiService) CreateUserExecute(r CreateUserApiRequest) (*CloudAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -239,7 +239,7 @@ func (a *MongoDBCloudUsersApiService) GetUserWithParams(ctx context.Context, arg
 }
 
 func (r GetUserApiRequest) Execute() (*CloudAppUser, *http.Response, error) {
-	return r.ApiService.getUserExecute(r)
+	return r.ApiService.GetUserExecute(r)
 }
 
 /*
@@ -262,7 +262,7 @@ func (a *MongoDBCloudUsersApiService) GetUser(ctx context.Context, userId string
 // Execute executes the request
 //
 //	@return CloudAppUser
-func (a *MongoDBCloudUsersApiService) getUserExecute(r GetUserApiRequest) (*CloudAppUser, *http.Response, error) {
+func (a *MongoDBCloudUsersApiService) GetUserExecute(r GetUserApiRequest) (*CloudAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -363,7 +363,7 @@ func (a *MongoDBCloudUsersApiService) GetUserByUsernameWithParams(ctx context.Co
 }
 
 func (r GetUserByUsernameApiRequest) Execute() (*CloudAppUser, *http.Response, error) {
-	return r.ApiService.getUserByUsernameExecute(r)
+	return r.ApiService.GetUserByUsernameExecute(r)
 }
 
 /*
@@ -386,7 +386,7 @@ func (a *MongoDBCloudUsersApiService) GetUserByUsername(ctx context.Context, use
 // Execute executes the request
 //
 //	@return CloudAppUser
-func (a *MongoDBCloudUsersApiService) getUserByUsernameExecute(r GetUserByUsernameApiRequest) (*CloudAppUser, *http.Response, error) {
+func (a *MongoDBCloudUsersApiService) GetUserByUsernameExecute(r GetUserByUsernameApiRequest) (*CloudAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_mongo_db_cloud_users.go
+++ b/admin/api_mongo_db_cloud_users.go
@@ -36,7 +36,7 @@ type MongoDBCloudUsersApi interface {
 	*/
 	CreateUserWithParams(ctx context.Context, args *CreateUserApiParams) CreateUserApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateUserExecute(r CreateUserApiRequest) (*CloudAppUser, *http.Response, error)
 
 	/*
@@ -59,7 +59,7 @@ type MongoDBCloudUsersApi interface {
 	*/
 	GetUserWithParams(ctx context.Context, args *GetUserApiParams) GetUserApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetUserExecute(r GetUserApiRequest) (*CloudAppUser, *http.Response, error)
 
 	/*
@@ -82,7 +82,7 @@ type MongoDBCloudUsersApi interface {
 	*/
 	GetUserByUsernameWithParams(ctx context.Context, args *GetUserByUsernameApiParams) GetUserByUsernameApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetUserByUsernameExecute(r GetUserByUsernameApiRequest) (*CloudAppUser, *http.Response, error)
 }
 

--- a/admin/api_monitoring_and_logs.go
+++ b/admin/api_monitoring_and_logs.go
@@ -37,7 +37,7 @@ type MonitoringAndLogsApi interface {
 	GetAtlasProcessWithParams(ctx context.Context, args *GetAtlasProcessApiParams) GetAtlasProcessApiRequest
 
 	// Interface only available internally
-	getAtlasProcessExecute(r GetAtlasProcessApiRequest) (*ApiHostViewAtlas, *http.Response, error)
+	GetAtlasProcessExecute(r GetAtlasProcessApiRequest) (*ApiHostViewAtlas, *http.Response, error)
 
 	/*
 		GetDatabase Return One Database for a MongoDB Process
@@ -62,7 +62,7 @@ type MonitoringAndLogsApi interface {
 	GetDatabaseWithParams(ctx context.Context, args *GetDatabaseApiParams) GetDatabaseApiRequest
 
 	// Interface only available internally
-	getDatabaseExecute(r GetDatabaseApiRequest) (*MesurementsDatabase, *http.Response, error)
+	GetDatabaseExecute(r GetDatabaseApiRequest) (*MesurementsDatabase, *http.Response, error)
 
 	/*
 		GetDatabaseMeasurements Return Measurements of One Database for One MongoDB Process
@@ -87,7 +87,7 @@ type MonitoringAndLogsApi interface {
 	GetDatabaseMeasurementsWithParams(ctx context.Context, args *GetDatabaseMeasurementsApiParams) GetDatabaseMeasurementsApiRequest
 
 	// Interface only available internally
-	getDatabaseMeasurementsExecute(r GetDatabaseMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error)
+	GetDatabaseMeasurementsExecute(r GetDatabaseMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error)
 
 	/*
 		GetDiskMeasurements Return Measurements of One Disk for One MongoDB Process
@@ -118,7 +118,7 @@ type MonitoringAndLogsApi interface {
 	GetDiskMeasurementsWithParams(ctx context.Context, args *GetDiskMeasurementsApiParams) GetDiskMeasurementsApiRequest
 
 	// Interface only available internally
-	getDiskMeasurementsExecute(r GetDiskMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error)
+	GetDiskMeasurementsExecute(r GetDiskMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error)
 
 	/*
 		GetHostLogs Download Logs for One Cluster Host in One Project
@@ -143,7 +143,7 @@ type MonitoringAndLogsApi interface {
 	GetHostLogsWithParams(ctx context.Context, args *GetHostLogsApiParams) GetHostLogsApiRequest
 
 	// Interface only available internally
-	getHostLogsExecute(r GetHostLogsApiRequest) (io.ReadCloser, *http.Response, error)
+	GetHostLogsExecute(r GetHostLogsApiRequest) (io.ReadCloser, *http.Response, error)
 
 	/*
 		GetHostMeasurements Return Measurements for One MongoDB Process
@@ -174,7 +174,7 @@ type MonitoringAndLogsApi interface {
 	GetHostMeasurementsWithParams(ctx context.Context, args *GetHostMeasurementsApiParams) GetHostMeasurementsApiRequest
 
 	// Interface only available internally
-	getHostMeasurementsExecute(r GetHostMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error)
+	GetHostMeasurementsExecute(r GetHostMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error)
 
 	/*
 		GetIndexMetrics Return Atlas Search Metrics for One Index in One Specified Namespace
@@ -201,7 +201,7 @@ type MonitoringAndLogsApi interface {
 	GetIndexMetricsWithParams(ctx context.Context, args *GetIndexMetricsApiParams) GetIndexMetricsApiRequest
 
 	// Interface only available internally
-	getIndexMetricsExecute(r GetIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error)
+	GetIndexMetricsExecute(r GetIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error)
 
 	/*
 		GetMeasurements Return Atlas Search Hardware and Status Metrics
@@ -225,7 +225,7 @@ type MonitoringAndLogsApi interface {
 	GetMeasurementsWithParams(ctx context.Context, args *GetMeasurementsApiParams) GetMeasurementsApiRequest
 
 	// Interface only available internally
-	getMeasurementsExecute(r GetMeasurementsApiRequest) (*MeasurementsNonIndex, *http.Response, error)
+	GetMeasurementsExecute(r GetMeasurementsApiRequest) (*MeasurementsNonIndex, *http.Response, error)
 
 	/*
 		ListAtlasProcesses Return All MongoDB Processes in One Project
@@ -248,7 +248,7 @@ type MonitoringAndLogsApi interface {
 	ListAtlasProcessesWithParams(ctx context.Context, args *ListAtlasProcessesApiParams) ListAtlasProcessesApiRequest
 
 	// Interface only available internally
-	listAtlasProcessesExecute(r ListAtlasProcessesApiRequest) (*PaginatedHostViewAtlas, *http.Response, error)
+	ListAtlasProcessesExecute(r ListAtlasProcessesApiRequest) (*PaginatedHostViewAtlas, *http.Response, error)
 
 	/*
 		ListDatabases Return Available Databases for One MongoDB Process
@@ -272,7 +272,7 @@ type MonitoringAndLogsApi interface {
 	ListDatabasesWithParams(ctx context.Context, args *ListDatabasesApiParams) ListDatabasesApiRequest
 
 	// Interface only available internally
-	listDatabasesExecute(r ListDatabasesApiRequest) (*PaginatedDatabase, *http.Response, error)
+	ListDatabasesExecute(r ListDatabasesApiRequest) (*PaginatedDatabase, *http.Response, error)
 
 	/*
 		ListDiskMeasurements Return Measurements of One Disk
@@ -297,7 +297,7 @@ type MonitoringAndLogsApi interface {
 	ListDiskMeasurementsWithParams(ctx context.Context, args *ListDiskMeasurementsApiParams) ListDiskMeasurementsApiRequest
 
 	// Interface only available internally
-	listDiskMeasurementsExecute(r ListDiskMeasurementsApiRequest) (*MeasurementDiskPartition, *http.Response, error)
+	ListDiskMeasurementsExecute(r ListDiskMeasurementsApiRequest) (*MeasurementDiskPartition, *http.Response, error)
 
 	/*
 		ListDiskPartitions Return Available Disks for One MongoDB Process
@@ -321,7 +321,7 @@ type MonitoringAndLogsApi interface {
 	ListDiskPartitionsWithParams(ctx context.Context, args *ListDiskPartitionsApiParams) ListDiskPartitionsApiRequest
 
 	// Interface only available internally
-	listDiskPartitionsExecute(r ListDiskPartitionsApiRequest) (*PaginatedDiskPartition, *http.Response, error)
+	ListDiskPartitionsExecute(r ListDiskPartitionsApiRequest) (*PaginatedDiskPartition, *http.Response, error)
 
 	/*
 		ListIndexMetrics Return All Atlas Search Index Metrics for One Namespace
@@ -347,7 +347,7 @@ type MonitoringAndLogsApi interface {
 	ListIndexMetricsWithParams(ctx context.Context, args *ListIndexMetricsApiParams) ListIndexMetricsApiRequest
 
 	// Interface only available internally
-	listIndexMetricsExecute(r ListIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error)
+	ListIndexMetricsExecute(r ListIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error)
 
 	/*
 		ListMetricTypes Return All Atlas Search Metric Types for One Process
@@ -371,7 +371,7 @@ type MonitoringAndLogsApi interface {
 	ListMetricTypesWithParams(ctx context.Context, args *ListMetricTypesApiParams) ListMetricTypesApiRequest
 
 	// Interface only available internally
-	listMetricTypesExecute(r ListMetricTypesApiRequest) (*CloudSearchMetrics, *http.Response, error)
+	ListMetricTypesExecute(r ListMetricTypesApiRequest) (*CloudSearchMetrics, *http.Response, error)
 }
 
 // MonitoringAndLogsApiService MonitoringAndLogsApi service
@@ -399,7 +399,7 @@ func (a *MonitoringAndLogsApiService) GetAtlasProcessWithParams(ctx context.Cont
 }
 
 func (r GetAtlasProcessApiRequest) Execute() (*ApiHostViewAtlas, *http.Response, error) {
-	return r.ApiService.getAtlasProcessExecute(r)
+	return r.ApiService.GetAtlasProcessExecute(r)
 }
 
 /*
@@ -424,7 +424,7 @@ func (a *MonitoringAndLogsApiService) GetAtlasProcess(ctx context.Context, group
 // Execute executes the request
 //
 //	@return ApiHostViewAtlas
-func (a *MonitoringAndLogsApiService) getAtlasProcessExecute(r GetAtlasProcessApiRequest) (*ApiHostViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetAtlasProcessExecute(r GetAtlasProcessApiRequest) (*ApiHostViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -532,7 +532,7 @@ func (a *MonitoringAndLogsApiService) GetDatabaseWithParams(ctx context.Context,
 }
 
 func (r GetDatabaseApiRequest) Execute() (*MesurementsDatabase, *http.Response, error) {
-	return r.ApiService.getDatabaseExecute(r)
+	return r.ApiService.GetDatabaseExecute(r)
 }
 
 /*
@@ -559,7 +559,7 @@ func (a *MonitoringAndLogsApiService) GetDatabase(ctx context.Context, groupId s
 // Execute executes the request
 //
 //	@return MesurementsDatabase
-func (a *MonitoringAndLogsApiService) getDatabaseExecute(r GetDatabaseApiRequest) (*MesurementsDatabase, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetDatabaseExecute(r GetDatabaseApiRequest) (*MesurementsDatabase, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -713,7 +713,7 @@ func (r GetDatabaseMeasurementsApiRequest) End(end time.Time) GetDatabaseMeasure
 }
 
 func (r GetDatabaseMeasurementsApiRequest) Execute() (*ApiMeasurementsGeneralViewAtlas, *http.Response, error) {
-	return r.ApiService.getDatabaseMeasurementsExecute(r)
+	return r.ApiService.GetDatabaseMeasurementsExecute(r)
 }
 
 /*
@@ -740,7 +740,7 @@ func (a *MonitoringAndLogsApiService) GetDatabaseMeasurements(ctx context.Contex
 // Execute executes the request
 //
 //	@return ApiMeasurementsGeneralViewAtlas
-func (a *MonitoringAndLogsApiService) getDatabaseMeasurementsExecute(r GetDatabaseMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetDatabaseMeasurementsExecute(r GetDatabaseMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -914,7 +914,7 @@ func (r GetDiskMeasurementsApiRequest) End(end time.Time) GetDiskMeasurementsApi
 }
 
 func (r GetDiskMeasurementsApiRequest) Execute() (*ApiMeasurementsGeneralViewAtlas, *http.Response, error) {
-	return r.ApiService.getDiskMeasurementsExecute(r)
+	return r.ApiService.GetDiskMeasurementsExecute(r)
 }
 
 /*
@@ -947,7 +947,7 @@ func (a *MonitoringAndLogsApiService) GetDiskMeasurements(ctx context.Context, g
 // Execute executes the request
 //
 //	@return ApiMeasurementsGeneralViewAtlas
-func (a *MonitoringAndLogsApiService) getDiskMeasurementsExecute(r GetDiskMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetDiskMeasurementsExecute(r GetDiskMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1094,7 +1094,7 @@ func (r GetHostLogsApiRequest) StartDate(startDate int64) GetHostLogsApiRequest 
 }
 
 func (r GetHostLogsApiRequest) Execute() (io.ReadCloser, *http.Response, error) {
-	return r.ApiService.getHostLogsExecute(r)
+	return r.ApiService.GetHostLogsExecute(r)
 }
 
 /*
@@ -1121,7 +1121,7 @@ func (a *MonitoringAndLogsApiService) GetHostLogs(ctx context.Context, groupId s
 // Execute executes the request
 //
 //	@return io.ReadCloser
-func (a *MonitoringAndLogsApiService) getHostLogsExecute(r GetHostLogsApiRequest) (io.ReadCloser, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetHostLogsExecute(r GetHostLogsApiRequest) (io.ReadCloser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1278,7 +1278,7 @@ func (r GetHostMeasurementsApiRequest) End(end time.Time) GetHostMeasurementsApi
 }
 
 func (r GetHostMeasurementsApiRequest) Execute() (*ApiMeasurementsGeneralViewAtlas, *http.Response, error) {
-	return r.ApiService.getHostMeasurementsExecute(r)
+	return r.ApiService.GetHostMeasurementsExecute(r)
 }
 
 /*
@@ -1310,7 +1310,7 @@ func (a *MonitoringAndLogsApiService) GetHostMeasurements(ctx context.Context, g
 // Execute executes the request
 //
 //	@return ApiMeasurementsGeneralViewAtlas
-func (a *MonitoringAndLogsApiService) getHostMeasurementsExecute(r GetHostMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetHostMeasurementsExecute(r GetHostMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1489,7 +1489,7 @@ func (r GetIndexMetricsApiRequest) End(end time.Time) GetIndexMetricsApiRequest 
 }
 
 func (r GetIndexMetricsApiRequest) Execute() (*MeasurementsIndexes, *http.Response, error) {
-	return r.ApiService.getIndexMetricsExecute(r)
+	return r.ApiService.GetIndexMetricsExecute(r)
 }
 
 /*
@@ -1520,7 +1520,7 @@ func (a *MonitoringAndLogsApiService) GetIndexMetrics(ctx context.Context, proce
 // Execute executes the request
 //
 //	@return MeasurementsIndexes
-func (a *MonitoringAndLogsApiService) getIndexMetricsExecute(r GetIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetIndexMetricsExecute(r GetIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1695,7 +1695,7 @@ func (r GetMeasurementsApiRequest) End(end time.Time) GetMeasurementsApiRequest 
 }
 
 func (r GetMeasurementsApiRequest) Execute() (*MeasurementsNonIndex, *http.Response, error) {
-	return r.ApiService.getMeasurementsExecute(r)
+	return r.ApiService.GetMeasurementsExecute(r)
 }
 
 /*
@@ -1720,7 +1720,7 @@ func (a *MonitoringAndLogsApiService) GetMeasurements(ctx context.Context, proce
 // Execute executes the request
 //
 //	@return MeasurementsNonIndex
-func (a *MonitoringAndLogsApiService) getMeasurementsExecute(r GetMeasurementsApiRequest) (*MeasurementsNonIndex, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetMeasurementsExecute(r GetMeasurementsApiRequest) (*MeasurementsNonIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1871,7 +1871,7 @@ func (r ListAtlasProcessesApiRequest) PageNum(pageNum int) ListAtlasProcessesApi
 }
 
 func (r ListAtlasProcessesApiRequest) Execute() (*PaginatedHostViewAtlas, *http.Response, error) {
-	return r.ApiService.listAtlasProcessesExecute(r)
+	return r.ApiService.ListAtlasProcessesExecute(r)
 }
 
 /*
@@ -1894,7 +1894,7 @@ func (a *MonitoringAndLogsApiService) ListAtlasProcesses(ctx context.Context, gr
 // Execute executes the request
 //
 //	@return PaginatedHostViewAtlas
-func (a *MonitoringAndLogsApiService) listAtlasProcessesExecute(r ListAtlasProcessesApiRequest) (*PaginatedHostViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) ListAtlasProcessesExecute(r ListAtlasProcessesApiRequest) (*PaginatedHostViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2046,7 +2046,7 @@ func (r ListDatabasesApiRequest) PageNum(pageNum int) ListDatabasesApiRequest {
 }
 
 func (r ListDatabasesApiRequest) Execute() (*PaginatedDatabase, *http.Response, error) {
-	return r.ApiService.listDatabasesExecute(r)
+	return r.ApiService.ListDatabasesExecute(r)
 }
 
 /*
@@ -2071,7 +2071,7 @@ func (a *MonitoringAndLogsApiService) ListDatabases(ctx context.Context, groupId
 // Execute executes the request
 //
 //	@return PaginatedDatabase
-func (a *MonitoringAndLogsApiService) listDatabasesExecute(r ListDatabasesApiRequest) (*PaginatedDatabase, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) ListDatabasesExecute(r ListDatabasesApiRequest) (*PaginatedDatabase, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2200,7 +2200,7 @@ func (a *MonitoringAndLogsApiService) ListDiskMeasurementsWithParams(ctx context
 }
 
 func (r ListDiskMeasurementsApiRequest) Execute() (*MeasurementDiskPartition, *http.Response, error) {
-	return r.ApiService.listDiskMeasurementsExecute(r)
+	return r.ApiService.ListDiskMeasurementsExecute(r)
 }
 
 /*
@@ -2227,7 +2227,7 @@ func (a *MonitoringAndLogsApiService) ListDiskMeasurements(ctx context.Context, 
 // Execute executes the request
 //
 //	@return MeasurementDiskPartition
-func (a *MonitoringAndLogsApiService) listDiskMeasurementsExecute(r ListDiskMeasurementsApiRequest) (*MeasurementDiskPartition, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) ListDiskMeasurementsExecute(r ListDiskMeasurementsApiRequest) (*MeasurementDiskPartition, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2360,7 +2360,7 @@ func (r ListDiskPartitionsApiRequest) PageNum(pageNum int) ListDiskPartitionsApi
 }
 
 func (r ListDiskPartitionsApiRequest) Execute() (*PaginatedDiskPartition, *http.Response, error) {
-	return r.ApiService.listDiskPartitionsExecute(r)
+	return r.ApiService.ListDiskPartitionsExecute(r)
 }
 
 /*
@@ -2385,7 +2385,7 @@ func (a *MonitoringAndLogsApiService) ListDiskPartitions(ctx context.Context, gr
 // Execute executes the request
 //
 //	@return PaginatedDiskPartition
-func (a *MonitoringAndLogsApiService) listDiskPartitionsExecute(r ListDiskPartitionsApiRequest) (*PaginatedDiskPartition, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) ListDiskPartitionsExecute(r ListDiskPartitionsApiRequest) (*PaginatedDiskPartition, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2562,7 +2562,7 @@ func (r ListIndexMetricsApiRequest) End(end time.Time) ListIndexMetricsApiReques
 }
 
 func (r ListIndexMetricsApiRequest) Execute() (*MeasurementsIndexes, *http.Response, error) {
-	return r.ApiService.listIndexMetricsExecute(r)
+	return r.ApiService.ListIndexMetricsExecute(r)
 }
 
 /*
@@ -2591,7 +2591,7 @@ func (a *MonitoringAndLogsApiService) ListIndexMetrics(ctx context.Context, proc
 // Execute executes the request
 //
 //	@return MeasurementsIndexes
-func (a *MonitoringAndLogsApiService) listIndexMetricsExecute(r ListIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) ListIndexMetricsExecute(r ListIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2720,7 +2720,7 @@ func (a *MonitoringAndLogsApiService) ListMetricTypesWithParams(ctx context.Cont
 }
 
 func (r ListMetricTypesApiRequest) Execute() (*CloudSearchMetrics, *http.Response, error) {
-	return r.ApiService.listMetricTypesExecute(r)
+	return r.ApiService.ListMetricTypesExecute(r)
 }
 
 /*
@@ -2745,7 +2745,7 @@ func (a *MonitoringAndLogsApiService) ListMetricTypes(ctx context.Context, proce
 // Execute executes the request
 //
 //	@return CloudSearchMetrics
-func (a *MonitoringAndLogsApiService) listMetricTypesExecute(r ListMetricTypesApiRequest) (*CloudSearchMetrics, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) ListMetricTypesExecute(r ListMetricTypesApiRequest) (*CloudSearchMetrics, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_monitoring_and_logs.go
+++ b/admin/api_monitoring_and_logs.go
@@ -36,7 +36,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	GetAtlasProcessWithParams(ctx context.Context, args *GetAtlasProcessApiParams) GetAtlasProcessApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetAtlasProcessExecute(r GetAtlasProcessApiRequest) (*ApiHostViewAtlas, *http.Response, error)
 
 	/*
@@ -61,7 +61,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	GetDatabaseWithParams(ctx context.Context, args *GetDatabaseApiParams) GetDatabaseApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetDatabaseExecute(r GetDatabaseApiRequest) (*MesurementsDatabase, *http.Response, error)
 
 	/*
@@ -86,7 +86,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	GetDatabaseMeasurementsWithParams(ctx context.Context, args *GetDatabaseMeasurementsApiParams) GetDatabaseMeasurementsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetDatabaseMeasurementsExecute(r GetDatabaseMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error)
 
 	/*
@@ -117,7 +117,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	GetDiskMeasurementsWithParams(ctx context.Context, args *GetDiskMeasurementsApiParams) GetDiskMeasurementsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetDiskMeasurementsExecute(r GetDiskMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error)
 
 	/*
@@ -142,7 +142,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	GetHostLogsWithParams(ctx context.Context, args *GetHostLogsApiParams) GetHostLogsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetHostLogsExecute(r GetHostLogsApiRequest) (io.ReadCloser, *http.Response, error)
 
 	/*
@@ -173,7 +173,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	GetHostMeasurementsWithParams(ctx context.Context, args *GetHostMeasurementsApiParams) GetHostMeasurementsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetHostMeasurementsExecute(r GetHostMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error)
 
 	/*
@@ -200,7 +200,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	GetIndexMetricsWithParams(ctx context.Context, args *GetIndexMetricsApiParams) GetIndexMetricsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetIndexMetricsExecute(r GetIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error)
 
 	/*
@@ -224,7 +224,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	GetMeasurementsWithParams(ctx context.Context, args *GetMeasurementsApiParams) GetMeasurementsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetMeasurementsExecute(r GetMeasurementsApiRequest) (*MeasurementsNonIndex, *http.Response, error)
 
 	/*
@@ -247,7 +247,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	ListAtlasProcessesWithParams(ctx context.Context, args *ListAtlasProcessesApiParams) ListAtlasProcessesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListAtlasProcessesExecute(r ListAtlasProcessesApiRequest) (*PaginatedHostViewAtlas, *http.Response, error)
 
 	/*
@@ -271,7 +271,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	ListDatabasesWithParams(ctx context.Context, args *ListDatabasesApiParams) ListDatabasesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListDatabasesExecute(r ListDatabasesApiRequest) (*PaginatedDatabase, *http.Response, error)
 
 	/*
@@ -296,7 +296,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	ListDiskMeasurementsWithParams(ctx context.Context, args *ListDiskMeasurementsApiParams) ListDiskMeasurementsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListDiskMeasurementsExecute(r ListDiskMeasurementsApiRequest) (*MeasurementDiskPartition, *http.Response, error)
 
 	/*
@@ -320,7 +320,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	ListDiskPartitionsWithParams(ctx context.Context, args *ListDiskPartitionsApiParams) ListDiskPartitionsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListDiskPartitionsExecute(r ListDiskPartitionsApiRequest) (*PaginatedDiskPartition, *http.Response, error)
 
 	/*
@@ -346,7 +346,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	ListIndexMetricsWithParams(ctx context.Context, args *ListIndexMetricsApiParams) ListIndexMetricsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListIndexMetricsExecute(r ListIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error)
 
 	/*
@@ -370,7 +370,7 @@ type MonitoringAndLogsApi interface {
 	*/
 	ListMetricTypesWithParams(ctx context.Context, args *ListMetricTypesApiParams) ListMetricTypesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListMetricTypesExecute(r ListMetricTypesApiRequest) (*CloudSearchMetrics, *http.Response, error)
 }
 

--- a/admin/api_network_peering.go
+++ b/admin/api_network_peering.go
@@ -33,7 +33,7 @@ type NetworkPeeringApi interface {
 	*/
 	CreatePeeringConnectionWithParams(ctx context.Context, args *CreatePeeringConnectionApiParams) CreatePeeringConnectionApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreatePeeringConnectionExecute(r CreatePeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error)
 
 	/*
@@ -56,7 +56,7 @@ type NetworkPeeringApi interface {
 	*/
 	CreatePeeringContainerWithParams(ctx context.Context, args *CreatePeeringContainerApiParams) CreatePeeringContainerApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreatePeeringContainerExecute(r CreatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
 
 	/*
@@ -80,7 +80,7 @@ type NetworkPeeringApi interface {
 	*/
 	DeletePeeringConnectionWithParams(ctx context.Context, args *DeletePeeringConnectionApiParams) DeletePeeringConnectionApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -104,7 +104,7 @@ type NetworkPeeringApi interface {
 	*/
 	DeletePeeringContainerWithParams(ctx context.Context, args *DeletePeeringContainerApiParams) DeletePeeringContainerApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -131,7 +131,7 @@ type NetworkPeeringApi interface {
 	*/
 	DisablePeeringWithParams(ctx context.Context, args *DisablePeeringApiParams) DisablePeeringApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DisablePeeringExecute(r DisablePeeringApiRequest) (*PrivateIPMode, *http.Response, error)
 
 	/*
@@ -155,7 +155,7 @@ type NetworkPeeringApi interface {
 	*/
 	GetPeeringConnectionWithParams(ctx context.Context, args *GetPeeringConnectionApiParams) GetPeeringConnectionApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetPeeringConnectionExecute(r GetPeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error)
 
 	/*
@@ -179,7 +179,7 @@ type NetworkPeeringApi interface {
 	*/
 	GetPeeringContainerWithParams(ctx context.Context, args *GetPeeringContainerApiParams) GetPeeringContainerApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetPeeringContainerExecute(r GetPeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
 
 	/*
@@ -202,7 +202,7 @@ type NetworkPeeringApi interface {
 	*/
 	ListPeeringConnectionsWithParams(ctx context.Context, args *ListPeeringConnectionsApiParams) ListPeeringConnectionsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListPeeringConnectionsExecute(r ListPeeringConnectionsApiRequest) (*PaginatedContainerPeer, *http.Response, error)
 
 	/*
@@ -225,7 +225,7 @@ type NetworkPeeringApi interface {
 	*/
 	ListPeeringContainerByCloudProviderWithParams(ctx context.Context, args *ListPeeringContainerByCloudProviderApiParams) ListPeeringContainerByCloudProviderApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListPeeringContainerByCloudProviderExecute(r ListPeeringContainerByCloudProviderApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
 
 	/*
@@ -248,7 +248,7 @@ type NetworkPeeringApi interface {
 	*/
 	ListPeeringContainersWithParams(ctx context.Context, args *ListPeeringContainersApiParams) ListPeeringContainersApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListPeeringContainersExecute(r ListPeeringContainersApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
 
 	/*
@@ -272,7 +272,7 @@ type NetworkPeeringApi interface {
 	*/
 	UpdatePeeringConnectionWithParams(ctx context.Context, args *UpdatePeeringConnectionApiParams) UpdatePeeringConnectionApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdatePeeringConnectionExecute(r UpdatePeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error)
 
 	/*
@@ -296,7 +296,7 @@ type NetworkPeeringApi interface {
 	*/
 	UpdatePeeringContainerWithParams(ctx context.Context, args *UpdatePeeringContainerApiParams) UpdatePeeringContainerApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdatePeeringContainerExecute(r UpdatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
 
 	/*
@@ -323,7 +323,7 @@ type NetworkPeeringApi interface {
 	*/
 	VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx context.Context, args *VerifyConnectViaPeeringOnlyModeForOneProjectApiParams) VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) (*PrivateIPMode, *http.Response, error)
 }
 

--- a/admin/api_network_peering.go
+++ b/admin/api_network_peering.go
@@ -34,7 +34,7 @@ type NetworkPeeringApi interface {
 	CreatePeeringConnectionWithParams(ctx context.Context, args *CreatePeeringConnectionApiParams) CreatePeeringConnectionApiRequest
 
 	// Interface only available internally
-	createPeeringConnectionExecute(r CreatePeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error)
+	CreatePeeringConnectionExecute(r CreatePeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error)
 
 	/*
 		CreatePeeringContainer Create One New Network Peering Container
@@ -57,7 +57,7 @@ type NetworkPeeringApi interface {
 	CreatePeeringContainerWithParams(ctx context.Context, args *CreatePeeringContainerApiParams) CreatePeeringContainerApiRequest
 
 	// Interface only available internally
-	createPeeringContainerExecute(r CreatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
+	CreatePeeringContainerExecute(r CreatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
 
 	/*
 		DeletePeeringConnection Remove One Existing Network Peering Connection
@@ -81,7 +81,7 @@ type NetworkPeeringApi interface {
 	DeletePeeringConnectionWithParams(ctx context.Context, args *DeletePeeringConnectionApiParams) DeletePeeringConnectionApiRequest
 
 	// Interface only available internally
-	deletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (map[string]interface{}, *http.Response, error)
+	DeletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DeletePeeringContainer Remove One Network Peering Container
@@ -105,7 +105,7 @@ type NetworkPeeringApi interface {
 	DeletePeeringContainerWithParams(ctx context.Context, args *DeletePeeringContainerApiParams) DeletePeeringContainerApiRequest
 
 	// Interface only available internally
-	deletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (map[string]interface{}, *http.Response, error)
+	DeletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DisablePeering Disable Connect via Peering Only Mode for One Project
@@ -132,7 +132,7 @@ type NetworkPeeringApi interface {
 	DisablePeeringWithParams(ctx context.Context, args *DisablePeeringApiParams) DisablePeeringApiRequest
 
 	// Interface only available internally
-	disablePeeringExecute(r DisablePeeringApiRequest) (*PrivateIPMode, *http.Response, error)
+	DisablePeeringExecute(r DisablePeeringApiRequest) (*PrivateIPMode, *http.Response, error)
 
 	/*
 		GetPeeringConnection Return One Network Peering Connection in One Project
@@ -156,7 +156,7 @@ type NetworkPeeringApi interface {
 	GetPeeringConnectionWithParams(ctx context.Context, args *GetPeeringConnectionApiParams) GetPeeringConnectionApiRequest
 
 	// Interface only available internally
-	getPeeringConnectionExecute(r GetPeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error)
+	GetPeeringConnectionExecute(r GetPeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error)
 
 	/*
 		GetPeeringContainer Return One Network Peering Container
@@ -180,7 +180,7 @@ type NetworkPeeringApi interface {
 	GetPeeringContainerWithParams(ctx context.Context, args *GetPeeringContainerApiParams) GetPeeringContainerApiRequest
 
 	// Interface only available internally
-	getPeeringContainerExecute(r GetPeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
+	GetPeeringContainerExecute(r GetPeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
 
 	/*
 		ListPeeringConnections Return All Network Peering Connections in One Project
@@ -203,7 +203,7 @@ type NetworkPeeringApi interface {
 	ListPeeringConnectionsWithParams(ctx context.Context, args *ListPeeringConnectionsApiParams) ListPeeringConnectionsApiRequest
 
 	// Interface only available internally
-	listPeeringConnectionsExecute(r ListPeeringConnectionsApiRequest) (*PaginatedContainerPeer, *http.Response, error)
+	ListPeeringConnectionsExecute(r ListPeeringConnectionsApiRequest) (*PaginatedContainerPeer, *http.Response, error)
 
 	/*
 		ListPeeringContainerByCloudProvider Return All Network Peering Containers in One Project for One Cloud Provider
@@ -226,7 +226,7 @@ type NetworkPeeringApi interface {
 	ListPeeringContainerByCloudProviderWithParams(ctx context.Context, args *ListPeeringContainerByCloudProviderApiParams) ListPeeringContainerByCloudProviderApiRequest
 
 	// Interface only available internally
-	listPeeringContainerByCloudProviderExecute(r ListPeeringContainerByCloudProviderApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
+	ListPeeringContainerByCloudProviderExecute(r ListPeeringContainerByCloudProviderApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
 
 	/*
 		ListPeeringContainers Return All Network Peering Containers in One Project
@@ -249,7 +249,7 @@ type NetworkPeeringApi interface {
 	ListPeeringContainersWithParams(ctx context.Context, args *ListPeeringContainersApiParams) ListPeeringContainersApiRequest
 
 	// Interface only available internally
-	listPeeringContainersExecute(r ListPeeringContainersApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
+	ListPeeringContainersExecute(r ListPeeringContainersApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
 
 	/*
 		UpdatePeeringConnection Update One New Network Peering Connection
@@ -273,7 +273,7 @@ type NetworkPeeringApi interface {
 	UpdatePeeringConnectionWithParams(ctx context.Context, args *UpdatePeeringConnectionApiParams) UpdatePeeringConnectionApiRequest
 
 	// Interface only available internally
-	updatePeeringConnectionExecute(r UpdatePeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error)
+	UpdatePeeringConnectionExecute(r UpdatePeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error)
 
 	/*
 		UpdatePeeringContainer Update One Network Peering Container
@@ -297,7 +297,7 @@ type NetworkPeeringApi interface {
 	UpdatePeeringContainerWithParams(ctx context.Context, args *UpdatePeeringContainerApiParams) UpdatePeeringContainerApiRequest
 
 	// Interface only available internally
-	updatePeeringContainerExecute(r UpdatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
+	UpdatePeeringContainerExecute(r UpdatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
 
 	/*
 		VerifyConnectViaPeeringOnlyModeForOneProject Verify Connect via Peering Only Mode for One Project
@@ -324,7 +324,7 @@ type NetworkPeeringApi interface {
 	VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx context.Context, args *VerifyConnectViaPeeringOnlyModeForOneProjectApiParams) VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
 
 	// Interface only available internally
-	verifyConnectViaPeeringOnlyModeForOneProjectExecute(r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) (*PrivateIPMode, *http.Response, error)
+	VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) (*PrivateIPMode, *http.Response, error)
 }
 
 // NetworkPeeringApiService NetworkPeeringApi service
@@ -352,7 +352,7 @@ func (a *NetworkPeeringApiService) CreatePeeringConnectionWithParams(ctx context
 }
 
 func (r CreatePeeringConnectionApiRequest) Execute() (*BaseNetworkPeeringConnectionSettings, *http.Response, error) {
-	return r.ApiService.createPeeringConnectionExecute(r)
+	return r.ApiService.CreatePeeringConnectionExecute(r)
 }
 
 /*
@@ -376,7 +376,7 @@ func (a *NetworkPeeringApiService) CreatePeeringConnection(ctx context.Context, 
 // Execute executes the request
 //
 //	@return BaseNetworkPeeringConnectionSettings
-func (a *NetworkPeeringApiService) createPeeringConnectionExecute(r CreatePeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error) {
+func (a *NetworkPeeringApiService) CreatePeeringConnectionExecute(r CreatePeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -485,7 +485,7 @@ func (a *NetworkPeeringApiService) CreatePeeringContainerWithParams(ctx context.
 }
 
 func (r CreatePeeringContainerApiRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
-	return r.ApiService.createPeeringContainerExecute(r)
+	return r.ApiService.CreatePeeringContainerExecute(r)
 }
 
 /*
@@ -509,7 +509,7 @@ func (a *NetworkPeeringApiService) CreatePeeringContainer(ctx context.Context, g
 // Execute executes the request
 //
 //	@return CloudProviderContainer
-func (a *NetworkPeeringApiService) createPeeringContainerExecute(r CreatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) CreatePeeringContainerExecute(r CreatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -618,7 +618,7 @@ func (a *NetworkPeeringApiService) DeletePeeringConnectionWithParams(ctx context
 }
 
 func (r DeletePeeringConnectionApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deletePeeringConnectionExecute(r)
+	return r.ApiService.DeletePeeringConnectionExecute(r)
 }
 
 /*
@@ -643,7 +643,7 @@ func (a *NetworkPeeringApiService) DeletePeeringConnection(ctx context.Context, 
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *NetworkPeeringApiService) deletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *NetworkPeeringApiService) DeletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -748,7 +748,7 @@ func (a *NetworkPeeringApiService) DeletePeeringContainerWithParams(ctx context.
 }
 
 func (r DeletePeeringContainerApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deletePeeringContainerExecute(r)
+	return r.ApiService.DeletePeeringContainerExecute(r)
 }
 
 /*
@@ -773,7 +773,7 @@ func (a *NetworkPeeringApiService) DeletePeeringContainer(ctx context.Context, g
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *NetworkPeeringApiService) deletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *NetworkPeeringApiService) DeletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -878,7 +878,7 @@ func (a *NetworkPeeringApiService) DisablePeeringWithParams(ctx context.Context,
 }
 
 func (r DisablePeeringApiRequest) Execute() (*PrivateIPMode, *http.Response, error) {
-	return r.ApiService.disablePeeringExecute(r)
+	return r.ApiService.DisablePeeringExecute(r)
 }
 
 /*
@@ -906,7 +906,7 @@ func (a *NetworkPeeringApiService) DisablePeering(ctx context.Context, groupId s
 //	@return PrivateIPMode
 //
 // Deprecated
-func (a *NetworkPeeringApiService) disablePeeringExecute(r DisablePeeringApiRequest) (*PrivateIPMode, *http.Response, error) {
+func (a *NetworkPeeringApiService) DisablePeeringExecute(r DisablePeeringApiRequest) (*PrivateIPMode, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -1015,7 +1015,7 @@ func (a *NetworkPeeringApiService) GetPeeringConnectionWithParams(ctx context.Co
 }
 
 func (r GetPeeringConnectionApiRequest) Execute() (*BaseNetworkPeeringConnectionSettings, *http.Response, error) {
-	return r.ApiService.getPeeringConnectionExecute(r)
+	return r.ApiService.GetPeeringConnectionExecute(r)
 }
 
 /*
@@ -1040,7 +1040,7 @@ func (a *NetworkPeeringApiService) GetPeeringConnection(ctx context.Context, gro
 // Execute executes the request
 //
 //	@return BaseNetworkPeeringConnectionSettings
-func (a *NetworkPeeringApiService) getPeeringConnectionExecute(r GetPeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error) {
+func (a *NetworkPeeringApiService) GetPeeringConnectionExecute(r GetPeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1145,7 +1145,7 @@ func (a *NetworkPeeringApiService) GetPeeringContainerWithParams(ctx context.Con
 }
 
 func (r GetPeeringContainerApiRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
-	return r.ApiService.getPeeringContainerExecute(r)
+	return r.ApiService.GetPeeringContainerExecute(r)
 }
 
 /*
@@ -1170,7 +1170,7 @@ func (a *NetworkPeeringApiService) GetPeeringContainer(ctx context.Context, grou
 // Execute executes the request
 //
 //	@return CloudProviderContainer
-func (a *NetworkPeeringApiService) getPeeringContainerExecute(r GetPeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) GetPeeringContainerExecute(r GetPeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1308,7 +1308,7 @@ func (r ListPeeringConnectionsApiRequest) ProviderName(providerName string) List
 }
 
 func (r ListPeeringConnectionsApiRequest) Execute() (*PaginatedContainerPeer, *http.Response, error) {
-	return r.ApiService.listPeeringConnectionsExecute(r)
+	return r.ApiService.ListPeeringConnectionsExecute(r)
 }
 
 /*
@@ -1331,7 +1331,7 @@ func (a *NetworkPeeringApiService) ListPeeringConnections(ctx context.Context, g
 // Execute executes the request
 //
 //	@return PaginatedContainerPeer
-func (a *NetworkPeeringApiService) listPeeringConnectionsExecute(r ListPeeringConnectionsApiRequest) (*PaginatedContainerPeer, *http.Response, error) {
+func (a *NetworkPeeringApiService) ListPeeringConnectionsExecute(r ListPeeringConnectionsApiRequest) (*PaginatedContainerPeer, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1496,7 +1496,7 @@ func (r ListPeeringContainerByCloudProviderApiRequest) PageNum(pageNum int) List
 }
 
 func (r ListPeeringContainerByCloudProviderApiRequest) Execute() (*PaginatedCloudProviderContainer, *http.Response, error) {
-	return r.ApiService.listPeeringContainerByCloudProviderExecute(r)
+	return r.ApiService.ListPeeringContainerByCloudProviderExecute(r)
 }
 
 /*
@@ -1519,7 +1519,7 @@ func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProvider(ctx conte
 // Execute executes the request
 //
 //	@return PaginatedCloudProviderContainer
-func (a *NetworkPeeringApiService) listPeeringContainerByCloudProviderExecute(r ListPeeringContainerByCloudProviderApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProviderExecute(r ListPeeringContainerByCloudProviderApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1672,7 +1672,7 @@ func (r ListPeeringContainersApiRequest) PageNum(pageNum int) ListPeeringContain
 }
 
 func (r ListPeeringContainersApiRequest) Execute() (*PaginatedCloudProviderContainer, *http.Response, error) {
-	return r.ApiService.listPeeringContainersExecute(r)
+	return r.ApiService.ListPeeringContainersExecute(r)
 }
 
 /*
@@ -1695,7 +1695,7 @@ func (a *NetworkPeeringApiService) ListPeeringContainers(ctx context.Context, gr
 // Execute executes the request
 //
 //	@return PaginatedCloudProviderContainer
-func (a *NetworkPeeringApiService) listPeeringContainersExecute(r ListPeeringContainersApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) ListPeeringContainersExecute(r ListPeeringContainersApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1823,7 +1823,7 @@ func (a *NetworkPeeringApiService) UpdatePeeringConnectionWithParams(ctx context
 }
 
 func (r UpdatePeeringConnectionApiRequest) Execute() (*BaseNetworkPeeringConnectionSettings, *http.Response, error) {
-	return r.ApiService.updatePeeringConnectionExecute(r)
+	return r.ApiService.UpdatePeeringConnectionExecute(r)
 }
 
 /*
@@ -1849,7 +1849,7 @@ func (a *NetworkPeeringApiService) UpdatePeeringConnection(ctx context.Context, 
 // Execute executes the request
 //
 //	@return BaseNetworkPeeringConnectionSettings
-func (a *NetworkPeeringApiService) updatePeeringConnectionExecute(r UpdatePeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error) {
+func (a *NetworkPeeringApiService) UpdatePeeringConnectionExecute(r UpdatePeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -1962,7 +1962,7 @@ func (a *NetworkPeeringApiService) UpdatePeeringContainerWithParams(ctx context.
 }
 
 func (r UpdatePeeringContainerApiRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
-	return r.ApiService.updatePeeringContainerExecute(r)
+	return r.ApiService.UpdatePeeringContainerExecute(r)
 }
 
 /*
@@ -1988,7 +1988,7 @@ func (a *NetworkPeeringApiService) UpdatePeeringContainer(ctx context.Context, g
 // Execute executes the request
 //
 //	@return CloudProviderContainer
-func (a *NetworkPeeringApiService) updatePeeringContainerExecute(r UpdatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) UpdatePeeringContainerExecute(r UpdatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -2095,7 +2095,7 @@ func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProjectW
 }
 
 func (r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) Execute() (*PrivateIPMode, *http.Response, error) {
-	return r.ApiService.verifyConnectViaPeeringOnlyModeForOneProjectExecute(r)
+	return r.ApiService.VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r)
 }
 
 /*
@@ -2122,7 +2122,7 @@ func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProject(
 //	@return PrivateIPMode
 //
 // Deprecated
-func (a *NetworkPeeringApiService) verifyConnectViaPeeringOnlyModeForOneProjectExecute(r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) (*PrivateIPMode, *http.Response, error) {
+func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) (*PrivateIPMode, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_online_archive.go
+++ b/admin/api_online_archive.go
@@ -35,7 +35,7 @@ type OnlineArchiveApi interface {
 	CreateOnlineArchiveWithParams(ctx context.Context, args *CreateOnlineArchiveApiParams) CreateOnlineArchiveApiRequest
 
 	// Interface only available internally
-	createOnlineArchiveExecute(r CreateOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error)
+	CreateOnlineArchiveExecute(r CreateOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error)
 
 	/*
 		DeleteOnlineArchive Remove One Online Archive
@@ -60,7 +60,7 @@ type OnlineArchiveApi interface {
 	DeleteOnlineArchiveWithParams(ctx context.Context, args *DeleteOnlineArchiveApiParams) DeleteOnlineArchiveApiRequest
 
 	// Interface only available internally
-	deleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DownloadOnlineArchiveQueryLogs Download Online Archive Query Logs
@@ -84,7 +84,7 @@ type OnlineArchiveApi interface {
 	DownloadOnlineArchiveQueryLogsWithParams(ctx context.Context, args *DownloadOnlineArchiveQueryLogsApiParams) DownloadOnlineArchiveQueryLogsApiRequest
 
 	// Interface only available internally
-	downloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (io.ReadCloser, *http.Response, error)
+	DownloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (io.ReadCloser, *http.Response, error)
 
 	/*
 		GetOnlineArchive Return One Online Archive
@@ -109,7 +109,7 @@ type OnlineArchiveApi interface {
 	GetOnlineArchiveWithParams(ctx context.Context, args *GetOnlineArchiveApiParams) GetOnlineArchiveApiRequest
 
 	// Interface only available internally
-	getOnlineArchiveExecute(r GetOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error)
+	GetOnlineArchiveExecute(r GetOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error)
 
 	/*
 		ListOnlineArchives Return All Online Archives for One Cluster
@@ -133,7 +133,7 @@ type OnlineArchiveApi interface {
 	ListOnlineArchivesWithParams(ctx context.Context, args *ListOnlineArchivesApiParams) ListOnlineArchivesApiRequest
 
 	// Interface only available internally
-	listOnlineArchivesExecute(r ListOnlineArchivesApiRequest) (*PaginatedOnlineArchive, *http.Response, error)
+	ListOnlineArchivesExecute(r ListOnlineArchivesApiRequest) (*PaginatedOnlineArchive, *http.Response, error)
 
 	/*
 		UpdateOnlineArchive Update One Online Archive
@@ -158,7 +158,7 @@ type OnlineArchiveApi interface {
 	UpdateOnlineArchiveWithParams(ctx context.Context, args *UpdateOnlineArchiveApiParams) UpdateOnlineArchiveApiRequest
 
 	// Interface only available internally
-	updateOnlineArchiveExecute(r UpdateOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error)
+	UpdateOnlineArchiveExecute(r UpdateOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error)
 }
 
 // OnlineArchiveApiService OnlineArchiveApi service
@@ -189,7 +189,7 @@ func (a *OnlineArchiveApiService) CreateOnlineArchiveWithParams(ctx context.Cont
 }
 
 func (r CreateOnlineArchiveApiRequest) Execute() (*BackupOnlineArchive, *http.Response, error) {
-	return r.ApiService.createOnlineArchiveExecute(r)
+	return r.ApiService.CreateOnlineArchiveExecute(r)
 }
 
 /*
@@ -215,7 +215,7 @@ func (a *OnlineArchiveApiService) CreateOnlineArchive(ctx context.Context, group
 // Execute executes the request
 //
 //	@return BackupOnlineArchive
-func (a *OnlineArchiveApiService) createOnlineArchiveExecute(r CreateOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error) {
+func (a *OnlineArchiveApiService) CreateOnlineArchiveExecute(r CreateOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -328,7 +328,7 @@ func (a *OnlineArchiveApiService) DeleteOnlineArchiveWithParams(ctx context.Cont
 }
 
 func (r DeleteOnlineArchiveApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteOnlineArchiveExecute(r)
+	return r.ApiService.DeleteOnlineArchiveExecute(r)
 }
 
 /*
@@ -355,7 +355,7 @@ func (a *OnlineArchiveApiService) DeleteOnlineArchive(ctx context.Context, group
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *OnlineArchiveApiService) deleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *OnlineArchiveApiService) DeleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -488,7 +488,7 @@ func (r DownloadOnlineArchiveQueryLogsApiRequest) ArchiveOnly(archiveOnly bool) 
 }
 
 func (r DownloadOnlineArchiveQueryLogsApiRequest) Execute() (io.ReadCloser, *http.Response, error) {
-	return r.ApiService.downloadOnlineArchiveQueryLogsExecute(r)
+	return r.ApiService.DownloadOnlineArchiveQueryLogsExecute(r)
 }
 
 /*
@@ -513,7 +513,7 @@ func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogs(ctx context.Con
 // Execute executes the request
 //
 //	@return io.ReadCloser
-func (a *OnlineArchiveApiService) downloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (io.ReadCloser, *http.Response, error) {
+func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (io.ReadCloser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -634,7 +634,7 @@ func (a *OnlineArchiveApiService) GetOnlineArchiveWithParams(ctx context.Context
 }
 
 func (r GetOnlineArchiveApiRequest) Execute() (*BackupOnlineArchive, *http.Response, error) {
-	return r.ApiService.getOnlineArchiveExecute(r)
+	return r.ApiService.GetOnlineArchiveExecute(r)
 }
 
 /*
@@ -661,7 +661,7 @@ func (a *OnlineArchiveApiService) GetOnlineArchive(ctx context.Context, groupId 
 // Execute executes the request
 //
 //	@return BackupOnlineArchive
-func (a *OnlineArchiveApiService) getOnlineArchiveExecute(r GetOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error) {
+func (a *OnlineArchiveApiService) GetOnlineArchiveExecute(r GetOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -794,7 +794,7 @@ func (r ListOnlineArchivesApiRequest) PageNum(pageNum int) ListOnlineArchivesApi
 }
 
 func (r ListOnlineArchivesApiRequest) Execute() (*PaginatedOnlineArchive, *http.Response, error) {
-	return r.ApiService.listOnlineArchivesExecute(r)
+	return r.ApiService.ListOnlineArchivesExecute(r)
 }
 
 /*
@@ -819,7 +819,7 @@ func (a *OnlineArchiveApiService) ListOnlineArchives(ctx context.Context, groupI
 // Execute executes the request
 //
 //	@return PaginatedOnlineArchive
-func (a *OnlineArchiveApiService) listOnlineArchivesExecute(r ListOnlineArchivesApiRequest) (*PaginatedOnlineArchive, *http.Response, error) {
+func (a *OnlineArchiveApiService) ListOnlineArchivesExecute(r ListOnlineArchivesApiRequest) (*PaginatedOnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -951,7 +951,7 @@ func (a *OnlineArchiveApiService) UpdateOnlineArchiveWithParams(ctx context.Cont
 }
 
 func (r UpdateOnlineArchiveApiRequest) Execute() (*BackupOnlineArchive, *http.Response, error) {
-	return r.ApiService.updateOnlineArchiveExecute(r)
+	return r.ApiService.UpdateOnlineArchiveExecute(r)
 }
 
 /*
@@ -979,7 +979,7 @@ func (a *OnlineArchiveApiService) UpdateOnlineArchive(ctx context.Context, group
 // Execute executes the request
 //
 //	@return BackupOnlineArchive
-func (a *OnlineArchiveApiService) updateOnlineArchiveExecute(r UpdateOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error) {
+func (a *OnlineArchiveApiService) UpdateOnlineArchiveExecute(r UpdateOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_online_archive.go
+++ b/admin/api_online_archive.go
@@ -34,7 +34,7 @@ type OnlineArchiveApi interface {
 	*/
 	CreateOnlineArchiveWithParams(ctx context.Context, args *CreateOnlineArchiveApiParams) CreateOnlineArchiveApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateOnlineArchiveExecute(r CreateOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error)
 
 	/*
@@ -59,7 +59,7 @@ type OnlineArchiveApi interface {
 	*/
 	DeleteOnlineArchiveWithParams(ctx context.Context, args *DeleteOnlineArchiveApiParams) DeleteOnlineArchiveApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -83,7 +83,7 @@ type OnlineArchiveApi interface {
 	*/
 	DownloadOnlineArchiveQueryLogsWithParams(ctx context.Context, args *DownloadOnlineArchiveQueryLogsApiParams) DownloadOnlineArchiveQueryLogsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DownloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (io.ReadCloser, *http.Response, error)
 
 	/*
@@ -108,7 +108,7 @@ type OnlineArchiveApi interface {
 	*/
 	GetOnlineArchiveWithParams(ctx context.Context, args *GetOnlineArchiveApiParams) GetOnlineArchiveApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetOnlineArchiveExecute(r GetOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error)
 
 	/*
@@ -132,7 +132,7 @@ type OnlineArchiveApi interface {
 	*/
 	ListOnlineArchivesWithParams(ctx context.Context, args *ListOnlineArchivesApiParams) ListOnlineArchivesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListOnlineArchivesExecute(r ListOnlineArchivesApiRequest) (*PaginatedOnlineArchive, *http.Response, error)
 
 	/*
@@ -157,7 +157,7 @@ type OnlineArchiveApi interface {
 	*/
 	UpdateOnlineArchiveWithParams(ctx context.Context, args *UpdateOnlineArchiveApiParams) UpdateOnlineArchiveApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateOnlineArchiveExecute(r UpdateOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error)
 }
 

--- a/admin/api_organizations.go
+++ b/admin/api_organizations.go
@@ -33,7 +33,7 @@ type OrganizationsApi interface {
 	CreateOrganizationWithParams(ctx context.Context, args *CreateOrganizationApiParams) CreateOrganizationApiRequest
 
 	// Interface only available internally
-	createOrganizationExecute(r CreateOrganizationApiRequest) (*CreateOrganizationResponse, *http.Response, error)
+	CreateOrganizationExecute(r CreateOrganizationApiRequest) (*CreateOrganizationResponse, *http.Response, error)
 
 	/*
 		CreateOrganizationInvitation Invite One MongoDB Cloud User to Join One Atlas Organization
@@ -56,7 +56,7 @@ type OrganizationsApi interface {
 	CreateOrganizationInvitationWithParams(ctx context.Context, args *CreateOrganizationInvitationApiParams) CreateOrganizationInvitationApiRequest
 
 	// Interface only available internally
-	createOrganizationInvitationExecute(r CreateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
+	CreateOrganizationInvitationExecute(r CreateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 		DeleteOrganization Remove One Organization
@@ -83,7 +83,7 @@ type OrganizationsApi interface {
 	DeleteOrganizationWithParams(ctx context.Context, args *DeleteOrganizationApiParams) DeleteOrganizationApiRequest
 
 	// Interface only available internally
-	deleteOrganizationExecute(r DeleteOrganizationApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteOrganizationExecute(r DeleteOrganizationApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DeleteOrganizationInvitation Cancel One Organization Invitation
@@ -107,7 +107,7 @@ type OrganizationsApi interface {
 	DeleteOrganizationInvitationWithParams(ctx context.Context, args *DeleteOrganizationInvitationApiParams) DeleteOrganizationInvitationApiRequest
 
 	// Interface only available internally
-	deleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetOrganization Return One Organization
@@ -130,7 +130,7 @@ type OrganizationsApi interface {
 	GetOrganizationWithParams(ctx context.Context, args *GetOrganizationApiParams) GetOrganizationApiRequest
 
 	// Interface only available internally
-	getOrganizationExecute(r GetOrganizationApiRequest) (*AtlasOrganization, *http.Response, error)
+	GetOrganizationExecute(r GetOrganizationApiRequest) (*AtlasOrganization, *http.Response, error)
 
 	/*
 		GetOrganizationInvitation Return One Organization Invitation
@@ -154,7 +154,7 @@ type OrganizationsApi interface {
 	GetOrganizationInvitationWithParams(ctx context.Context, args *GetOrganizationInvitationApiParams) GetOrganizationInvitationApiRequest
 
 	// Interface only available internally
-	getOrganizationInvitationExecute(r GetOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
+	GetOrganizationInvitationExecute(r GetOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 		GetOrganizationSettings Return Settings for One Organization
@@ -177,7 +177,7 @@ type OrganizationsApi interface {
 	GetOrganizationSettingsWithParams(ctx context.Context, args *GetOrganizationSettingsApiParams) GetOrganizationSettingsApiRequest
 
 	// Interface only available internally
-	getOrganizationSettingsExecute(r GetOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error)
+	GetOrganizationSettingsExecute(r GetOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error)
 
 	/*
 		ListOrganizationInvitations Return All Organization Invitations
@@ -200,7 +200,7 @@ type OrganizationsApi interface {
 	ListOrganizationInvitationsWithParams(ctx context.Context, args *ListOrganizationInvitationsApiParams) ListOrganizationInvitationsApiRequest
 
 	// Interface only available internally
-	listOrganizationInvitationsExecute(r ListOrganizationInvitationsApiRequest) ([]OrganizationInvitation, *http.Response, error)
+	ListOrganizationInvitationsExecute(r ListOrganizationInvitationsApiRequest) ([]OrganizationInvitation, *http.Response, error)
 
 	/*
 		ListOrganizationProjects Return One or More Projects in One Organization
@@ -230,7 +230,7 @@ type OrganizationsApi interface {
 	ListOrganizationProjectsWithParams(ctx context.Context, args *ListOrganizationProjectsApiParams) ListOrganizationProjectsApiRequest
 
 	// Interface only available internally
-	listOrganizationProjectsExecute(r ListOrganizationProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error)
+	ListOrganizationProjectsExecute(r ListOrganizationProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error)
 
 	/*
 		ListOrganizationUsers Return All MongoDB Cloud Users in One Organization
@@ -253,7 +253,7 @@ type OrganizationsApi interface {
 	ListOrganizationUsersWithParams(ctx context.Context, args *ListOrganizationUsersApiParams) ListOrganizationUsersApiRequest
 
 	// Interface only available internally
-	listOrganizationUsersExecute(r ListOrganizationUsersApiRequest) (*PaginatedAppUser, *http.Response, error)
+	ListOrganizationUsersExecute(r ListOrganizationUsersApiRequest) (*PaginatedAppUser, *http.Response, error)
 
 	/*
 		ListOrganizations Return All Organizations
@@ -275,7 +275,7 @@ type OrganizationsApi interface {
 	ListOrganizationsWithParams(ctx context.Context, args *ListOrganizationsApiParams) ListOrganizationsApiRequest
 
 	// Interface only available internally
-	listOrganizationsExecute(r ListOrganizationsApiRequest) (*PaginatedOrganization, *http.Response, error)
+	ListOrganizationsExecute(r ListOrganizationsApiRequest) (*PaginatedOrganization, *http.Response, error)
 
 	/*
 		RemoveOrganizationUser Remove One MongoDB Cloud User from One Organization
@@ -299,7 +299,7 @@ type OrganizationsApi interface {
 	RemoveOrganizationUserWithParams(ctx context.Context, args *RemoveOrganizationUserApiParams) RemoveOrganizationUserApiRequest
 
 	// Interface only available internally
-	removeOrganizationUserExecute(r RemoveOrganizationUserApiRequest) (map[string]interface{}, *http.Response, error)
+	RemoveOrganizationUserExecute(r RemoveOrganizationUserApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		RenameOrganization Rename One Organization
@@ -322,7 +322,7 @@ type OrganizationsApi interface {
 	RenameOrganizationWithParams(ctx context.Context, args *RenameOrganizationApiParams) RenameOrganizationApiRequest
 
 	// Interface only available internally
-	renameOrganizationExecute(r RenameOrganizationApiRequest) (*AtlasOrganization, *http.Response, error)
+	RenameOrganizationExecute(r RenameOrganizationApiRequest) (*AtlasOrganization, *http.Response, error)
 
 	/*
 		UpdateOrganizationInvitation Update One Organization Invitation
@@ -345,7 +345,7 @@ type OrganizationsApi interface {
 	UpdateOrganizationInvitationWithParams(ctx context.Context, args *UpdateOrganizationInvitationApiParams) UpdateOrganizationInvitationApiRequest
 
 	// Interface only available internally
-	updateOrganizationInvitationExecute(r UpdateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
+	UpdateOrganizationInvitationExecute(r UpdateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 		UpdateOrganizationInvitationById Update One Organization Invitation by Invitation ID
@@ -369,7 +369,7 @@ type OrganizationsApi interface {
 	UpdateOrganizationInvitationByIdWithParams(ctx context.Context, args *UpdateOrganizationInvitationByIdApiParams) UpdateOrganizationInvitationByIdApiRequest
 
 	// Interface only available internally
-	updateOrganizationInvitationByIdExecute(r UpdateOrganizationInvitationByIdApiRequest) (*OrganizationInvitation, *http.Response, error)
+	UpdateOrganizationInvitationByIdExecute(r UpdateOrganizationInvitationByIdApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 		UpdateOrganizationRoles Update Organization Roles for One MongoDB Cloud User
@@ -393,7 +393,7 @@ type OrganizationsApi interface {
 	UpdateOrganizationRolesWithParams(ctx context.Context, args *UpdateOrganizationRolesApiParams) UpdateOrganizationRolesApiRequest
 
 	// Interface only available internally
-	updateOrganizationRolesExecute(r UpdateOrganizationRolesApiRequest) (*UpdateOrgRolesForUser, *http.Response, error)
+	UpdateOrganizationRolesExecute(r UpdateOrganizationRolesApiRequest) (*UpdateOrgRolesForUser, *http.Response, error)
 
 	/*
 		UpdateOrganizationSettings Update Settings for One Organization
@@ -416,7 +416,7 @@ type OrganizationsApi interface {
 	UpdateOrganizationSettingsWithParams(ctx context.Context, args *UpdateOrganizationSettingsApiParams) UpdateOrganizationSettingsApiRequest
 
 	// Interface only available internally
-	updateOrganizationSettingsExecute(r UpdateOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error)
+	UpdateOrganizationSettingsExecute(r UpdateOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error)
 }
 
 // OrganizationsApiService OrganizationsApi service
@@ -441,7 +441,7 @@ func (a *OrganizationsApiService) CreateOrganizationWithParams(ctx context.Conte
 }
 
 func (r CreateOrganizationApiRequest) Execute() (*CreateOrganizationResponse, *http.Response, error) {
-	return r.ApiService.createOrganizationExecute(r)
+	return r.ApiService.CreateOrganizationExecute(r)
 }
 
 /*
@@ -463,7 +463,7 @@ func (a *OrganizationsApiService) CreateOrganization(ctx context.Context, create
 // Execute executes the request
 //
 //	@return CreateOrganizationResponse
-func (a *OrganizationsApiService) createOrganizationExecute(r CreateOrganizationApiRequest) (*CreateOrganizationResponse, *http.Response, error) {
+func (a *OrganizationsApiService) CreateOrganizationExecute(r CreateOrganizationApiRequest) (*CreateOrganizationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -571,7 +571,7 @@ func (a *OrganizationsApiService) CreateOrganizationInvitationWithParams(ctx con
 }
 
 func (r CreateOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
-	return r.ApiService.createOrganizationInvitationExecute(r)
+	return r.ApiService.CreateOrganizationInvitationExecute(r)
 }
 
 /*
@@ -595,7 +595,7 @@ func (a *OrganizationsApiService) CreateOrganizationInvitation(ctx context.Conte
 // Execute executes the request
 //
 //	@return OrganizationInvitation
-func (a *OrganizationsApiService) createOrganizationInvitationExecute(r CreateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) CreateOrganizationInvitationExecute(r CreateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -701,7 +701,7 @@ func (a *OrganizationsApiService) DeleteOrganizationWithParams(ctx context.Conte
 }
 
 func (r DeleteOrganizationApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteOrganizationExecute(r)
+	return r.ApiService.DeleteOrganizationExecute(r)
 }
 
 /*
@@ -729,7 +729,7 @@ func (a *OrganizationsApiService) DeleteOrganization(ctx context.Context, orgId 
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *OrganizationsApiService) deleteOrganizationExecute(r DeleteOrganizationApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *OrganizationsApiService) DeleteOrganizationExecute(r DeleteOrganizationApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -833,7 +833,7 @@ func (a *OrganizationsApiService) DeleteOrganizationInvitationWithParams(ctx con
 }
 
 func (r DeleteOrganizationInvitationApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteOrganizationInvitationExecute(r)
+	return r.ApiService.DeleteOrganizationInvitationExecute(r)
 }
 
 /*
@@ -858,7 +858,7 @@ func (a *OrganizationsApiService) DeleteOrganizationInvitation(ctx context.Conte
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *OrganizationsApiService) deleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *OrganizationsApiService) DeleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -960,7 +960,7 @@ func (a *OrganizationsApiService) GetOrganizationWithParams(ctx context.Context,
 }
 
 func (r GetOrganizationApiRequest) Execute() (*AtlasOrganization, *http.Response, error) {
-	return r.ApiService.getOrganizationExecute(r)
+	return r.ApiService.GetOrganizationExecute(r)
 }
 
 /*
@@ -983,7 +983,7 @@ func (a *OrganizationsApiService) GetOrganization(ctx context.Context, orgId str
 // Execute executes the request
 //
 //	@return AtlasOrganization
-func (a *OrganizationsApiService) getOrganizationExecute(r GetOrganizationApiRequest) (*AtlasOrganization, *http.Response, error) {
+func (a *OrganizationsApiService) GetOrganizationExecute(r GetOrganizationApiRequest) (*AtlasOrganization, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1087,7 +1087,7 @@ func (a *OrganizationsApiService) GetOrganizationInvitationWithParams(ctx contex
 }
 
 func (r GetOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
-	return r.ApiService.getOrganizationInvitationExecute(r)
+	return r.ApiService.GetOrganizationInvitationExecute(r)
 }
 
 /*
@@ -1112,7 +1112,7 @@ func (a *OrganizationsApiService) GetOrganizationInvitation(ctx context.Context,
 // Execute executes the request
 //
 //	@return OrganizationInvitation
-func (a *OrganizationsApiService) getOrganizationInvitationExecute(r GetOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) GetOrganizationInvitationExecute(r GetOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1214,7 +1214,7 @@ func (a *OrganizationsApiService) GetOrganizationSettingsWithParams(ctx context.
 }
 
 func (r GetOrganizationSettingsApiRequest) Execute() (*OrganizationSettings, *http.Response, error) {
-	return r.ApiService.getOrganizationSettingsExecute(r)
+	return r.ApiService.GetOrganizationSettingsExecute(r)
 }
 
 /*
@@ -1237,7 +1237,7 @@ func (a *OrganizationsApiService) GetOrganizationSettings(ctx context.Context, o
 // Execute executes the request
 //
 //	@return OrganizationSettings
-func (a *OrganizationsApiService) getOrganizationSettingsExecute(r GetOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error) {
+func (a *OrganizationsApiService) GetOrganizationSettingsExecute(r GetOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1347,7 +1347,7 @@ func (r ListOrganizationInvitationsApiRequest) Username(username string) ListOrg
 }
 
 func (r ListOrganizationInvitationsApiRequest) Execute() ([]OrganizationInvitation, *http.Response, error) {
-	return r.ApiService.listOrganizationInvitationsExecute(r)
+	return r.ApiService.ListOrganizationInvitationsExecute(r)
 }
 
 /*
@@ -1370,7 +1370,7 @@ func (a *OrganizationsApiService) ListOrganizationInvitations(ctx context.Contex
 // Execute executes the request
 //
 //	@return []OrganizationInvitation
-func (a *OrganizationsApiService) listOrganizationInvitationsExecute(r ListOrganizationInvitationsApiRequest) ([]OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) ListOrganizationInvitationsExecute(r ListOrganizationInvitationsApiRequest) ([]OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1510,7 +1510,7 @@ func (r ListOrganizationProjectsApiRequest) Name(name string) ListOrganizationPr
 }
 
 func (r ListOrganizationProjectsApiRequest) Execute() (*PaginatedAtlasGroup, *http.Response, error) {
-	return r.ApiService.listOrganizationProjectsExecute(r)
+	return r.ApiService.ListOrganizationProjectsExecute(r)
 }
 
 /*
@@ -1540,7 +1540,7 @@ func (a *OrganizationsApiService) ListOrganizationProjects(ctx context.Context, 
 // Execute executes the request
 //
 //	@return PaginatedAtlasGroup
-func (a *OrganizationsApiService) listOrganizationProjectsExecute(r ListOrganizationProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error) {
+func (a *OrganizationsApiService) ListOrganizationProjectsExecute(r ListOrganizationProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1692,7 +1692,7 @@ func (r ListOrganizationUsersApiRequest) PageNum(pageNum int) ListOrganizationUs
 }
 
 func (r ListOrganizationUsersApiRequest) Execute() (*PaginatedAppUser, *http.Response, error) {
-	return r.ApiService.listOrganizationUsersExecute(r)
+	return r.ApiService.ListOrganizationUsersExecute(r)
 }
 
 /*
@@ -1715,7 +1715,7 @@ func (a *OrganizationsApiService) ListOrganizationUsers(ctx context.Context, org
 // Execute executes the request
 //
 //	@return PaginatedAppUser
-func (a *OrganizationsApiService) listOrganizationUsersExecute(r ListOrganizationUsersApiRequest) (*PaginatedAppUser, *http.Response, error) {
+func (a *OrganizationsApiService) ListOrganizationUsersExecute(r ListOrganizationUsersApiRequest) (*PaginatedAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1870,7 +1870,7 @@ func (r ListOrganizationsApiRequest) Name(name string) ListOrganizationsApiReque
 }
 
 func (r ListOrganizationsApiRequest) Execute() (*PaginatedOrganization, *http.Response, error) {
-	return r.ApiService.listOrganizationsExecute(r)
+	return r.ApiService.ListOrganizationsExecute(r)
 }
 
 /*
@@ -1891,7 +1891,7 @@ func (a *OrganizationsApiService) ListOrganizations(ctx context.Context) ListOrg
 // Execute executes the request
 //
 //	@return PaginatedOrganization
-func (a *OrganizationsApiService) listOrganizationsExecute(r ListOrganizationsApiRequest) (*PaginatedOrganization, *http.Response, error) {
+func (a *OrganizationsApiService) ListOrganizationsExecute(r ListOrganizationsApiRequest) (*PaginatedOrganization, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2018,7 +2018,7 @@ func (a *OrganizationsApiService) RemoveOrganizationUserWithParams(ctx context.C
 }
 
 func (r RemoveOrganizationUserApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.removeOrganizationUserExecute(r)
+	return r.ApiService.RemoveOrganizationUserExecute(r)
 }
 
 /*
@@ -2043,7 +2043,7 @@ func (a *OrganizationsApiService) RemoveOrganizationUser(ctx context.Context, or
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *OrganizationsApiService) removeOrganizationUserExecute(r RemoveOrganizationUserApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *OrganizationsApiService) RemoveOrganizationUserExecute(r RemoveOrganizationUserApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -2148,7 +2148,7 @@ func (a *OrganizationsApiService) RenameOrganizationWithParams(ctx context.Conte
 }
 
 func (r RenameOrganizationApiRequest) Execute() (*AtlasOrganization, *http.Response, error) {
-	return r.ApiService.renameOrganizationExecute(r)
+	return r.ApiService.RenameOrganizationExecute(r)
 }
 
 /*
@@ -2172,7 +2172,7 @@ func (a *OrganizationsApiService) RenameOrganization(ctx context.Context, orgId 
 // Execute executes the request
 //
 //	@return AtlasOrganization
-func (a *OrganizationsApiService) renameOrganizationExecute(r RenameOrganizationApiRequest) (*AtlasOrganization, *http.Response, error) {
+func (a *OrganizationsApiService) RenameOrganizationExecute(r RenameOrganizationApiRequest) (*AtlasOrganization, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -2281,7 +2281,7 @@ func (a *OrganizationsApiService) UpdateOrganizationInvitationWithParams(ctx con
 }
 
 func (r UpdateOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
-	return r.ApiService.updateOrganizationInvitationExecute(r)
+	return r.ApiService.UpdateOrganizationInvitationExecute(r)
 }
 
 /*
@@ -2305,7 +2305,7 @@ func (a *OrganizationsApiService) UpdateOrganizationInvitation(ctx context.Conte
 // Execute executes the request
 //
 //	@return OrganizationInvitation
-func (a *OrganizationsApiService) updateOrganizationInvitationExecute(r UpdateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) UpdateOrganizationInvitationExecute(r UpdateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -2417,7 +2417,7 @@ func (a *OrganizationsApiService) UpdateOrganizationInvitationByIdWithParams(ctx
 }
 
 func (r UpdateOrganizationInvitationByIdApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
-	return r.ApiService.updateOrganizationInvitationByIdExecute(r)
+	return r.ApiService.UpdateOrganizationInvitationByIdExecute(r)
 }
 
 /*
@@ -2443,7 +2443,7 @@ func (a *OrganizationsApiService) UpdateOrganizationInvitationById(ctx context.C
 // Execute executes the request
 //
 //	@return OrganizationInvitation
-func (a *OrganizationsApiService) updateOrganizationInvitationByIdExecute(r UpdateOrganizationInvitationByIdApiRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) UpdateOrganizationInvitationByIdExecute(r UpdateOrganizationInvitationByIdApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -2556,7 +2556,7 @@ func (a *OrganizationsApiService) UpdateOrganizationRolesWithParams(ctx context.
 }
 
 func (r UpdateOrganizationRolesApiRequest) Execute() (*UpdateOrgRolesForUser, *http.Response, error) {
-	return r.ApiService.updateOrganizationRolesExecute(r)
+	return r.ApiService.UpdateOrganizationRolesExecute(r)
 }
 
 /*
@@ -2582,7 +2582,7 @@ func (a *OrganizationsApiService) UpdateOrganizationRoles(ctx context.Context, o
 // Execute executes the request
 //
 //	@return UpdateOrgRolesForUser
-func (a *OrganizationsApiService) updateOrganizationRolesExecute(r UpdateOrganizationRolesApiRequest) (*UpdateOrgRolesForUser, *http.Response, error) {
+func (a *OrganizationsApiService) UpdateOrganizationRolesExecute(r UpdateOrganizationRolesApiRequest) (*UpdateOrgRolesForUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
 		localVarPostBody    interface{}
@@ -2692,7 +2692,7 @@ func (a *OrganizationsApiService) UpdateOrganizationSettingsWithParams(ctx conte
 }
 
 func (r UpdateOrganizationSettingsApiRequest) Execute() (*OrganizationSettings, *http.Response, error) {
-	return r.ApiService.updateOrganizationSettingsExecute(r)
+	return r.ApiService.UpdateOrganizationSettingsExecute(r)
 }
 
 /*
@@ -2716,7 +2716,7 @@ func (a *OrganizationsApiService) UpdateOrganizationSettings(ctx context.Context
 // Execute executes the request
 //
 //	@return OrganizationSettings
-func (a *OrganizationsApiService) updateOrganizationSettingsExecute(r UpdateOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error) {
+func (a *OrganizationsApiService) UpdateOrganizationSettingsExecute(r UpdateOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_organizations.go
+++ b/admin/api_organizations.go
@@ -32,7 +32,7 @@ type OrganizationsApi interface {
 	*/
 	CreateOrganizationWithParams(ctx context.Context, args *CreateOrganizationApiParams) CreateOrganizationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateOrganizationExecute(r CreateOrganizationApiRequest) (*CreateOrganizationResponse, *http.Response, error)
 
 	/*
@@ -55,7 +55,7 @@ type OrganizationsApi interface {
 	*/
 	CreateOrganizationInvitationWithParams(ctx context.Context, args *CreateOrganizationInvitationApiParams) CreateOrganizationInvitationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateOrganizationInvitationExecute(r CreateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
@@ -82,7 +82,7 @@ type OrganizationsApi interface {
 	*/
 	DeleteOrganizationWithParams(ctx context.Context, args *DeleteOrganizationApiParams) DeleteOrganizationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteOrganizationExecute(r DeleteOrganizationApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -106,7 +106,7 @@ type OrganizationsApi interface {
 	*/
 	DeleteOrganizationInvitationWithParams(ctx context.Context, args *DeleteOrganizationInvitationApiParams) DeleteOrganizationInvitationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -129,7 +129,7 @@ type OrganizationsApi interface {
 	*/
 	GetOrganizationWithParams(ctx context.Context, args *GetOrganizationApiParams) GetOrganizationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetOrganizationExecute(r GetOrganizationApiRequest) (*AtlasOrganization, *http.Response, error)
 
 	/*
@@ -153,7 +153,7 @@ type OrganizationsApi interface {
 	*/
 	GetOrganizationInvitationWithParams(ctx context.Context, args *GetOrganizationInvitationApiParams) GetOrganizationInvitationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetOrganizationInvitationExecute(r GetOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
@@ -176,7 +176,7 @@ type OrganizationsApi interface {
 	*/
 	GetOrganizationSettingsWithParams(ctx context.Context, args *GetOrganizationSettingsApiParams) GetOrganizationSettingsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetOrganizationSettingsExecute(r GetOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error)
 
 	/*
@@ -199,7 +199,7 @@ type OrganizationsApi interface {
 	*/
 	ListOrganizationInvitationsWithParams(ctx context.Context, args *ListOrganizationInvitationsApiParams) ListOrganizationInvitationsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListOrganizationInvitationsExecute(r ListOrganizationInvitationsApiRequest) ([]OrganizationInvitation, *http.Response, error)
 
 	/*
@@ -229,7 +229,7 @@ type OrganizationsApi interface {
 	*/
 	ListOrganizationProjectsWithParams(ctx context.Context, args *ListOrganizationProjectsApiParams) ListOrganizationProjectsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListOrganizationProjectsExecute(r ListOrganizationProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error)
 
 	/*
@@ -252,7 +252,7 @@ type OrganizationsApi interface {
 	*/
 	ListOrganizationUsersWithParams(ctx context.Context, args *ListOrganizationUsersApiParams) ListOrganizationUsersApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListOrganizationUsersExecute(r ListOrganizationUsersApiRequest) (*PaginatedAppUser, *http.Response, error)
 
 	/*
@@ -274,7 +274,7 @@ type OrganizationsApi interface {
 	*/
 	ListOrganizationsWithParams(ctx context.Context, args *ListOrganizationsApiParams) ListOrganizationsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListOrganizationsExecute(r ListOrganizationsApiRequest) (*PaginatedOrganization, *http.Response, error)
 
 	/*
@@ -298,7 +298,7 @@ type OrganizationsApi interface {
 	*/
 	RemoveOrganizationUserWithParams(ctx context.Context, args *RemoveOrganizationUserApiParams) RemoveOrganizationUserApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	RemoveOrganizationUserExecute(r RemoveOrganizationUserApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -321,7 +321,7 @@ type OrganizationsApi interface {
 	*/
 	RenameOrganizationWithParams(ctx context.Context, args *RenameOrganizationApiParams) RenameOrganizationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	RenameOrganizationExecute(r RenameOrganizationApiRequest) (*AtlasOrganization, *http.Response, error)
 
 	/*
@@ -344,7 +344,7 @@ type OrganizationsApi interface {
 	*/
 	UpdateOrganizationInvitationWithParams(ctx context.Context, args *UpdateOrganizationInvitationApiParams) UpdateOrganizationInvitationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateOrganizationInvitationExecute(r UpdateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
@@ -368,7 +368,7 @@ type OrganizationsApi interface {
 	*/
 	UpdateOrganizationInvitationByIdWithParams(ctx context.Context, args *UpdateOrganizationInvitationByIdApiParams) UpdateOrganizationInvitationByIdApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateOrganizationInvitationByIdExecute(r UpdateOrganizationInvitationByIdApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
@@ -392,7 +392,7 @@ type OrganizationsApi interface {
 	*/
 	UpdateOrganizationRolesWithParams(ctx context.Context, args *UpdateOrganizationRolesApiParams) UpdateOrganizationRolesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateOrganizationRolesExecute(r UpdateOrganizationRolesApiRequest) (*UpdateOrgRolesForUser, *http.Response, error)
 
 	/*
@@ -415,7 +415,7 @@ type OrganizationsApi interface {
 	*/
 	UpdateOrganizationSettingsWithParams(ctx context.Context, args *UpdateOrganizationSettingsApiParams) UpdateOrganizationSettingsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateOrganizationSettingsExecute(r UpdateOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error)
 }
 

--- a/admin/api_performance_advisor.go
+++ b/admin/api_performance_advisor.go
@@ -34,7 +34,7 @@ type PerformanceAdvisorApi interface {
 	*/
 	DisableSlowOperationThresholdingWithParams(ctx context.Context, args *DisableSlowOperationThresholdingApiParams) DisableSlowOperationThresholdingApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DisableSlowOperationThresholdingExecute(r DisableSlowOperationThresholdingApiRequest) (*http.Response, error)
 
 	/*
@@ -57,7 +57,7 @@ type PerformanceAdvisorApi interface {
 	*/
 	EnableSlowOperationThresholdingWithParams(ctx context.Context, args *EnableSlowOperationThresholdingApiParams) EnableSlowOperationThresholdingApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	EnableSlowOperationThresholdingExecute(r EnableSlowOperationThresholdingApiRequest) (*http.Response, error)
 
 	/*
@@ -81,7 +81,7 @@ type PerformanceAdvisorApi interface {
 	*/
 	ListSlowQueriesWithParams(ctx context.Context, args *ListSlowQueriesApiParams) ListSlowQueriesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListSlowQueriesExecute(r ListSlowQueriesApiRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error)
 
 	/*
@@ -105,7 +105,7 @@ type PerformanceAdvisorApi interface {
 	*/
 	ListSlowQueryNamespacesWithParams(ctx context.Context, args *ListSlowQueryNamespacesApiParams) ListSlowQueryNamespacesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListSlowQueryNamespacesExecute(r ListSlowQueryNamespacesApiRequest) (*Namespaces, *http.Response, error)
 
 	/*
@@ -129,7 +129,7 @@ type PerformanceAdvisorApi interface {
 	*/
 	ListSuggestedIndexesWithParams(ctx context.Context, args *ListSuggestedIndexesApiParams) ListSuggestedIndexesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListSuggestedIndexesExecute(r ListSuggestedIndexesApiRequest) (*PerformanceAdvisorResponse, *http.Response, error)
 }
 

--- a/admin/api_performance_advisor.go
+++ b/admin/api_performance_advisor.go
@@ -35,7 +35,7 @@ type PerformanceAdvisorApi interface {
 	DisableSlowOperationThresholdingWithParams(ctx context.Context, args *DisableSlowOperationThresholdingApiParams) DisableSlowOperationThresholdingApiRequest
 
 	// Interface only available internally
-	disableSlowOperationThresholdingExecute(r DisableSlowOperationThresholdingApiRequest) (*http.Response, error)
+	DisableSlowOperationThresholdingExecute(r DisableSlowOperationThresholdingApiRequest) (*http.Response, error)
 
 	/*
 		EnableSlowOperationThresholding Enable Managed Slow Operation Threshold
@@ -58,7 +58,7 @@ type PerformanceAdvisorApi interface {
 	EnableSlowOperationThresholdingWithParams(ctx context.Context, args *EnableSlowOperationThresholdingApiParams) EnableSlowOperationThresholdingApiRequest
 
 	// Interface only available internally
-	enableSlowOperationThresholdingExecute(r EnableSlowOperationThresholdingApiRequest) (*http.Response, error)
+	EnableSlowOperationThresholdingExecute(r EnableSlowOperationThresholdingApiRequest) (*http.Response, error)
 
 	/*
 		ListSlowQueries Return Slow Queries
@@ -82,7 +82,7 @@ type PerformanceAdvisorApi interface {
 	ListSlowQueriesWithParams(ctx context.Context, args *ListSlowQueriesApiParams) ListSlowQueriesApiRequest
 
 	// Interface only available internally
-	listSlowQueriesExecute(r ListSlowQueriesApiRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error)
+	ListSlowQueriesExecute(r ListSlowQueriesApiRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error)
 
 	/*
 		ListSlowQueryNamespaces Return All Namespaces for One Host
@@ -106,7 +106,7 @@ type PerformanceAdvisorApi interface {
 	ListSlowQueryNamespacesWithParams(ctx context.Context, args *ListSlowQueryNamespacesApiParams) ListSlowQueryNamespacesApiRequest
 
 	// Interface only available internally
-	listSlowQueryNamespacesExecute(r ListSlowQueryNamespacesApiRequest) (*Namespaces, *http.Response, error)
+	ListSlowQueryNamespacesExecute(r ListSlowQueryNamespacesApiRequest) (*Namespaces, *http.Response, error)
 
 	/*
 		ListSuggestedIndexes Return Suggested Indexes
@@ -130,7 +130,7 @@ type PerformanceAdvisorApi interface {
 	ListSuggestedIndexesWithParams(ctx context.Context, args *ListSuggestedIndexesApiParams) ListSuggestedIndexesApiRequest
 
 	// Interface only available internally
-	listSuggestedIndexesExecute(r ListSuggestedIndexesApiRequest) (*PerformanceAdvisorResponse, *http.Response, error)
+	ListSuggestedIndexesExecute(r ListSuggestedIndexesApiRequest) (*PerformanceAdvisorResponse, *http.Response, error)
 }
 
 // PerformanceAdvisorApiService PerformanceAdvisorApi service
@@ -155,7 +155,7 @@ func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholdingWithParam
 }
 
 func (r DisableSlowOperationThresholdingApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.disableSlowOperationThresholdingExecute(r)
+	return r.ApiService.DisableSlowOperationThresholdingExecute(r)
 }
 
 /*
@@ -176,7 +176,7 @@ func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholding(ctx cont
 }
 
 // Execute executes the request
-func (a *PerformanceAdvisorApiService) disableSlowOperationThresholdingExecute(r DisableSlowOperationThresholdingApiRequest) (*http.Response, error) {
+func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholdingExecute(r DisableSlowOperationThresholdingApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -267,7 +267,7 @@ func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholdingWithParams
 }
 
 func (r EnableSlowOperationThresholdingApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.enableSlowOperationThresholdingExecute(r)
+	return r.ApiService.EnableSlowOperationThresholdingExecute(r)
 }
 
 /*
@@ -288,7 +288,7 @@ func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholding(ctx conte
 }
 
 // Execute executes the request
-func (a *PerformanceAdvisorApiService) enableSlowOperationThresholdingExecute(r EnableSlowOperationThresholdingApiRequest) (*http.Response, error) {
+func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholdingExecute(r EnableSlowOperationThresholdingApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -418,7 +418,7 @@ func (r ListSlowQueriesApiRequest) Since(since int64) ListSlowQueriesApiRequest 
 }
 
 func (r ListSlowQueriesApiRequest) Execute() (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
-	return r.ApiService.listSlowQueriesExecute(r)
+	return r.ApiService.ListSlowQueriesExecute(r)
 }
 
 /*
@@ -443,7 +443,7 @@ func (a *PerformanceAdvisorApiService) ListSlowQueries(ctx context.Context, grou
 // Execute executes the request
 //
 //	@return PerformanceAdvisorSlowQueryList
-func (a *PerformanceAdvisorApiService) listSlowQueriesExecute(r ListSlowQueriesApiRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
+func (a *PerformanceAdvisorApiService) ListSlowQueriesExecute(r ListSlowQueriesApiRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -586,7 +586,7 @@ func (r ListSlowQueryNamespacesApiRequest) Since(since int64) ListSlowQueryNames
 }
 
 func (r ListSlowQueryNamespacesApiRequest) Execute() (*Namespaces, *http.Response, error) {
-	return r.ApiService.listSlowQueryNamespacesExecute(r)
+	return r.ApiService.ListSlowQueryNamespacesExecute(r)
 }
 
 /*
@@ -611,7 +611,7 @@ func (a *PerformanceAdvisorApiService) ListSlowQueryNamespaces(ctx context.Conte
 // Execute executes the request
 //
 //	@return Namespaces
-func (a *PerformanceAdvisorApiService) listSlowQueryNamespacesExecute(r ListSlowQueryNamespacesApiRequest) (*Namespaces, *http.Response, error) {
+func (a *PerformanceAdvisorApiService) ListSlowQueryNamespacesExecute(r ListSlowQueryNamespacesApiRequest) (*Namespaces, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -794,7 +794,7 @@ func (r ListSuggestedIndexesApiRequest) Since(since int64) ListSuggestedIndexesA
 }
 
 func (r ListSuggestedIndexesApiRequest) Execute() (*PerformanceAdvisorResponse, *http.Response, error) {
-	return r.ApiService.listSuggestedIndexesExecute(r)
+	return r.ApiService.ListSuggestedIndexesExecute(r)
 }
 
 /*
@@ -819,7 +819,7 @@ func (a *PerformanceAdvisorApiService) ListSuggestedIndexes(ctx context.Context,
 // Execute executes the request
 //
 //	@return PerformanceAdvisorResponse
-func (a *PerformanceAdvisorApiService) listSuggestedIndexesExecute(r ListSuggestedIndexesApiRequest) (*PerformanceAdvisorResponse, *http.Response, error) {
+func (a *PerformanceAdvisorApiService) ListSuggestedIndexesExecute(r ListSuggestedIndexesApiRequest) (*PerformanceAdvisorResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_private_endpoint_services.go
+++ b/admin/api_private_endpoint_services.go
@@ -36,7 +36,7 @@ type PrivateEndpointServicesApi interface {
 	CreatePrivateEndpointWithParams(ctx context.Context, args *CreatePrivateEndpointApiParams) CreatePrivateEndpointApiRequest
 
 	// Interface only available internally
-	createPrivateEndpointExecute(r CreatePrivateEndpointApiRequest) (*PrivateLinkEndpoint, *http.Response, error)
+	CreatePrivateEndpointExecute(r CreatePrivateEndpointApiRequest) (*PrivateLinkEndpoint, *http.Response, error)
 
 	/*
 		CreatePrivateEndpointService Create One Private Endpoint Service for One Provider
@@ -59,7 +59,7 @@ type PrivateEndpointServicesApi interface {
 	CreatePrivateEndpointServiceWithParams(ctx context.Context, args *CreatePrivateEndpointServiceApiParams) CreatePrivateEndpointServiceApiRequest
 
 	// Interface only available internally
-	createPrivateEndpointServiceExecute(r CreatePrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error)
+	CreatePrivateEndpointServiceExecute(r CreatePrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error)
 
 	/*
 		DeletePrivateEndpoint Remove One Private Endpoint for One Provider
@@ -85,7 +85,7 @@ type PrivateEndpointServicesApi interface {
 	DeletePrivateEndpointWithParams(ctx context.Context, args *DeletePrivateEndpointApiParams) DeletePrivateEndpointApiRequest
 
 	// Interface only available internally
-	deletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error)
+	DeletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DeletePrivateEndpointService Remove One Private Endpoint Service for One Provider
@@ -110,7 +110,7 @@ type PrivateEndpointServicesApi interface {
 	DeletePrivateEndpointServiceWithParams(ctx context.Context, args *DeletePrivateEndpointServiceApiParams) DeletePrivateEndpointServiceApiRequest
 
 	// Interface only available internally
-	deletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (map[string]interface{}, *http.Response, error)
+	DeletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetPrivateEndpoint Return One Private Endpoint for One Provider
@@ -136,7 +136,7 @@ type PrivateEndpointServicesApi interface {
 	GetPrivateEndpointWithParams(ctx context.Context, args *GetPrivateEndpointApiParams) GetPrivateEndpointApiRequest
 
 	// Interface only available internally
-	getPrivateEndpointExecute(r GetPrivateEndpointApiRequest) (*PrivateLinkEndpoint, *http.Response, error)
+	GetPrivateEndpointExecute(r GetPrivateEndpointApiRequest) (*PrivateLinkEndpoint, *http.Response, error)
 
 	/*
 		GetPrivateEndpointService Return One Private Endpoint Service for One Provider
@@ -161,7 +161,7 @@ type PrivateEndpointServicesApi interface {
 	GetPrivateEndpointServiceWithParams(ctx context.Context, args *GetPrivateEndpointServiceApiParams) GetPrivateEndpointServiceApiRequest
 
 	// Interface only available internally
-	getPrivateEndpointServiceExecute(r GetPrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error)
+	GetPrivateEndpointServiceExecute(r GetPrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error)
 
 	/*
 		GetRegionalizedPrivateEndpointSetting Return Regionalized Private Endpoint Status
@@ -184,7 +184,7 @@ type PrivateEndpointServicesApi interface {
 	GetRegionalizedPrivateEndpointSettingWithParams(ctx context.Context, args *GetRegionalizedPrivateEndpointSettingApiParams) GetRegionalizedPrivateEndpointSettingApiRequest
 
 	// Interface only available internally
-	getRegionalizedPrivateEndpointSettingExecute(r GetRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error)
+	GetRegionalizedPrivateEndpointSettingExecute(r GetRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error)
 
 	/*
 		ListPrivateEndpointServices Return All Private Endpoint Services for One Provider
@@ -208,7 +208,7 @@ type PrivateEndpointServicesApi interface {
 	ListPrivateEndpointServicesWithParams(ctx context.Context, args *ListPrivateEndpointServicesApiParams) ListPrivateEndpointServicesApiRequest
 
 	// Interface only available internally
-	listPrivateEndpointServicesExecute(r ListPrivateEndpointServicesApiRequest) ([]EndpointService, *http.Response, error)
+	ListPrivateEndpointServicesExecute(r ListPrivateEndpointServicesApiRequest) ([]EndpointService, *http.Response, error)
 
 	/*
 		ToggleRegionalizedPrivateEndpointSetting Toggle Regionalized Private Endpoint Status
@@ -231,7 +231,7 @@ type PrivateEndpointServicesApi interface {
 	ToggleRegionalizedPrivateEndpointSettingWithParams(ctx context.Context, args *ToggleRegionalizedPrivateEndpointSettingApiParams) ToggleRegionalizedPrivateEndpointSettingApiRequest
 
 	// Interface only available internally
-	toggleRegionalizedPrivateEndpointSettingExecute(r ToggleRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error)
+	ToggleRegionalizedPrivateEndpointSettingExecute(r ToggleRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error)
 }
 
 // PrivateEndpointServicesApiService PrivateEndpointServicesApi service
@@ -265,7 +265,7 @@ func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointWithParams(ctx 
 }
 
 func (r CreatePrivateEndpointApiRequest) Execute() (*PrivateLinkEndpoint, *http.Response, error) {
-	return r.ApiService.createPrivateEndpointExecute(r)
+	return r.ApiService.CreatePrivateEndpointExecute(r)
 }
 
 /*
@@ -293,7 +293,7 @@ func (a *PrivateEndpointServicesApiService) CreatePrivateEndpoint(ctx context.Co
 // Execute executes the request
 //
 //	@return PrivateLinkEndpoint
-func (a *PrivateEndpointServicesApiService) createPrivateEndpointExecute(r CreatePrivateEndpointApiRequest) (*PrivateLinkEndpoint, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointExecute(r CreatePrivateEndpointApiRequest) (*PrivateLinkEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -404,7 +404,7 @@ func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointServiceWithPara
 }
 
 func (r CreatePrivateEndpointServiceApiRequest) Execute() (*EndpointService, *http.Response, error) {
-	return r.ApiService.createPrivateEndpointServiceExecute(r)
+	return r.ApiService.CreatePrivateEndpointServiceExecute(r)
 }
 
 /*
@@ -428,7 +428,7 @@ func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointService(ctx con
 // Execute executes the request
 //
 //	@return EndpointService
-func (a *PrivateEndpointServicesApiService) createPrivateEndpointServiceExecute(r CreatePrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointServiceExecute(r CreatePrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -543,7 +543,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointWithParams(ctx 
 }
 
 func (r DeletePrivateEndpointApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deletePrivateEndpointExecute(r)
+	return r.ApiService.DeletePrivateEndpointExecute(r)
 }
 
 /*
@@ -572,7 +572,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpoint(ctx context.Co
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *PrivateEndpointServicesApiService) deletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -682,7 +682,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointServiceWithPara
 }
 
 func (r DeletePrivateEndpointServiceApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deletePrivateEndpointServiceExecute(r)
+	return r.ApiService.DeletePrivateEndpointServiceExecute(r)
 }
 
 /*
@@ -709,7 +709,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointService(ctx con
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *PrivateEndpointServicesApiService) deletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -821,7 +821,7 @@ func (a *PrivateEndpointServicesApiService) GetPrivateEndpointWithParams(ctx con
 }
 
 func (r GetPrivateEndpointApiRequest) Execute() (*PrivateLinkEndpoint, *http.Response, error) {
-	return r.ApiService.getPrivateEndpointExecute(r)
+	return r.ApiService.GetPrivateEndpointExecute(r)
 }
 
 /*
@@ -850,7 +850,7 @@ func (a *PrivateEndpointServicesApiService) GetPrivateEndpoint(ctx context.Conte
 // Execute executes the request
 //
 //	@return PrivateLinkEndpoint
-func (a *PrivateEndpointServicesApiService) getPrivateEndpointExecute(r GetPrivateEndpointApiRequest) (*PrivateLinkEndpoint, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) GetPrivateEndpointExecute(r GetPrivateEndpointApiRequest) (*PrivateLinkEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -960,7 +960,7 @@ func (a *PrivateEndpointServicesApiService) GetPrivateEndpointServiceWithParams(
 }
 
 func (r GetPrivateEndpointServiceApiRequest) Execute() (*EndpointService, *http.Response, error) {
-	return r.ApiService.getPrivateEndpointServiceExecute(r)
+	return r.ApiService.GetPrivateEndpointServiceExecute(r)
 }
 
 /*
@@ -987,7 +987,7 @@ func (a *PrivateEndpointServicesApiService) GetPrivateEndpointService(ctx contex
 // Execute executes the request
 //
 //	@return EndpointService
-func (a *PrivateEndpointServicesApiService) getPrivateEndpointServiceExecute(r GetPrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) GetPrivateEndpointServiceExecute(r GetPrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1090,7 +1090,7 @@ func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSettin
 }
 
 func (r GetRegionalizedPrivateEndpointSettingApiRequest) Execute() (*ProjectSettingItem, *http.Response, error) {
-	return r.ApiService.getRegionalizedPrivateEndpointSettingExecute(r)
+	return r.ApiService.GetRegionalizedPrivateEndpointSettingExecute(r)
 }
 
 /*
@@ -1113,7 +1113,7 @@ func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSettin
 // Execute executes the request
 //
 //	@return ProjectSettingItem
-func (a *PrivateEndpointServicesApiService) getRegionalizedPrivateEndpointSettingExecute(r GetRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSettingExecute(r GetRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1217,7 +1217,7 @@ func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServicesWithParam
 }
 
 func (r ListPrivateEndpointServicesApiRequest) Execute() ([]EndpointService, *http.Response, error) {
-	return r.ApiService.listPrivateEndpointServicesExecute(r)
+	return r.ApiService.ListPrivateEndpointServicesExecute(r)
 }
 
 /*
@@ -1242,7 +1242,7 @@ func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServices(ctx cont
 // Execute executes the request
 //
 //	@return []EndpointService
-func (a *PrivateEndpointServicesApiService) listPrivateEndpointServicesExecute(r ListPrivateEndpointServicesApiRequest) ([]EndpointService, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServicesExecute(r ListPrivateEndpointServicesApiRequest) ([]EndpointService, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1347,7 +1347,7 @@ func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSet
 }
 
 func (r ToggleRegionalizedPrivateEndpointSettingApiRequest) Execute() (*ProjectSettingItem, *http.Response, error) {
-	return r.ApiService.toggleRegionalizedPrivateEndpointSettingExecute(r)
+	return r.ApiService.ToggleRegionalizedPrivateEndpointSettingExecute(r)
 }
 
 /*
@@ -1371,7 +1371,7 @@ func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSet
 // Execute executes the request
 //
 //	@return ProjectSettingItem
-func (a *PrivateEndpointServicesApiService) toggleRegionalizedPrivateEndpointSettingExecute(r ToggleRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSettingExecute(r ToggleRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_private_endpoint_services.go
+++ b/admin/api_private_endpoint_services.go
@@ -35,7 +35,7 @@ type PrivateEndpointServicesApi interface {
 	*/
 	CreatePrivateEndpointWithParams(ctx context.Context, args *CreatePrivateEndpointApiParams) CreatePrivateEndpointApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreatePrivateEndpointExecute(r CreatePrivateEndpointApiRequest) (*PrivateLinkEndpoint, *http.Response, error)
 
 	/*
@@ -58,7 +58,7 @@ type PrivateEndpointServicesApi interface {
 	*/
 	CreatePrivateEndpointServiceWithParams(ctx context.Context, args *CreatePrivateEndpointServiceApiParams) CreatePrivateEndpointServiceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreatePrivateEndpointServiceExecute(r CreatePrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error)
 
 	/*
@@ -84,7 +84,7 @@ type PrivateEndpointServicesApi interface {
 	*/
 	DeletePrivateEndpointWithParams(ctx context.Context, args *DeletePrivateEndpointApiParams) DeletePrivateEndpointApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -109,7 +109,7 @@ type PrivateEndpointServicesApi interface {
 	*/
 	DeletePrivateEndpointServiceWithParams(ctx context.Context, args *DeletePrivateEndpointServiceApiParams) DeletePrivateEndpointServiceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -135,7 +135,7 @@ type PrivateEndpointServicesApi interface {
 	*/
 	GetPrivateEndpointWithParams(ctx context.Context, args *GetPrivateEndpointApiParams) GetPrivateEndpointApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetPrivateEndpointExecute(r GetPrivateEndpointApiRequest) (*PrivateLinkEndpoint, *http.Response, error)
 
 	/*
@@ -160,7 +160,7 @@ type PrivateEndpointServicesApi interface {
 	*/
 	GetPrivateEndpointServiceWithParams(ctx context.Context, args *GetPrivateEndpointServiceApiParams) GetPrivateEndpointServiceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetPrivateEndpointServiceExecute(r GetPrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error)
 
 	/*
@@ -183,7 +183,7 @@ type PrivateEndpointServicesApi interface {
 	*/
 	GetRegionalizedPrivateEndpointSettingWithParams(ctx context.Context, args *GetRegionalizedPrivateEndpointSettingApiParams) GetRegionalizedPrivateEndpointSettingApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetRegionalizedPrivateEndpointSettingExecute(r GetRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error)
 
 	/*
@@ -207,7 +207,7 @@ type PrivateEndpointServicesApi interface {
 	*/
 	ListPrivateEndpointServicesWithParams(ctx context.Context, args *ListPrivateEndpointServicesApiParams) ListPrivateEndpointServicesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListPrivateEndpointServicesExecute(r ListPrivateEndpointServicesApiRequest) ([]EndpointService, *http.Response, error)
 
 	/*
@@ -230,7 +230,7 @@ type PrivateEndpointServicesApi interface {
 	*/
 	ToggleRegionalizedPrivateEndpointSettingWithParams(ctx context.Context, args *ToggleRegionalizedPrivateEndpointSettingApiParams) ToggleRegionalizedPrivateEndpointSettingApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ToggleRegionalizedPrivateEndpointSettingExecute(r ToggleRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error)
 }
 

--- a/admin/api_programmatic_api_keys.go
+++ b/admin/api_programmatic_api_keys.go
@@ -34,7 +34,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	AddProjectApiKeyWithParams(ctx context.Context, args *AddProjectApiKeyApiParams) AddProjectApiKeyApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	AddProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
 
 	/*
@@ -57,7 +57,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	CreateApiKeyWithParams(ctx context.Context, args *CreateApiKeyApiParams) CreateApiKeyApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateApiKeyExecute(r CreateApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
 
 	/*
@@ -81,7 +81,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	CreateApiKeyAccessListWithParams(ctx context.Context, args *CreateApiKeyAccessListApiParams) CreateApiKeyAccessListApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateApiKeyAccessListExecute(r CreateApiKeyAccessListApiRequest) (*PaginatedApiUserAccessList, *http.Response, error)
 
 	/*
@@ -104,7 +104,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	CreateProjectApiKeyWithParams(ctx context.Context, args *CreateProjectApiKeyApiParams) CreateProjectApiKeyApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateProjectApiKeyExecute(r CreateProjectApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
 
 	/*
@@ -128,7 +128,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	DeleteApiKeyWithParams(ctx context.Context, args *DeleteApiKeyApiParams) DeleteApiKeyApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteApiKeyExecute(r DeleteApiKeyApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -153,7 +153,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	DeleteApiKeyAccessListEntryWithParams(ctx context.Context, args *DeleteApiKeyAccessListEntryApiParams) DeleteApiKeyAccessListEntryApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -177,7 +177,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	GetApiKeyWithParams(ctx context.Context, args *GetApiKeyApiParams) GetApiKeyApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetApiKeyExecute(r GetApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
 
 	/*
@@ -202,7 +202,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	GetApiKeyAccessListWithParams(ctx context.Context, args *GetApiKeyAccessListApiParams) GetApiKeyAccessListApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetApiKeyAccessListExecute(r GetApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error)
 
 	/*
@@ -226,7 +226,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	ListApiKeyAccessListsEntriesWithParams(ctx context.Context, args *ListApiKeyAccessListsEntriesApiParams) ListApiKeyAccessListsEntriesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListApiKeyAccessListsEntriesExecute(r ListApiKeyAccessListsEntriesApiRequest) (*PaginatedApiUserAccessList, *http.Response, error)
 
 	/*
@@ -249,7 +249,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	ListApiKeysWithParams(ctx context.Context, args *ListApiKeysApiParams) ListApiKeysApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListApiKeysExecute(r ListApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error)
 
 	/*
@@ -272,7 +272,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	ListProjectApiKeysWithParams(ctx context.Context, args *ListProjectApiKeysApiParams) ListProjectApiKeysApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListProjectApiKeysExecute(r ListProjectApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error)
 
 	/*
@@ -296,7 +296,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	RemoveProjectApiKeyWithParams(ctx context.Context, args *RemoveProjectApiKeyApiParams) RemoveProjectApiKeyApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	RemoveProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -320,7 +320,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	UpdateApiKeyWithParams(ctx context.Context, args *UpdateApiKeyApiParams) UpdateApiKeyApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateApiKeyExecute(r UpdateApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
 
 	/*
@@ -344,7 +344,7 @@ type ProgrammaticAPIKeysApi interface {
 	*/
 	UpdateApiKeyRolesWithParams(ctx context.Context, args *UpdateApiKeyRolesApiParams) UpdateApiKeyRolesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateApiKeyRolesExecute(r UpdateApiKeyRolesApiRequest) (*ApiKeyUserDetails, *http.Response, error)
 }
 

--- a/admin/api_programmatic_api_keys.go
+++ b/admin/api_programmatic_api_keys.go
@@ -35,7 +35,7 @@ type ProgrammaticAPIKeysApi interface {
 	AddProjectApiKeyWithParams(ctx context.Context, args *AddProjectApiKeyApiParams) AddProjectApiKeyApiRequest
 
 	// Interface only available internally
-	addProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
+	AddProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
 
 	/*
 		CreateApiKey Create One Organization API Key
@@ -58,7 +58,7 @@ type ProgrammaticAPIKeysApi interface {
 	CreateApiKeyWithParams(ctx context.Context, args *CreateApiKeyApiParams) CreateApiKeyApiRequest
 
 	// Interface only available internally
-	createApiKeyExecute(r CreateApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
+	CreateApiKeyExecute(r CreateApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
 
 	/*
 		CreateApiKeyAccessList Create Access List Entries for One Organization API Key
@@ -82,7 +82,7 @@ type ProgrammaticAPIKeysApi interface {
 	CreateApiKeyAccessListWithParams(ctx context.Context, args *CreateApiKeyAccessListApiParams) CreateApiKeyAccessListApiRequest
 
 	// Interface only available internally
-	createApiKeyAccessListExecute(r CreateApiKeyAccessListApiRequest) (*PaginatedApiUserAccessList, *http.Response, error)
+	CreateApiKeyAccessListExecute(r CreateApiKeyAccessListApiRequest) (*PaginatedApiUserAccessList, *http.Response, error)
 
 	/*
 		CreateProjectApiKey Create and Assign One Organization API Key to One Project
@@ -105,7 +105,7 @@ type ProgrammaticAPIKeysApi interface {
 	CreateProjectApiKeyWithParams(ctx context.Context, args *CreateProjectApiKeyApiParams) CreateProjectApiKeyApiRequest
 
 	// Interface only available internally
-	createProjectApiKeyExecute(r CreateProjectApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
+	CreateProjectApiKeyExecute(r CreateProjectApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
 
 	/*
 		DeleteApiKey Remove One Organization API Key
@@ -129,7 +129,7 @@ type ProgrammaticAPIKeysApi interface {
 	DeleteApiKeyWithParams(ctx context.Context, args *DeleteApiKeyApiParams) DeleteApiKeyApiRequest
 
 	// Interface only available internally
-	deleteApiKeyExecute(r DeleteApiKeyApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteApiKeyExecute(r DeleteApiKeyApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DeleteApiKeyAccessListEntry Remove One Access List Entry for One Organization API Key
@@ -154,7 +154,7 @@ type ProgrammaticAPIKeysApi interface {
 	DeleteApiKeyAccessListEntryWithParams(ctx context.Context, args *DeleteApiKeyAccessListEntryApiParams) DeleteApiKeyAccessListEntryApiRequest
 
 	// Interface only available internally
-	deleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetApiKey Return One Organization API Key
@@ -178,7 +178,7 @@ type ProgrammaticAPIKeysApi interface {
 	GetApiKeyWithParams(ctx context.Context, args *GetApiKeyApiParams) GetApiKeyApiRequest
 
 	// Interface only available internally
-	getApiKeyExecute(r GetApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
+	GetApiKeyExecute(r GetApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
 
 	/*
 		GetApiKeyAccessList Return One Access List Entry for One Organization API Key
@@ -203,7 +203,7 @@ type ProgrammaticAPIKeysApi interface {
 	GetApiKeyAccessListWithParams(ctx context.Context, args *GetApiKeyAccessListApiParams) GetApiKeyAccessListApiRequest
 
 	// Interface only available internally
-	getApiKeyAccessListExecute(r GetApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error)
+	GetApiKeyAccessListExecute(r GetApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error)
 
 	/*
 		ListApiKeyAccessListsEntries Return All Access List Entries for One Organization API Key
@@ -227,7 +227,7 @@ type ProgrammaticAPIKeysApi interface {
 	ListApiKeyAccessListsEntriesWithParams(ctx context.Context, args *ListApiKeyAccessListsEntriesApiParams) ListApiKeyAccessListsEntriesApiRequest
 
 	// Interface only available internally
-	listApiKeyAccessListsEntriesExecute(r ListApiKeyAccessListsEntriesApiRequest) (*PaginatedApiUserAccessList, *http.Response, error)
+	ListApiKeyAccessListsEntriesExecute(r ListApiKeyAccessListsEntriesApiRequest) (*PaginatedApiUserAccessList, *http.Response, error)
 
 	/*
 		ListApiKeys Return All Organization API Keys
@@ -250,7 +250,7 @@ type ProgrammaticAPIKeysApi interface {
 	ListApiKeysWithParams(ctx context.Context, args *ListApiKeysApiParams) ListApiKeysApiRequest
 
 	// Interface only available internally
-	listApiKeysExecute(r ListApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error)
+	ListApiKeysExecute(r ListApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error)
 
 	/*
 		ListProjectApiKeys Return All Organization API Keys Assigned to One Project
@@ -273,7 +273,7 @@ type ProgrammaticAPIKeysApi interface {
 	ListProjectApiKeysWithParams(ctx context.Context, args *ListProjectApiKeysApiParams) ListProjectApiKeysApiRequest
 
 	// Interface only available internally
-	listProjectApiKeysExecute(r ListProjectApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error)
+	ListProjectApiKeysExecute(r ListProjectApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error)
 
 	/*
 		RemoveProjectApiKey Unassign One Organization API Key from One Project
@@ -297,7 +297,7 @@ type ProgrammaticAPIKeysApi interface {
 	RemoveProjectApiKeyWithParams(ctx context.Context, args *RemoveProjectApiKeyApiParams) RemoveProjectApiKeyApiRequest
 
 	// Interface only available internally
-	removeProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (map[string]interface{}, *http.Response, error)
+	RemoveProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		UpdateApiKey Update One Organization API Key
@@ -321,7 +321,7 @@ type ProgrammaticAPIKeysApi interface {
 	UpdateApiKeyWithParams(ctx context.Context, args *UpdateApiKeyApiParams) UpdateApiKeyApiRequest
 
 	// Interface only available internally
-	updateApiKeyExecute(r UpdateApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
+	UpdateApiKeyExecute(r UpdateApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error)
 
 	/*
 		UpdateApiKeyRoles Update Roles of One Organization API Key to One Project
@@ -345,7 +345,7 @@ type ProgrammaticAPIKeysApi interface {
 	UpdateApiKeyRolesWithParams(ctx context.Context, args *UpdateApiKeyRolesApiParams) UpdateApiKeyRolesApiRequest
 
 	// Interface only available internally
-	updateApiKeyRolesExecute(r UpdateApiKeyRolesApiRequest) (*ApiKeyUserDetails, *http.Response, error)
+	UpdateApiKeyRolesExecute(r UpdateApiKeyRolesApiRequest) (*ApiKeyUserDetails, *http.Response, error)
 }
 
 // ProgrammaticAPIKeysApiService ProgrammaticAPIKeysApi service
@@ -376,7 +376,7 @@ func (a *ProgrammaticAPIKeysApiService) AddProjectApiKeyWithParams(ctx context.C
 }
 
 func (r AddProjectApiKeyApiRequest) Execute() (*ApiKeyUserDetails, *http.Response, error) {
-	return r.ApiService.addProjectApiKeyExecute(r)
+	return r.ApiService.AddProjectApiKeyExecute(r)
 }
 
 /*
@@ -402,7 +402,7 @@ func (a *ProgrammaticAPIKeysApiService) AddProjectApiKey(ctx context.Context, gr
 // Execute executes the request
 //
 //	@return ApiKeyUserDetails
-func (a *ProgrammaticAPIKeysApiService) addProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) AddProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -512,7 +512,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateApiKeyWithParams(ctx context.Conte
 }
 
 func (r CreateApiKeyApiRequest) Execute() (*ApiKeyUserDetails, *http.Response, error) {
-	return r.ApiService.createApiKeyExecute(r)
+	return r.ApiService.CreateApiKeyExecute(r)
 }
 
 /*
@@ -536,7 +536,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateApiKey(ctx context.Context, orgId 
 // Execute executes the request
 //
 //	@return ApiKeyUserDetails
-func (a *ProgrammaticAPIKeysApiService) createApiKeyExecute(r CreateApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) CreateApiKeyExecute(r CreateApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -675,7 +675,7 @@ func (r CreateApiKeyAccessListApiRequest) PageNum(pageNum int) CreateApiKeyAcces
 }
 
 func (r CreateApiKeyAccessListApiRequest) Execute() (*PaginatedApiUserAccessList, *http.Response, error) {
-	return r.ApiService.createApiKeyAccessListExecute(r)
+	return r.ApiService.CreateApiKeyAccessListExecute(r)
 }
 
 /*
@@ -701,7 +701,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessList(ctx context.Conte
 // Execute executes the request
 //
 //	@return PaginatedApiUserAccessList
-func (a *ProgrammaticAPIKeysApiService) createApiKeyAccessListExecute(r CreateApiKeyAccessListApiRequest) (*PaginatedApiUserAccessList, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessListExecute(r CreateApiKeyAccessListApiRequest) (*PaginatedApiUserAccessList, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -832,7 +832,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKeyWithParams(ctx contex
 }
 
 func (r CreateProjectApiKeyApiRequest) Execute() (*ApiKeyUserDetails, *http.Response, error) {
-	return r.ApiService.createProjectApiKeyExecute(r)
+	return r.ApiService.CreateProjectApiKeyExecute(r)
 }
 
 /*
@@ -856,7 +856,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKey(ctx context.Context,
 // Execute executes the request
 //
 //	@return ApiKeyUserDetails
-func (a *ProgrammaticAPIKeysApiService) createProjectApiKeyExecute(r CreateProjectApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKeyExecute(r CreateProjectApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -965,7 +965,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyWithParams(ctx context.Conte
 }
 
 func (r DeleteApiKeyApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteApiKeyExecute(r)
+	return r.ApiService.DeleteApiKeyExecute(r)
 }
 
 /*
@@ -990,7 +990,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKey(ctx context.Context, orgId 
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *ProgrammaticAPIKeysApiService) deleteApiKeyExecute(r DeleteApiKeyApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyExecute(r DeleteApiKeyApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -1098,7 +1098,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntryWithParams(ct
 }
 
 func (r DeleteApiKeyAccessListEntryApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteApiKeyAccessListEntryExecute(r)
+	return r.ApiService.DeleteApiKeyAccessListEntryExecute(r)
 }
 
 /*
@@ -1125,7 +1125,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntry(ctx context.
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *ProgrammaticAPIKeysApiService) deleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -1231,7 +1231,7 @@ func (a *ProgrammaticAPIKeysApiService) GetApiKeyWithParams(ctx context.Context,
 }
 
 func (r GetApiKeyApiRequest) Execute() (*ApiKeyUserDetails, *http.Response, error) {
-	return r.ApiService.getApiKeyExecute(r)
+	return r.ApiService.GetApiKeyExecute(r)
 }
 
 /*
@@ -1256,7 +1256,7 @@ func (a *ProgrammaticAPIKeysApiService) GetApiKey(ctx context.Context, orgId str
 // Execute executes the request
 //
 //	@return ApiKeyUserDetails
-func (a *ProgrammaticAPIKeysApiService) getApiKeyExecute(r GetApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) GetApiKeyExecute(r GetApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1364,7 +1364,7 @@ func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessListWithParams(ctx contex
 }
 
 func (r GetApiKeyAccessListApiRequest) Execute() (*UserAccessList, *http.Response, error) {
-	return r.ApiService.getApiKeyAccessListExecute(r)
+	return r.ApiService.GetApiKeyAccessListExecute(r)
 }
 
 /*
@@ -1391,7 +1391,7 @@ func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessList(ctx context.Context,
 // Execute executes the request
 //
 //	@return UserAccessList
-func (a *ProgrammaticAPIKeysApiService) getApiKeyAccessListExecute(r GetApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessListExecute(r GetApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1524,7 +1524,7 @@ func (r ListApiKeyAccessListsEntriesApiRequest) PageNum(pageNum int) ListApiKeyA
 }
 
 func (r ListApiKeyAccessListsEntriesApiRequest) Execute() (*PaginatedApiUserAccessList, *http.Response, error) {
-	return r.ApiService.listApiKeyAccessListsEntriesExecute(r)
+	return r.ApiService.ListApiKeyAccessListsEntriesExecute(r)
 }
 
 /*
@@ -1549,7 +1549,7 @@ func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntries(ctx context
 // Execute executes the request
 //
 //	@return PaginatedApiUserAccessList
-func (a *ProgrammaticAPIKeysApiService) listApiKeyAccessListsEntriesExecute(r ListApiKeyAccessListsEntriesApiRequest) (*PaginatedApiUserAccessList, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntriesExecute(r ListApiKeyAccessListsEntriesApiRequest) (*PaginatedApiUserAccessList, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1699,7 +1699,7 @@ func (r ListApiKeysApiRequest) PageNum(pageNum int) ListApiKeysApiRequest {
 }
 
 func (r ListApiKeysApiRequest) Execute() (*PaginatedApiApiUser, *http.Response, error) {
-	return r.ApiService.listApiKeysExecute(r)
+	return r.ApiService.ListApiKeysExecute(r)
 }
 
 /*
@@ -1722,7 +1722,7 @@ func (a *ProgrammaticAPIKeysApiService) ListApiKeys(ctx context.Context, orgId s
 // Execute executes the request
 //
 //	@return PaginatedApiApiUser
-func (a *ProgrammaticAPIKeysApiService) listApiKeysExecute(r ListApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) ListApiKeysExecute(r ListApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1871,7 +1871,7 @@ func (r ListProjectApiKeysApiRequest) PageNum(pageNum int) ListProjectApiKeysApi
 }
 
 func (r ListProjectApiKeysApiRequest) Execute() (*PaginatedApiApiUser, *http.Response, error) {
-	return r.ApiService.listProjectApiKeysExecute(r)
+	return r.ApiService.ListProjectApiKeysExecute(r)
 }
 
 /*
@@ -1894,7 +1894,7 @@ func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeys(ctx context.Context, 
 // Execute executes the request
 //
 //	@return PaginatedApiApiUser
-func (a *ProgrammaticAPIKeysApiService) listProjectApiKeysExecute(r ListProjectApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeysExecute(r ListProjectApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2019,7 +2019,7 @@ func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKeyWithParams(ctx contex
 }
 
 func (r RemoveProjectApiKeyApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.removeProjectApiKeyExecute(r)
+	return r.ApiService.RemoveProjectApiKeyExecute(r)
 }
 
 /*
@@ -2044,7 +2044,7 @@ func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKey(ctx context.Context,
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *ProgrammaticAPIKeysApiService) removeProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -2152,7 +2152,7 @@ func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyWithParams(ctx context.Conte
 }
 
 func (r UpdateApiKeyApiRequest) Execute() (*ApiKeyUserDetails, *http.Response, error) {
-	return r.ApiService.updateApiKeyExecute(r)
+	return r.ApiService.UpdateApiKeyExecute(r)
 }
 
 /*
@@ -2178,7 +2178,7 @@ func (a *ProgrammaticAPIKeysApiService) UpdateApiKey(ctx context.Context, orgId 
 // Execute executes the request
 //
 //	@return ApiKeyUserDetails
-func (a *ProgrammaticAPIKeysApiService) updateApiKeyExecute(r UpdateApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyExecute(r UpdateApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -2318,7 +2318,7 @@ func (r UpdateApiKeyRolesApiRequest) IncludeCount(includeCount bool) UpdateApiKe
 }
 
 func (r UpdateApiKeyRolesApiRequest) Execute() (*ApiKeyUserDetails, *http.Response, error) {
-	return r.ApiService.updateApiKeyRolesExecute(r)
+	return r.ApiService.UpdateApiKeyRolesExecute(r)
 }
 
 /*
@@ -2344,7 +2344,7 @@ func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyRoles(ctx context.Context, g
 // Execute executes the request
 //
 //	@return ApiKeyUserDetails
-func (a *ProgrammaticAPIKeysApiService) updateApiKeyRolesExecute(r UpdateApiKeyRolesApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyRolesExecute(r UpdateApiKeyRolesApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_project_ip_access_list.go
+++ b/admin/api_project_ip_access_list.go
@@ -34,7 +34,7 @@ type ProjectIPAccessListApi interface {
 	CreateProjectIpAccessListWithParams(ctx context.Context, args *CreateProjectIpAccessListApiParams) CreateProjectIpAccessListApiRequest
 
 	// Interface only available internally
-	createProjectIpAccessListExecute(r CreateProjectIpAccessListApiRequest) (*PaginatedNetworkAccess, *http.Response, error)
+	CreateProjectIpAccessListExecute(r CreateProjectIpAccessListApiRequest) (*PaginatedNetworkAccess, *http.Response, error)
 
 	/*
 		DeleteProjectIpAccessList Remove One Entry from One Project IP Access List
@@ -58,7 +58,7 @@ type ProjectIPAccessListApi interface {
 	DeleteProjectIpAccessListWithParams(ctx context.Context, args *DeleteProjectIpAccessListApiParams) DeleteProjectIpAccessListApiRequest
 
 	// Interface only available internally
-	deleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetProjectIpAccessListStatus Return Status of One Project IP Access List Entry
@@ -82,7 +82,7 @@ type ProjectIPAccessListApi interface {
 	GetProjectIpAccessListStatusWithParams(ctx context.Context, args *GetProjectIpAccessListStatusApiParams) GetProjectIpAccessListStatusApiRequest
 
 	// Interface only available internally
-	getProjectIpAccessListStatusExecute(r GetProjectIpAccessListStatusApiRequest) (*NetworkPermissionEntryStatus, *http.Response, error)
+	GetProjectIpAccessListStatusExecute(r GetProjectIpAccessListStatusApiRequest) (*NetworkPermissionEntryStatus, *http.Response, error)
 
 	/*
 		GetProjectIpList Return One Project IP Access List Entry
@@ -106,7 +106,7 @@ type ProjectIPAccessListApi interface {
 	GetProjectIpListWithParams(ctx context.Context, args *GetProjectIpListApiParams) GetProjectIpListApiRequest
 
 	// Interface only available internally
-	getProjectIpListExecute(r GetProjectIpListApiRequest) (*NetworkPermissionEntry, *http.Response, error)
+	GetProjectIpListExecute(r GetProjectIpListApiRequest) (*NetworkPermissionEntry, *http.Response, error)
 
 	/*
 		ListProjectIpAccessLists Return Project IP Access List
@@ -129,7 +129,7 @@ type ProjectIPAccessListApi interface {
 	ListProjectIpAccessListsWithParams(ctx context.Context, args *ListProjectIpAccessListsApiParams) ListProjectIpAccessListsApiRequest
 
 	// Interface only available internally
-	listProjectIpAccessListsExecute(r ListProjectIpAccessListsApiRequest) (*PaginatedNetworkAccess, *http.Response, error)
+	ListProjectIpAccessListsExecute(r ListProjectIpAccessListsApiRequest) (*PaginatedNetworkAccess, *http.Response, error)
 }
 
 // ProjectIPAccessListApiService ProjectIPAccessListApi service
@@ -184,7 +184,7 @@ func (r CreateProjectIpAccessListApiRequest) PageNum(pageNum int) CreateProjectI
 }
 
 func (r CreateProjectIpAccessListApiRequest) Execute() (*PaginatedNetworkAccess, *http.Response, error) {
-	return r.ApiService.createProjectIpAccessListExecute(r)
+	return r.ApiService.CreateProjectIpAccessListExecute(r)
 }
 
 /*
@@ -208,7 +208,7 @@ func (a *ProjectIPAccessListApiService) CreateProjectIpAccessList(ctx context.Co
 // Execute executes the request
 //
 //	@return PaginatedNetworkAccess
-func (a *ProjectIPAccessListApiService) createProjectIpAccessListExecute(r CreateProjectIpAccessListApiRequest) (*PaginatedNetworkAccess, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) CreateProjectIpAccessListExecute(r CreateProjectIpAccessListApiRequest) (*PaginatedNetworkAccess, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -338,7 +338,7 @@ func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessListWithParams(ctx 
 }
 
 func (r DeleteProjectIpAccessListApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteProjectIpAccessListExecute(r)
+	return r.ApiService.DeleteProjectIpAccessListExecute(r)
 }
 
 /*
@@ -363,7 +363,7 @@ func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessList(ctx context.Co
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *ProjectIPAccessListApiService) deleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -468,7 +468,7 @@ func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatusWithParams(c
 }
 
 func (r GetProjectIpAccessListStatusApiRequest) Execute() (*NetworkPermissionEntryStatus, *http.Response, error) {
-	return r.ApiService.getProjectIpAccessListStatusExecute(r)
+	return r.ApiService.GetProjectIpAccessListStatusExecute(r)
 }
 
 /*
@@ -493,7 +493,7 @@ func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatus(ctx context
 // Execute executes the request
 //
 //	@return NetworkPermissionEntryStatus
-func (a *ProjectIPAccessListApiService) getProjectIpAccessListStatusExecute(r GetProjectIpAccessListStatusApiRequest) (*NetworkPermissionEntryStatus, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatusExecute(r GetProjectIpAccessListStatusApiRequest) (*NetworkPermissionEntryStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -598,7 +598,7 @@ func (a *ProjectIPAccessListApiService) GetProjectIpListWithParams(ctx context.C
 }
 
 func (r GetProjectIpListApiRequest) Execute() (*NetworkPermissionEntry, *http.Response, error) {
-	return r.ApiService.getProjectIpListExecute(r)
+	return r.ApiService.GetProjectIpListExecute(r)
 }
 
 /*
@@ -623,7 +623,7 @@ func (a *ProjectIPAccessListApiService) GetProjectIpList(ctx context.Context, gr
 // Execute executes the request
 //
 //	@return NetworkPermissionEntry
-func (a *ProjectIPAccessListApiService) getProjectIpListExecute(r GetProjectIpListApiRequest) (*NetworkPermissionEntry, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) GetProjectIpListExecute(r GetProjectIpListApiRequest) (*NetworkPermissionEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -752,7 +752,7 @@ func (r ListProjectIpAccessListsApiRequest) PageNum(pageNum int) ListProjectIpAc
 }
 
 func (r ListProjectIpAccessListsApiRequest) Execute() (*PaginatedNetworkAccess, *http.Response, error) {
-	return r.ApiService.listProjectIpAccessListsExecute(r)
+	return r.ApiService.ListProjectIpAccessListsExecute(r)
 }
 
 /*
@@ -775,7 +775,7 @@ func (a *ProjectIPAccessListApiService) ListProjectIpAccessLists(ctx context.Con
 // Execute executes the request
 //
 //	@return PaginatedNetworkAccess
-func (a *ProjectIPAccessListApiService) listProjectIpAccessListsExecute(r ListProjectIpAccessListsApiRequest) (*PaginatedNetworkAccess, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) ListProjectIpAccessListsExecute(r ListProjectIpAccessListsApiRequest) (*PaginatedNetworkAccess, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_project_ip_access_list.go
+++ b/admin/api_project_ip_access_list.go
@@ -33,7 +33,7 @@ type ProjectIPAccessListApi interface {
 	*/
 	CreateProjectIpAccessListWithParams(ctx context.Context, args *CreateProjectIpAccessListApiParams) CreateProjectIpAccessListApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateProjectIpAccessListExecute(r CreateProjectIpAccessListApiRequest) (*PaginatedNetworkAccess, *http.Response, error)
 
 	/*
@@ -57,7 +57,7 @@ type ProjectIPAccessListApi interface {
 	*/
 	DeleteProjectIpAccessListWithParams(ctx context.Context, args *DeleteProjectIpAccessListApiParams) DeleteProjectIpAccessListApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -81,7 +81,7 @@ type ProjectIPAccessListApi interface {
 	*/
 	GetProjectIpAccessListStatusWithParams(ctx context.Context, args *GetProjectIpAccessListStatusApiParams) GetProjectIpAccessListStatusApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetProjectIpAccessListStatusExecute(r GetProjectIpAccessListStatusApiRequest) (*NetworkPermissionEntryStatus, *http.Response, error)
 
 	/*
@@ -105,7 +105,7 @@ type ProjectIPAccessListApi interface {
 	*/
 	GetProjectIpListWithParams(ctx context.Context, args *GetProjectIpListApiParams) GetProjectIpListApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetProjectIpListExecute(r GetProjectIpListApiRequest) (*NetworkPermissionEntry, *http.Response, error)
 
 	/*
@@ -128,7 +128,7 @@ type ProjectIPAccessListApi interface {
 	*/
 	ListProjectIpAccessListsWithParams(ctx context.Context, args *ListProjectIpAccessListsApiParams) ListProjectIpAccessListsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListProjectIpAccessListsExecute(r ListProjectIpAccessListsApiRequest) (*PaginatedNetworkAccess, *http.Response, error)
 }
 

--- a/admin/api_projects.go
+++ b/admin/api_projects.go
@@ -34,7 +34,7 @@ type ProjectsApi interface {
 	AddUserToProjectWithParams(ctx context.Context, args *AddUserToProjectApiParams) AddUserToProjectApiRequest
 
 	// Interface only available internally
-	addUserToProjectExecute(r AddUserToProjectApiRequest) (*OrganizationInvitation, *http.Response, error)
+	AddUserToProjectExecute(r AddUserToProjectApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 		CreateProject Create One Project
@@ -56,7 +56,7 @@ type ProjectsApi interface {
 	CreateProjectWithParams(ctx context.Context, args *CreateProjectApiParams) CreateProjectApiRequest
 
 	// Interface only available internally
-	createProjectExecute(r CreateProjectApiRequest) (*Group, *http.Response, error)
+	CreateProjectExecute(r CreateProjectApiRequest) (*Group, *http.Response, error)
 
 	/*
 		CreateProjectInvitation Invite One MongoDB Cloud User to Join One Project
@@ -83,7 +83,7 @@ type ProjectsApi interface {
 	CreateProjectInvitationWithParams(ctx context.Context, args *CreateProjectInvitationApiParams) CreateProjectInvitationApiRequest
 
 	// Interface only available internally
-	createProjectInvitationExecute(r CreateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
+	CreateProjectInvitationExecute(r CreateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
 		DeleteProject Remove One Project
@@ -106,7 +106,7 @@ type ProjectsApi interface {
 	DeleteProjectWithParams(ctx context.Context, args *DeleteProjectApiParams) DeleteProjectApiRequest
 
 	// Interface only available internally
-	deleteProjectExecute(r DeleteProjectApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteProjectExecute(r DeleteProjectApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DeleteProjectInvitation Cancel One Project Invitation
@@ -134,7 +134,7 @@ type ProjectsApi interface {
 	DeleteProjectInvitationWithParams(ctx context.Context, args *DeleteProjectInvitationApiParams) DeleteProjectInvitationApiRequest
 
 	// Interface only available internally
-	deleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DeleteProjectLimit Remove One Project Limit
@@ -158,7 +158,7 @@ type ProjectsApi interface {
 	DeleteProjectLimitWithParams(ctx context.Context, args *DeleteProjectLimitApiParams) DeleteProjectLimitApiRequest
 
 	// Interface only available internally
-	deleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetProject Return One Project
@@ -181,7 +181,7 @@ type ProjectsApi interface {
 	GetProjectWithParams(ctx context.Context, args *GetProjectApiParams) GetProjectApiRequest
 
 	// Interface only available internally
-	getProjectExecute(r GetProjectApiRequest) (*Group, *http.Response, error)
+	GetProjectExecute(r GetProjectApiRequest) (*Group, *http.Response, error)
 
 	/*
 		GetProjectByName Return One Project using Its Name
@@ -204,7 +204,7 @@ type ProjectsApi interface {
 	GetProjectByNameWithParams(ctx context.Context, args *GetProjectByNameApiParams) GetProjectByNameApiRequest
 
 	// Interface only available internally
-	getProjectByNameExecute(r GetProjectByNameApiRequest) (*Group, *http.Response, error)
+	GetProjectByNameExecute(r GetProjectByNameApiRequest) (*Group, *http.Response, error)
 
 	/*
 		GetProjectInvitation Return One Project Invitation
@@ -232,7 +232,7 @@ type ProjectsApi interface {
 	GetProjectInvitationWithParams(ctx context.Context, args *GetProjectInvitationApiParams) GetProjectInvitationApiRequest
 
 	// Interface only available internally
-	getProjectInvitationExecute(r GetProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
+	GetProjectInvitationExecute(r GetProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
 		GetProjectLimit Return One Limit for One Project
@@ -256,7 +256,7 @@ type ProjectsApi interface {
 	GetProjectLimitWithParams(ctx context.Context, args *GetProjectLimitApiParams) GetProjectLimitApiRequest
 
 	// Interface only available internally
-	getProjectLimitExecute(r GetProjectLimitApiRequest) (*DataFederationLimit, *http.Response, error)
+	GetProjectLimitExecute(r GetProjectLimitApiRequest) (*DataFederationLimit, *http.Response, error)
 
 	/*
 		GetProjectSettings Return One Project Settings
@@ -279,7 +279,7 @@ type ProjectsApi interface {
 	GetProjectSettingsWithParams(ctx context.Context, args *GetProjectSettingsApiParams) GetProjectSettingsApiRequest
 
 	// Interface only available internally
-	getProjectSettingsExecute(r GetProjectSettingsApiRequest) (*GroupSettings, *http.Response, error)
+	GetProjectSettingsExecute(r GetProjectSettingsApiRequest) (*GroupSettings, *http.Response, error)
 
 	/*
 		ListProjectInvitations Return All Project Invitations
@@ -306,7 +306,7 @@ type ProjectsApi interface {
 	ListProjectInvitationsWithParams(ctx context.Context, args *ListProjectInvitationsApiParams) ListProjectInvitationsApiRequest
 
 	// Interface only available internally
-	listProjectInvitationsExecute(r ListProjectInvitationsApiRequest) ([]GroupInvitation, *http.Response, error)
+	ListProjectInvitationsExecute(r ListProjectInvitationsApiRequest) ([]GroupInvitation, *http.Response, error)
 
 	/*
 		ListProjectLimits Return All Limits for One Project
@@ -329,7 +329,7 @@ type ProjectsApi interface {
 	ListProjectLimitsWithParams(ctx context.Context, args *ListProjectLimitsApiParams) ListProjectLimitsApiRequest
 
 	// Interface only available internally
-	listProjectLimitsExecute(r ListProjectLimitsApiRequest) ([]DataFederationLimit, *http.Response, error)
+	ListProjectLimitsExecute(r ListProjectLimitsApiRequest) ([]DataFederationLimit, *http.Response, error)
 
 	/*
 		ListProjectUsers Return All Users in One Project
@@ -352,7 +352,7 @@ type ProjectsApi interface {
 	ListProjectUsersWithParams(ctx context.Context, args *ListProjectUsersApiParams) ListProjectUsersApiRequest
 
 	// Interface only available internally
-	listProjectUsersExecute(r ListProjectUsersApiRequest) (*PaginatedAppUser, *http.Response, error)
+	ListProjectUsersExecute(r ListProjectUsersApiRequest) (*PaginatedAppUser, *http.Response, error)
 
 	/*
 		ListProjects Return All Projects
@@ -374,7 +374,7 @@ type ProjectsApi interface {
 	ListProjectsWithParams(ctx context.Context, args *ListProjectsApiParams) ListProjectsApiRequest
 
 	// Interface only available internally
-	listProjectsExecute(r ListProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error)
+	ListProjectsExecute(r ListProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error)
 
 	/*
 		RemoveProjectUser Remove One User from One Project
@@ -398,7 +398,7 @@ type ProjectsApi interface {
 	RemoveProjectUserWithParams(ctx context.Context, args *RemoveProjectUserApiParams) RemoveProjectUserApiRequest
 
 	// Interface only available internally
-	removeProjectUserExecute(r RemoveProjectUserApiRequest) (*http.Response, error)
+	RemoveProjectUserExecute(r RemoveProjectUserApiRequest) (*http.Response, error)
 
 	/*
 		ReturnAllIPAddresses Return All IP Addresses for One Project
@@ -421,7 +421,7 @@ type ProjectsApi interface {
 	ReturnAllIPAddressesWithParams(ctx context.Context, args *ReturnAllIPAddressesApiParams) ReturnAllIPAddressesApiRequest
 
 	// Interface only available internally
-	returnAllIPAddressesExecute(r ReturnAllIPAddressesApiRequest) (*GroupIPAddresses, *http.Response, error)
+	ReturnAllIPAddressesExecute(r ReturnAllIPAddressesApiRequest) (*GroupIPAddresses, *http.Response, error)
 
 	/*
 		SetProjectLimit Set One Project Limit
@@ -447,7 +447,7 @@ type ProjectsApi interface {
 	SetProjectLimitWithParams(ctx context.Context, args *SetProjectLimitApiParams) SetProjectLimitApiRequest
 
 	// Interface only available internally
-	setProjectLimitExecute(r SetProjectLimitApiRequest) (*DataFederationLimit, *http.Response, error)
+	SetProjectLimitExecute(r SetProjectLimitApiRequest) (*DataFederationLimit, *http.Response, error)
 
 	/*
 		UpdateProject Update One Project Name
@@ -470,7 +470,7 @@ type ProjectsApi interface {
 	UpdateProjectWithParams(ctx context.Context, args *UpdateProjectApiParams) UpdateProjectApiRequest
 
 	// Interface only available internally
-	updateProjectExecute(r UpdateProjectApiRequest) (*Group, *http.Response, error)
+	UpdateProjectExecute(r UpdateProjectApiRequest) (*Group, *http.Response, error)
 
 	/*
 		UpdateProjectInvitation Update One Project Invitation
@@ -497,7 +497,7 @@ type ProjectsApi interface {
 	UpdateProjectInvitationWithParams(ctx context.Context, args *UpdateProjectInvitationApiParams) UpdateProjectInvitationApiRequest
 
 	// Interface only available internally
-	updateProjectInvitationExecute(r UpdateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
+	UpdateProjectInvitationExecute(r UpdateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
 		UpdateProjectInvitationById Update One Project Invitation by Invitation ID
@@ -525,7 +525,7 @@ type ProjectsApi interface {
 	UpdateProjectInvitationByIdWithParams(ctx context.Context, args *UpdateProjectInvitationByIdApiParams) UpdateProjectInvitationByIdApiRequest
 
 	// Interface only available internally
-	updateProjectInvitationByIdExecute(r UpdateProjectInvitationByIdApiRequest) (*GroupInvitation, *http.Response, error)
+	UpdateProjectInvitationByIdExecute(r UpdateProjectInvitationByIdApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
 		UpdateProjectRoles Update Project Roles for One MongoDB Cloud User
@@ -549,7 +549,7 @@ type ProjectsApi interface {
 	UpdateProjectRolesWithParams(ctx context.Context, args *UpdateProjectRolesApiParams) UpdateProjectRolesApiRequest
 
 	// Interface only available internally
-	updateProjectRolesExecute(r UpdateProjectRolesApiRequest) (*UpdateGroupRolesForUser, *http.Response, error)
+	UpdateProjectRolesExecute(r UpdateProjectRolesApiRequest) (*UpdateGroupRolesForUser, *http.Response, error)
 
 	/*
 		UpdateProjectSettings Update One Project Settings
@@ -572,7 +572,7 @@ type ProjectsApi interface {
 	UpdateProjectSettingsWithParams(ctx context.Context, args *UpdateProjectSettingsApiParams) UpdateProjectSettingsApiRequest
 
 	// Interface only available internally
-	updateProjectSettingsExecute(r UpdateProjectSettingsApiRequest) (*GroupSettings, *http.Response, error)
+	UpdateProjectSettingsExecute(r UpdateProjectSettingsApiRequest) (*GroupSettings, *http.Response, error)
 }
 
 // ProjectsApiService ProjectsApi service
@@ -600,7 +600,7 @@ func (a *ProjectsApiService) AddUserToProjectWithParams(ctx context.Context, arg
 }
 
 func (r AddUserToProjectApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
-	return r.ApiService.addUserToProjectExecute(r)
+	return r.ApiService.AddUserToProjectExecute(r)
 }
 
 /*
@@ -624,7 +624,7 @@ func (a *ProjectsApiService) AddUserToProject(ctx context.Context, groupId strin
 // Execute executes the request
 //
 //	@return OrganizationInvitation
-func (a *ProjectsApiService) addUserToProjectExecute(r AddUserToProjectApiRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *ProjectsApiService) AddUserToProjectExecute(r AddUserToProjectApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -739,7 +739,7 @@ func (r CreateProjectApiRequest) ProjectOwnerId(projectOwnerId string) CreatePro
 }
 
 func (r CreateProjectApiRequest) Execute() (*Group, *http.Response, error) {
-	return r.ApiService.createProjectExecute(r)
+	return r.ApiService.CreateProjectExecute(r)
 }
 
 /*
@@ -761,7 +761,7 @@ func (a *ProjectsApiService) CreateProject(ctx context.Context, group *Group) Cr
 // Execute executes the request
 //
 //	@return Group
-func (a *ProjectsApiService) createProjectExecute(r CreateProjectApiRequest) (*Group, *http.Response, error) {
+func (a *ProjectsApiService) CreateProjectExecute(r CreateProjectApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -872,7 +872,7 @@ func (a *ProjectsApiService) CreateProjectInvitationWithParams(ctx context.Conte
 }
 
 func (r CreateProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
-	return r.ApiService.createProjectInvitationExecute(r)
+	return r.ApiService.CreateProjectInvitationExecute(r)
 }
 
 /*
@@ -900,7 +900,7 @@ func (a *ProjectsApiService) CreateProjectInvitation(ctx context.Context, groupI
 //	@return GroupInvitation
 //
 // Deprecated
-func (a *ProjectsApiService) createProjectInvitationExecute(r CreateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) CreateProjectInvitationExecute(r CreateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -1006,7 +1006,7 @@ func (a *ProjectsApiService) DeleteProjectWithParams(ctx context.Context, args *
 }
 
 func (r DeleteProjectApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteProjectExecute(r)
+	return r.ApiService.DeleteProjectExecute(r)
 }
 
 /*
@@ -1029,7 +1029,7 @@ func (a *ProjectsApiService) DeleteProject(ctx context.Context, groupId string) 
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *ProjectsApiService) deleteProjectExecute(r DeleteProjectApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *ProjectsApiService) DeleteProjectExecute(r DeleteProjectApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -1133,7 +1133,7 @@ func (a *ProjectsApiService) DeleteProjectInvitationWithParams(ctx context.Conte
 }
 
 func (r DeleteProjectInvitationApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteProjectInvitationExecute(r)
+	return r.ApiService.DeleteProjectInvitationExecute(r)
 }
 
 /*
@@ -1162,7 +1162,7 @@ func (a *ProjectsApiService) DeleteProjectInvitation(ctx context.Context, groupI
 //	@return map[string]interface{}
 //
 // Deprecated
-func (a *ProjectsApiService) deleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *ProjectsApiService) DeleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -1267,7 +1267,7 @@ func (a *ProjectsApiService) DeleteProjectLimitWithParams(ctx context.Context, a
 }
 
 func (r DeleteProjectLimitApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteProjectLimitExecute(r)
+	return r.ApiService.DeleteProjectLimitExecute(r)
 }
 
 /*
@@ -1292,7 +1292,7 @@ func (a *ProjectsApiService) DeleteProjectLimit(ctx context.Context, limitName s
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *ProjectsApiService) deleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *ProjectsApiService) DeleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -1394,7 +1394,7 @@ func (a *ProjectsApiService) GetProjectWithParams(ctx context.Context, args *Get
 }
 
 func (r GetProjectApiRequest) Execute() (*Group, *http.Response, error) {
-	return r.ApiService.getProjectExecute(r)
+	return r.ApiService.GetProjectExecute(r)
 }
 
 /*
@@ -1417,7 +1417,7 @@ func (a *ProjectsApiService) GetProject(ctx context.Context, groupId string) Get
 // Execute executes the request
 //
 //	@return Group
-func (a *ProjectsApiService) getProjectExecute(r GetProjectApiRequest) (*Group, *http.Response, error) {
+func (a *ProjectsApiService) GetProjectExecute(r GetProjectApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1518,7 +1518,7 @@ func (a *ProjectsApiService) GetProjectByNameWithParams(ctx context.Context, arg
 }
 
 func (r GetProjectByNameApiRequest) Execute() (*Group, *http.Response, error) {
-	return r.ApiService.getProjectByNameExecute(r)
+	return r.ApiService.GetProjectByNameExecute(r)
 }
 
 /*
@@ -1541,7 +1541,7 @@ func (a *ProjectsApiService) GetProjectByName(ctx context.Context, groupName str
 // Execute executes the request
 //
 //	@return Group
-func (a *ProjectsApiService) getProjectByNameExecute(r GetProjectByNameApiRequest) (*Group, *http.Response, error) {
+func (a *ProjectsApiService) GetProjectByNameExecute(r GetProjectByNameApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1645,7 +1645,7 @@ func (a *ProjectsApiService) GetProjectInvitationWithParams(ctx context.Context,
 }
 
 func (r GetProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
-	return r.ApiService.getProjectInvitationExecute(r)
+	return r.ApiService.GetProjectInvitationExecute(r)
 }
 
 /*
@@ -1674,7 +1674,7 @@ func (a *ProjectsApiService) GetProjectInvitation(ctx context.Context, groupId s
 //	@return GroupInvitation
 //
 // Deprecated
-func (a *ProjectsApiService) getProjectInvitationExecute(r GetProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) GetProjectInvitationExecute(r GetProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1779,7 +1779,7 @@ func (a *ProjectsApiService) GetProjectLimitWithParams(ctx context.Context, args
 }
 
 func (r GetProjectLimitApiRequest) Execute() (*DataFederationLimit, *http.Response, error) {
-	return r.ApiService.getProjectLimitExecute(r)
+	return r.ApiService.GetProjectLimitExecute(r)
 }
 
 /*
@@ -1804,7 +1804,7 @@ func (a *ProjectsApiService) GetProjectLimit(ctx context.Context, limitName stri
 // Execute executes the request
 //
 //	@return DataFederationLimit
-func (a *ProjectsApiService) getProjectLimitExecute(r GetProjectLimitApiRequest) (*DataFederationLimit, *http.Response, error) {
+func (a *ProjectsApiService) GetProjectLimitExecute(r GetProjectLimitApiRequest) (*DataFederationLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1906,7 +1906,7 @@ func (a *ProjectsApiService) GetProjectSettingsWithParams(ctx context.Context, a
 }
 
 func (r GetProjectSettingsApiRequest) Execute() (*GroupSettings, *http.Response, error) {
-	return r.ApiService.getProjectSettingsExecute(r)
+	return r.ApiService.GetProjectSettingsExecute(r)
 }
 
 /*
@@ -1929,7 +1929,7 @@ func (a *ProjectsApiService) GetProjectSettings(ctx context.Context, groupId str
 // Execute executes the request
 //
 //	@return GroupSettings
-func (a *ProjectsApiService) getProjectSettingsExecute(r GetProjectSettingsApiRequest) (*GroupSettings, *http.Response, error) {
+func (a *ProjectsApiService) GetProjectSettingsExecute(r GetProjectSettingsApiRequest) (*GroupSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2039,7 +2039,7 @@ func (r ListProjectInvitationsApiRequest) Username(username string) ListProjectI
 }
 
 func (r ListProjectInvitationsApiRequest) Execute() ([]GroupInvitation, *http.Response, error) {
-	return r.ApiService.listProjectInvitationsExecute(r)
+	return r.ApiService.ListProjectInvitationsExecute(r)
 }
 
 /*
@@ -2066,7 +2066,7 @@ func (a *ProjectsApiService) ListProjectInvitations(ctx context.Context, groupId
 //	@return []GroupInvitation
 //
 // Deprecated
-func (a *ProjectsApiService) listProjectInvitationsExecute(r ListProjectInvitationsApiRequest) ([]GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) ListProjectInvitationsExecute(r ListProjectInvitationsApiRequest) ([]GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2170,7 +2170,7 @@ func (a *ProjectsApiService) ListProjectLimitsWithParams(ctx context.Context, ar
 }
 
 func (r ListProjectLimitsApiRequest) Execute() ([]DataFederationLimit, *http.Response, error) {
-	return r.ApiService.listProjectLimitsExecute(r)
+	return r.ApiService.ListProjectLimitsExecute(r)
 }
 
 /*
@@ -2193,7 +2193,7 @@ func (a *ProjectsApiService) ListProjectLimits(ctx context.Context, groupId stri
 // Execute executes the request
 //
 //	@return []DataFederationLimit
-func (a *ProjectsApiService) listProjectLimitsExecute(r ListProjectLimitsApiRequest) ([]DataFederationLimit, *http.Response, error) {
+func (a *ProjectsApiService) ListProjectLimitsExecute(r ListProjectLimitsApiRequest) ([]DataFederationLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2339,7 +2339,7 @@ func (r ListProjectUsersApiRequest) IncludeOrgUsers(includeOrgUsers bool) ListPr
 }
 
 func (r ListProjectUsersApiRequest) Execute() (*PaginatedAppUser, *http.Response, error) {
-	return r.ApiService.listProjectUsersExecute(r)
+	return r.ApiService.ListProjectUsersExecute(r)
 }
 
 /*
@@ -2362,7 +2362,7 @@ func (a *ProjectsApiService) ListProjectUsers(ctx context.Context, groupId strin
 // Execute executes the request
 //
 //	@return PaginatedAppUser
-func (a *ProjectsApiService) listProjectUsersExecute(r ListProjectUsersApiRequest) (*PaginatedAppUser, *http.Response, error) {
+func (a *ProjectsApiService) ListProjectUsersExecute(r ListProjectUsersApiRequest) (*PaginatedAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2522,7 +2522,7 @@ func (r ListProjectsApiRequest) PageNum(pageNum int) ListProjectsApiRequest {
 }
 
 func (r ListProjectsApiRequest) Execute() (*PaginatedAtlasGroup, *http.Response, error) {
-	return r.ApiService.listProjectsExecute(r)
+	return r.ApiService.ListProjectsExecute(r)
 }
 
 /*
@@ -2543,7 +2543,7 @@ func (a *ProjectsApiService) ListProjects(ctx context.Context) ListProjectsApiRe
 // Execute executes the request
 //
 //	@return PaginatedAtlasGroup
-func (a *ProjectsApiService) listProjectsExecute(r ListProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error) {
+func (a *ProjectsApiService) ListProjectsExecute(r ListProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2667,7 +2667,7 @@ func (a *ProjectsApiService) RemoveProjectUserWithParams(ctx context.Context, ar
 }
 
 func (r RemoveProjectUserApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.removeProjectUserExecute(r)
+	return r.ApiService.RemoveProjectUserExecute(r)
 }
 
 /*
@@ -2690,7 +2690,7 @@ func (a *ProjectsApiService) RemoveProjectUser(ctx context.Context, groupId stri
 }
 
 // Execute executes the request
-func (a *ProjectsApiService) removeProjectUserExecute(r RemoveProjectUserApiRequest) (*http.Response, error) {
+func (a *ProjectsApiService) RemoveProjectUserExecute(r RemoveProjectUserApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2782,7 +2782,7 @@ func (a *ProjectsApiService) ReturnAllIPAddressesWithParams(ctx context.Context,
 }
 
 func (r ReturnAllIPAddressesApiRequest) Execute() (*GroupIPAddresses, *http.Response, error) {
-	return r.ApiService.returnAllIPAddressesExecute(r)
+	return r.ApiService.ReturnAllIPAddressesExecute(r)
 }
 
 /*
@@ -2805,7 +2805,7 @@ func (a *ProjectsApiService) ReturnAllIPAddresses(ctx context.Context, groupId s
 // Execute executes the request
 //
 //	@return GroupIPAddresses
-func (a *ProjectsApiService) returnAllIPAddressesExecute(r ReturnAllIPAddressesApiRequest) (*GroupIPAddresses, *http.Response, error) {
+func (a *ProjectsApiService) ReturnAllIPAddressesExecute(r ReturnAllIPAddressesApiRequest) (*GroupIPAddresses, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -2912,7 +2912,7 @@ func (a *ProjectsApiService) SetProjectLimitWithParams(ctx context.Context, args
 }
 
 func (r SetProjectLimitApiRequest) Execute() (*DataFederationLimit, *http.Response, error) {
-	return r.ApiService.setProjectLimitExecute(r)
+	return r.ApiService.SetProjectLimitExecute(r)
 }
 
 /*
@@ -2940,7 +2940,7 @@ func (a *ProjectsApiService) SetProjectLimit(ctx context.Context, limitName stri
 // Execute executes the request
 //
 //	@return DataFederationLimit
-func (a *ProjectsApiService) setProjectLimitExecute(r SetProjectLimitApiRequest) (*DataFederationLimit, *http.Response, error) {
+func (a *ProjectsApiService) SetProjectLimitExecute(r SetProjectLimitApiRequest) (*DataFederationLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -3050,7 +3050,7 @@ func (a *ProjectsApiService) UpdateProjectWithParams(ctx context.Context, args *
 }
 
 func (r UpdateProjectApiRequest) Execute() (*Group, *http.Response, error) {
-	return r.ApiService.updateProjectExecute(r)
+	return r.ApiService.UpdateProjectExecute(r)
 }
 
 /*
@@ -3074,7 +3074,7 @@ func (a *ProjectsApiService) UpdateProject(ctx context.Context, groupId string, 
 // Execute executes the request
 //
 //	@return Group
-func (a *ProjectsApiService) updateProjectExecute(r UpdateProjectApiRequest) (*Group, *http.Response, error) {
+func (a *ProjectsApiService) UpdateProjectExecute(r UpdateProjectApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -3183,7 +3183,7 @@ func (a *ProjectsApiService) UpdateProjectInvitationWithParams(ctx context.Conte
 }
 
 func (r UpdateProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
-	return r.ApiService.updateProjectInvitationExecute(r)
+	return r.ApiService.UpdateProjectInvitationExecute(r)
 }
 
 /*
@@ -3211,7 +3211,7 @@ func (a *ProjectsApiService) UpdateProjectInvitation(ctx context.Context, groupI
 //	@return GroupInvitation
 //
 // Deprecated
-func (a *ProjectsApiService) updateProjectInvitationExecute(r UpdateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) UpdateProjectInvitationExecute(r UpdateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -3323,7 +3323,7 @@ func (a *ProjectsApiService) UpdateProjectInvitationByIdWithParams(ctx context.C
 }
 
 func (r UpdateProjectInvitationByIdApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
-	return r.ApiService.updateProjectInvitationByIdExecute(r)
+	return r.ApiService.UpdateProjectInvitationByIdExecute(r)
 }
 
 /*
@@ -3353,7 +3353,7 @@ func (a *ProjectsApiService) UpdateProjectInvitationById(ctx context.Context, gr
 //	@return GroupInvitation
 //
 // Deprecated
-func (a *ProjectsApiService) updateProjectInvitationByIdExecute(r UpdateProjectInvitationByIdApiRequest) (*GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) UpdateProjectInvitationByIdExecute(r UpdateProjectInvitationByIdApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -3466,7 +3466,7 @@ func (a *ProjectsApiService) UpdateProjectRolesWithParams(ctx context.Context, a
 }
 
 func (r UpdateProjectRolesApiRequest) Execute() (*UpdateGroupRolesForUser, *http.Response, error) {
-	return r.ApiService.updateProjectRolesExecute(r)
+	return r.ApiService.UpdateProjectRolesExecute(r)
 }
 
 /*
@@ -3492,7 +3492,7 @@ func (a *ProjectsApiService) UpdateProjectRoles(ctx context.Context, groupId str
 // Execute executes the request
 //
 //	@return UpdateGroupRolesForUser
-func (a *ProjectsApiService) updateProjectRolesExecute(r UpdateProjectRolesApiRequest) (*UpdateGroupRolesForUser, *http.Response, error) {
+func (a *ProjectsApiService) UpdateProjectRolesExecute(r UpdateProjectRolesApiRequest) (*UpdateGroupRolesForUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
 		localVarPostBody    interface{}
@@ -3602,7 +3602,7 @@ func (a *ProjectsApiService) UpdateProjectSettingsWithParams(ctx context.Context
 }
 
 func (r UpdateProjectSettingsApiRequest) Execute() (*GroupSettings, *http.Response, error) {
-	return r.ApiService.updateProjectSettingsExecute(r)
+	return r.ApiService.UpdateProjectSettingsExecute(r)
 }
 
 /*
@@ -3626,7 +3626,7 @@ func (a *ProjectsApiService) UpdateProjectSettings(ctx context.Context, groupId 
 // Execute executes the request
 //
 //	@return GroupSettings
-func (a *ProjectsApiService) updateProjectSettingsExecute(r UpdateProjectSettingsApiRequest) (*GroupSettings, *http.Response, error) {
+func (a *ProjectsApiService) UpdateProjectSettingsExecute(r UpdateProjectSettingsApiRequest) (*GroupSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_projects.go
+++ b/admin/api_projects.go
@@ -33,7 +33,7 @@ type ProjectsApi interface {
 	*/
 	AddUserToProjectWithParams(ctx context.Context, args *AddUserToProjectApiParams) AddUserToProjectApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	AddUserToProjectExecute(r AddUserToProjectApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
@@ -55,7 +55,7 @@ type ProjectsApi interface {
 	*/
 	CreateProjectWithParams(ctx context.Context, args *CreateProjectApiParams) CreateProjectApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateProjectExecute(r CreateProjectApiRequest) (*Group, *http.Response, error)
 
 	/*
@@ -82,7 +82,7 @@ type ProjectsApi interface {
 	*/
 	CreateProjectInvitationWithParams(ctx context.Context, args *CreateProjectInvitationApiParams) CreateProjectInvitationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateProjectInvitationExecute(r CreateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
@@ -105,7 +105,7 @@ type ProjectsApi interface {
 	*/
 	DeleteProjectWithParams(ctx context.Context, args *DeleteProjectApiParams) DeleteProjectApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteProjectExecute(r DeleteProjectApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -133,7 +133,7 @@ type ProjectsApi interface {
 	*/
 	DeleteProjectInvitationWithParams(ctx context.Context, args *DeleteProjectInvitationApiParams) DeleteProjectInvitationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -157,7 +157,7 @@ type ProjectsApi interface {
 	*/
 	DeleteProjectLimitWithParams(ctx context.Context, args *DeleteProjectLimitApiParams) DeleteProjectLimitApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -180,7 +180,7 @@ type ProjectsApi interface {
 	*/
 	GetProjectWithParams(ctx context.Context, args *GetProjectApiParams) GetProjectApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetProjectExecute(r GetProjectApiRequest) (*Group, *http.Response, error)
 
 	/*
@@ -203,7 +203,7 @@ type ProjectsApi interface {
 	*/
 	GetProjectByNameWithParams(ctx context.Context, args *GetProjectByNameApiParams) GetProjectByNameApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetProjectByNameExecute(r GetProjectByNameApiRequest) (*Group, *http.Response, error)
 
 	/*
@@ -231,7 +231,7 @@ type ProjectsApi interface {
 	*/
 	GetProjectInvitationWithParams(ctx context.Context, args *GetProjectInvitationApiParams) GetProjectInvitationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetProjectInvitationExecute(r GetProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
@@ -255,7 +255,7 @@ type ProjectsApi interface {
 	*/
 	GetProjectLimitWithParams(ctx context.Context, args *GetProjectLimitApiParams) GetProjectLimitApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetProjectLimitExecute(r GetProjectLimitApiRequest) (*DataFederationLimit, *http.Response, error)
 
 	/*
@@ -278,7 +278,7 @@ type ProjectsApi interface {
 	*/
 	GetProjectSettingsWithParams(ctx context.Context, args *GetProjectSettingsApiParams) GetProjectSettingsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetProjectSettingsExecute(r GetProjectSettingsApiRequest) (*GroupSettings, *http.Response, error)
 
 	/*
@@ -305,7 +305,7 @@ type ProjectsApi interface {
 	*/
 	ListProjectInvitationsWithParams(ctx context.Context, args *ListProjectInvitationsApiParams) ListProjectInvitationsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListProjectInvitationsExecute(r ListProjectInvitationsApiRequest) ([]GroupInvitation, *http.Response, error)
 
 	/*
@@ -328,7 +328,7 @@ type ProjectsApi interface {
 	*/
 	ListProjectLimitsWithParams(ctx context.Context, args *ListProjectLimitsApiParams) ListProjectLimitsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListProjectLimitsExecute(r ListProjectLimitsApiRequest) ([]DataFederationLimit, *http.Response, error)
 
 	/*
@@ -351,7 +351,7 @@ type ProjectsApi interface {
 	*/
 	ListProjectUsersWithParams(ctx context.Context, args *ListProjectUsersApiParams) ListProjectUsersApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListProjectUsersExecute(r ListProjectUsersApiRequest) (*PaginatedAppUser, *http.Response, error)
 
 	/*
@@ -373,7 +373,7 @@ type ProjectsApi interface {
 	*/
 	ListProjectsWithParams(ctx context.Context, args *ListProjectsApiParams) ListProjectsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListProjectsExecute(r ListProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error)
 
 	/*
@@ -397,7 +397,7 @@ type ProjectsApi interface {
 	*/
 	RemoveProjectUserWithParams(ctx context.Context, args *RemoveProjectUserApiParams) RemoveProjectUserApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	RemoveProjectUserExecute(r RemoveProjectUserApiRequest) (*http.Response, error)
 
 	/*
@@ -420,7 +420,7 @@ type ProjectsApi interface {
 	*/
 	ReturnAllIPAddressesWithParams(ctx context.Context, args *ReturnAllIPAddressesApiParams) ReturnAllIPAddressesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ReturnAllIPAddressesExecute(r ReturnAllIPAddressesApiRequest) (*GroupIPAddresses, *http.Response, error)
 
 	/*
@@ -446,7 +446,7 @@ type ProjectsApi interface {
 	*/
 	SetProjectLimitWithParams(ctx context.Context, args *SetProjectLimitApiParams) SetProjectLimitApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	SetProjectLimitExecute(r SetProjectLimitApiRequest) (*DataFederationLimit, *http.Response, error)
 
 	/*
@@ -469,7 +469,7 @@ type ProjectsApi interface {
 	*/
 	UpdateProjectWithParams(ctx context.Context, args *UpdateProjectApiParams) UpdateProjectApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateProjectExecute(r UpdateProjectApiRequest) (*Group, *http.Response, error)
 
 	/*
@@ -496,7 +496,7 @@ type ProjectsApi interface {
 	*/
 	UpdateProjectInvitationWithParams(ctx context.Context, args *UpdateProjectInvitationApiParams) UpdateProjectInvitationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateProjectInvitationExecute(r UpdateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
@@ -524,7 +524,7 @@ type ProjectsApi interface {
 	*/
 	UpdateProjectInvitationByIdWithParams(ctx context.Context, args *UpdateProjectInvitationByIdApiParams) UpdateProjectInvitationByIdApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateProjectInvitationByIdExecute(r UpdateProjectInvitationByIdApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
@@ -548,7 +548,7 @@ type ProjectsApi interface {
 	*/
 	UpdateProjectRolesWithParams(ctx context.Context, args *UpdateProjectRolesApiParams) UpdateProjectRolesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateProjectRolesExecute(r UpdateProjectRolesApiRequest) (*UpdateGroupRolesForUser, *http.Response, error)
 
 	/*
@@ -571,7 +571,7 @@ type ProjectsApi interface {
 	*/
 	UpdateProjectSettingsWithParams(ctx context.Context, args *UpdateProjectSettingsApiParams) UpdateProjectSettingsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateProjectSettingsExecute(r UpdateProjectSettingsApiRequest) (*GroupSettings, *http.Response, error)
 }
 

--- a/admin/api_push_based_log_export.go
+++ b/admin/api_push_based_log_export.go
@@ -34,7 +34,7 @@ type PushBasedLogExportApi interface {
 	CreatePushBasedLogConfigurationWithParams(ctx context.Context, args *CreatePushBasedLogConfigurationApiParams) CreatePushBasedLogConfigurationApiRequest
 
 	// Interface only available internally
-	createPushBasedLogConfigurationExecute(r CreatePushBasedLogConfigurationApiRequest) (*http.Response, error)
+	CreatePushBasedLogConfigurationExecute(r CreatePushBasedLogConfigurationApiRequest) (*http.Response, error)
 
 	/*
 		DeletePushBasedLogConfiguration Disable the push-based log export feature for a project
@@ -57,7 +57,7 @@ type PushBasedLogExportApi interface {
 	DeletePushBasedLogConfigurationWithParams(ctx context.Context, args *DeletePushBasedLogConfigurationApiParams) DeletePushBasedLogConfigurationApiRequest
 
 	// Interface only available internally
-	deletePushBasedLogConfigurationExecute(r DeletePushBasedLogConfigurationApiRequest) (*http.Response, error)
+	DeletePushBasedLogConfigurationExecute(r DeletePushBasedLogConfigurationApiRequest) (*http.Response, error)
 
 	/*
 		GetPushBasedLogConfiguration Get the push-based log export configuration for a project
@@ -80,7 +80,7 @@ type PushBasedLogExportApi interface {
 	GetPushBasedLogConfigurationWithParams(ctx context.Context, args *GetPushBasedLogConfigurationApiParams) GetPushBasedLogConfigurationApiRequest
 
 	// Interface only available internally
-	getPushBasedLogConfigurationExecute(r GetPushBasedLogConfigurationApiRequest) (*PushBasedLogExportProject, *http.Response, error)
+	GetPushBasedLogConfigurationExecute(r GetPushBasedLogConfigurationApiRequest) (*PushBasedLogExportProject, *http.Response, error)
 
 	/*
 		UpdatePushBasedLogConfiguration Update the push-based log export feature for a project
@@ -103,7 +103,7 @@ type PushBasedLogExportApi interface {
 	UpdatePushBasedLogConfigurationWithParams(ctx context.Context, args *UpdatePushBasedLogConfigurationApiParams) UpdatePushBasedLogConfigurationApiRequest
 
 	// Interface only available internally
-	updatePushBasedLogConfigurationExecute(r UpdatePushBasedLogConfigurationApiRequest) (*http.Response, error)
+	UpdatePushBasedLogConfigurationExecute(r UpdatePushBasedLogConfigurationApiRequest) (*http.Response, error)
 }
 
 // PushBasedLogExportApiService PushBasedLogExportApi service
@@ -131,7 +131,7 @@ func (a *PushBasedLogExportApiService) CreatePushBasedLogConfigurationWithParams
 }
 
 func (r CreatePushBasedLogConfigurationApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.createPushBasedLogConfigurationExecute(r)
+	return r.ApiService.CreatePushBasedLogConfigurationExecute(r)
 }
 
 /*
@@ -153,7 +153,7 @@ func (a *PushBasedLogExportApiService) CreatePushBasedLogConfiguration(ctx conte
 }
 
 // Execute executes the request
-func (a *PushBasedLogExportApiService) createPushBasedLogConfigurationExecute(r CreatePushBasedLogConfigurationApiRequest) (*http.Response, error) {
+func (a *PushBasedLogExportApiService) CreatePushBasedLogConfigurationExecute(r CreatePushBasedLogConfigurationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -249,7 +249,7 @@ func (a *PushBasedLogExportApiService) DeletePushBasedLogConfigurationWithParams
 }
 
 func (r DeletePushBasedLogConfigurationApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.deletePushBasedLogConfigurationExecute(r)
+	return r.ApiService.DeletePushBasedLogConfigurationExecute(r)
 }
 
 /*
@@ -270,7 +270,7 @@ func (a *PushBasedLogExportApiService) DeletePushBasedLogConfiguration(ctx conte
 }
 
 // Execute executes the request
-func (a *PushBasedLogExportApiService) deletePushBasedLogConfigurationExecute(r DeletePushBasedLogConfigurationApiRequest) (*http.Response, error) {
+func (a *PushBasedLogExportApiService) DeletePushBasedLogConfigurationExecute(r DeletePushBasedLogConfigurationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -361,7 +361,7 @@ func (a *PushBasedLogExportApiService) GetPushBasedLogConfigurationWithParams(ct
 }
 
 func (r GetPushBasedLogConfigurationApiRequest) Execute() (*PushBasedLogExportProject, *http.Response, error) {
-	return r.ApiService.getPushBasedLogConfigurationExecute(r)
+	return r.ApiService.GetPushBasedLogConfigurationExecute(r)
 }
 
 /*
@@ -384,7 +384,7 @@ func (a *PushBasedLogExportApiService) GetPushBasedLogConfiguration(ctx context.
 // Execute executes the request
 //
 //	@return PushBasedLogExportProject
-func (a *PushBasedLogExportApiService) getPushBasedLogConfigurationExecute(r GetPushBasedLogConfigurationApiRequest) (*PushBasedLogExportProject, *http.Response, error) {
+func (a *PushBasedLogExportApiService) GetPushBasedLogConfigurationExecute(r GetPushBasedLogConfigurationApiRequest) (*PushBasedLogExportProject, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -488,7 +488,7 @@ func (a *PushBasedLogExportApiService) UpdatePushBasedLogConfigurationWithParams
 }
 
 func (r UpdatePushBasedLogConfigurationApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.updatePushBasedLogConfigurationExecute(r)
+	return r.ApiService.UpdatePushBasedLogConfigurationExecute(r)
 }
 
 /*
@@ -510,7 +510,7 @@ func (a *PushBasedLogExportApiService) UpdatePushBasedLogConfiguration(ctx conte
 }
 
 // Execute executes the request
-func (a *PushBasedLogExportApiService) updatePushBasedLogConfigurationExecute(r UpdatePushBasedLogConfigurationApiRequest) (*http.Response, error) {
+func (a *PushBasedLogExportApiService) UpdatePushBasedLogConfigurationExecute(r UpdatePushBasedLogConfigurationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPatch
 		localVarPostBody   interface{}

--- a/admin/api_push_based_log_export.go
+++ b/admin/api_push_based_log_export.go
@@ -33,7 +33,7 @@ type PushBasedLogExportApi interface {
 	*/
 	CreatePushBasedLogConfigurationWithParams(ctx context.Context, args *CreatePushBasedLogConfigurationApiParams) CreatePushBasedLogConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreatePushBasedLogConfigurationExecute(r CreatePushBasedLogConfigurationApiRequest) (*http.Response, error)
 
 	/*
@@ -56,7 +56,7 @@ type PushBasedLogExportApi interface {
 	*/
 	DeletePushBasedLogConfigurationWithParams(ctx context.Context, args *DeletePushBasedLogConfigurationApiParams) DeletePushBasedLogConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeletePushBasedLogConfigurationExecute(r DeletePushBasedLogConfigurationApiRequest) (*http.Response, error)
 
 	/*
@@ -79,7 +79,7 @@ type PushBasedLogExportApi interface {
 	*/
 	GetPushBasedLogConfigurationWithParams(ctx context.Context, args *GetPushBasedLogConfigurationApiParams) GetPushBasedLogConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetPushBasedLogConfigurationExecute(r GetPushBasedLogConfigurationApiRequest) (*PushBasedLogExportProject, *http.Response, error)
 
 	/*
@@ -102,7 +102,7 @@ type PushBasedLogExportApi interface {
 	*/
 	UpdatePushBasedLogConfigurationWithParams(ctx context.Context, args *UpdatePushBasedLogConfigurationApiParams) UpdatePushBasedLogConfigurationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdatePushBasedLogConfigurationExecute(r UpdatePushBasedLogConfigurationApiRequest) (*http.Response, error)
 }
 

--- a/admin/api_rolling_index.go
+++ b/admin/api_rolling_index.go
@@ -34,7 +34,7 @@ type RollingIndexApi interface {
 	*/
 	CreateRollingIndexWithParams(ctx context.Context, args *CreateRollingIndexApiParams) CreateRollingIndexApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateRollingIndexExecute(r CreateRollingIndexApiRequest) (*http.Response, error)
 }
 

--- a/admin/api_rolling_index.go
+++ b/admin/api_rolling_index.go
@@ -35,7 +35,7 @@ type RollingIndexApi interface {
 	CreateRollingIndexWithParams(ctx context.Context, args *CreateRollingIndexApiParams) CreateRollingIndexApiRequest
 
 	// Interface only available internally
-	createRollingIndexExecute(r CreateRollingIndexApiRequest) (*http.Response, error)
+	CreateRollingIndexExecute(r CreateRollingIndexApiRequest) (*http.Response, error)
 }
 
 // RollingIndexApiService RollingIndexApi service
@@ -66,7 +66,7 @@ func (a *RollingIndexApiService) CreateRollingIndexWithParams(ctx context.Contex
 }
 
 func (r CreateRollingIndexApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.createRollingIndexExecute(r)
+	return r.ApiService.CreateRollingIndexExecute(r)
 }
 
 /*
@@ -90,7 +90,7 @@ func (a *RollingIndexApiService) CreateRollingIndex(ctx context.Context, groupId
 }
 
 // Execute executes the request
-func (a *RollingIndexApiService) createRollingIndexExecute(r CreateRollingIndexApiRequest) (*http.Response, error) {
+func (a *RollingIndexApiService) CreateRollingIndexExecute(r CreateRollingIndexApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}

--- a/admin/api_root.go
+++ b/admin/api_root.go
@@ -32,7 +32,7 @@ type RootApi interface {
 	GetSystemStatusWithParams(ctx context.Context, args *GetSystemStatusApiParams) GetSystemStatusApiRequest
 
 	// Interface only available internally
-	getSystemStatusExecute(r GetSystemStatusApiRequest) (*SystemStatus, *http.Response, error)
+	GetSystemStatusExecute(r GetSystemStatusApiRequest) (*SystemStatus, *http.Response, error)
 }
 
 // RootApiService RootApi service
@@ -54,7 +54,7 @@ func (a *RootApiService) GetSystemStatusWithParams(ctx context.Context, args *Ge
 }
 
 func (r GetSystemStatusApiRequest) Execute() (*SystemStatus, *http.Response, error) {
-	return r.ApiService.getSystemStatusExecute(r)
+	return r.ApiService.GetSystemStatusExecute(r)
 }
 
 /*
@@ -75,7 +75,7 @@ func (a *RootApiService) GetSystemStatus(ctx context.Context) GetSystemStatusApi
 // Execute executes the request
 //
 //	@return SystemStatus
-func (a *RootApiService) getSystemStatusExecute(r GetSystemStatusApiRequest) (*SystemStatus, *http.Response, error) {
+func (a *RootApiService) GetSystemStatusExecute(r GetSystemStatusApiRequest) (*SystemStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_root.go
+++ b/admin/api_root.go
@@ -31,7 +31,7 @@ type RootApi interface {
 	*/
 	GetSystemStatusWithParams(ctx context.Context, args *GetSystemStatusApiParams) GetSystemStatusApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetSystemStatusExecute(r GetSystemStatusApiRequest) (*SystemStatus, *http.Response, error)
 }
 

--- a/admin/api_serverless_instances.go
+++ b/admin/api_serverless_instances.go
@@ -33,7 +33,7 @@ type ServerlessInstancesApi interface {
 	*/
 	CreateServerlessInstanceWithParams(ctx context.Context, args *CreateServerlessInstanceApiParams) CreateServerlessInstanceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateServerlessInstanceExecute(r CreateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 
 	/*
@@ -57,7 +57,7 @@ type ServerlessInstancesApi interface {
 	*/
 	DeleteServerlessInstanceWithParams(ctx context.Context, args *DeleteServerlessInstanceApiParams) DeleteServerlessInstanceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -81,7 +81,7 @@ type ServerlessInstancesApi interface {
 	*/
 	GetServerlessInstanceWithParams(ctx context.Context, args *GetServerlessInstanceApiParams) GetServerlessInstanceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetServerlessInstanceExecute(r GetServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 
 	/*
@@ -104,7 +104,7 @@ type ServerlessInstancesApi interface {
 	*/
 	ListServerlessInstancesWithParams(ctx context.Context, args *ListServerlessInstancesApiParams) ListServerlessInstancesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListServerlessInstancesExecute(r ListServerlessInstancesApiRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error)
 
 	/*
@@ -128,7 +128,7 @@ type ServerlessInstancesApi interface {
 	*/
 	UpdateServerlessInstanceWithParams(ctx context.Context, args *UpdateServerlessInstanceApiParams) UpdateServerlessInstanceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateServerlessInstanceExecute(r UpdateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 }
 

--- a/admin/api_serverless_instances.go
+++ b/admin/api_serverless_instances.go
@@ -34,7 +34,7 @@ type ServerlessInstancesApi interface {
 	CreateServerlessInstanceWithParams(ctx context.Context, args *CreateServerlessInstanceApiParams) CreateServerlessInstanceApiRequest
 
 	// Interface only available internally
-	createServerlessInstanceExecute(r CreateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
+	CreateServerlessInstanceExecute(r CreateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 
 	/*
 		DeleteServerlessInstance Remove One Serverless Instance from One Project
@@ -58,7 +58,7 @@ type ServerlessInstancesApi interface {
 	DeleteServerlessInstanceWithParams(ctx context.Context, args *DeleteServerlessInstanceApiParams) DeleteServerlessInstanceApiRequest
 
 	// Interface only available internally
-	deleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetServerlessInstance Return One Serverless Instance from One Project
@@ -82,7 +82,7 @@ type ServerlessInstancesApi interface {
 	GetServerlessInstanceWithParams(ctx context.Context, args *GetServerlessInstanceApiParams) GetServerlessInstanceApiRequest
 
 	// Interface only available internally
-	getServerlessInstanceExecute(r GetServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
+	GetServerlessInstanceExecute(r GetServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 
 	/*
 		ListServerlessInstances Return All Serverless Instances from One Project
@@ -105,7 +105,7 @@ type ServerlessInstancesApi interface {
 	ListServerlessInstancesWithParams(ctx context.Context, args *ListServerlessInstancesApiParams) ListServerlessInstancesApiRequest
 
 	// Interface only available internally
-	listServerlessInstancesExecute(r ListServerlessInstancesApiRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error)
+	ListServerlessInstancesExecute(r ListServerlessInstancesApiRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error)
 
 	/*
 		UpdateServerlessInstance Update One Serverless Instance in One Project
@@ -129,7 +129,7 @@ type ServerlessInstancesApi interface {
 	UpdateServerlessInstanceWithParams(ctx context.Context, args *UpdateServerlessInstanceApiParams) UpdateServerlessInstanceApiRequest
 
 	// Interface only available internally
-	updateServerlessInstanceExecute(r UpdateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
+	UpdateServerlessInstanceExecute(r UpdateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 }
 
 // ServerlessInstancesApiService ServerlessInstancesApi service
@@ -157,7 +157,7 @@ func (a *ServerlessInstancesApiService) CreateServerlessInstanceWithParams(ctx c
 }
 
 func (r CreateServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
-	return r.ApiService.createServerlessInstanceExecute(r)
+	return r.ApiService.CreateServerlessInstanceExecute(r)
 }
 
 /*
@@ -181,7 +181,7 @@ func (a *ServerlessInstancesApiService) CreateServerlessInstance(ctx context.Con
 // Execute executes the request
 //
 //	@return ServerlessInstanceDescription
-func (a *ServerlessInstancesApiService) createServerlessInstanceExecute(r CreateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
+func (a *ServerlessInstancesApiService) CreateServerlessInstanceExecute(r CreateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -290,7 +290,7 @@ func (a *ServerlessInstancesApiService) DeleteServerlessInstanceWithParams(ctx c
 }
 
 func (r DeleteServerlessInstanceApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteServerlessInstanceExecute(r)
+	return r.ApiService.DeleteServerlessInstanceExecute(r)
 }
 
 /*
@@ -315,7 +315,7 @@ func (a *ServerlessInstancesApiService) DeleteServerlessInstance(ctx context.Con
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *ServerlessInstancesApiService) deleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *ServerlessInstancesApiService) DeleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -420,7 +420,7 @@ func (a *ServerlessInstancesApiService) GetServerlessInstanceWithParams(ctx cont
 }
 
 func (r GetServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
-	return r.ApiService.getServerlessInstanceExecute(r)
+	return r.ApiService.GetServerlessInstanceExecute(r)
 }
 
 /*
@@ -445,7 +445,7 @@ func (a *ServerlessInstancesApiService) GetServerlessInstance(ctx context.Contex
 // Execute executes the request
 //
 //	@return ServerlessInstanceDescription
-func (a *ServerlessInstancesApiService) getServerlessInstanceExecute(r GetServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
+func (a *ServerlessInstancesApiService) GetServerlessInstanceExecute(r GetServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -574,7 +574,7 @@ func (r ListServerlessInstancesApiRequest) PageNum(pageNum int) ListServerlessIn
 }
 
 func (r ListServerlessInstancesApiRequest) Execute() (*PaginatedServerlessInstanceDescription, *http.Response, error) {
-	return r.ApiService.listServerlessInstancesExecute(r)
+	return r.ApiService.ListServerlessInstancesExecute(r)
 }
 
 /*
@@ -597,7 +597,7 @@ func (a *ServerlessInstancesApiService) ListServerlessInstances(ctx context.Cont
 // Execute executes the request
 //
 //	@return PaginatedServerlessInstanceDescription
-func (a *ServerlessInstancesApiService) listServerlessInstancesExecute(r ListServerlessInstancesApiRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error) {
+func (a *ServerlessInstancesApiService) ListServerlessInstancesExecute(r ListServerlessInstancesApiRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -725,7 +725,7 @@ func (a *ServerlessInstancesApiService) UpdateServerlessInstanceWithParams(ctx c
 }
 
 func (r UpdateServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
-	return r.ApiService.updateServerlessInstanceExecute(r)
+	return r.ApiService.UpdateServerlessInstanceExecute(r)
 }
 
 /*
@@ -751,7 +751,7 @@ func (a *ServerlessInstancesApiService) UpdateServerlessInstance(ctx context.Con
 // Execute executes the request
 //
 //	@return ServerlessInstanceDescription
-func (a *ServerlessInstancesApiService) updateServerlessInstanceExecute(r UpdateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
+func (a *ServerlessInstancesApiService) UpdateServerlessInstanceExecute(r UpdateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_serverless_private_endpoints.go
+++ b/admin/api_serverless_private_endpoints.go
@@ -37,7 +37,7 @@ type ServerlessPrivateEndpointsApi interface {
 	CreateServerlessPrivateEndpointWithParams(ctx context.Context, args *CreateServerlessPrivateEndpointApiParams) CreateServerlessPrivateEndpointApiRequest
 
 	// Interface only available internally
-	createServerlessPrivateEndpointExecute(r CreateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
+	CreateServerlessPrivateEndpointExecute(r CreateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
 
 	/*
 		DeleteServerlessPrivateEndpoint Remove One Private Endpoint for One Serverless Instance
@@ -62,7 +62,7 @@ type ServerlessPrivateEndpointsApi interface {
 	DeleteServerlessPrivateEndpointWithParams(ctx context.Context, args *DeleteServerlessPrivateEndpointApiParams) DeleteServerlessPrivateEndpointApiRequest
 
 	// Interface only available internally
-	deleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetServerlessPrivateEndpoint Return One Private Endpoint for One Serverless Instance
@@ -87,7 +87,7 @@ type ServerlessPrivateEndpointsApi interface {
 	GetServerlessPrivateEndpointWithParams(ctx context.Context, args *GetServerlessPrivateEndpointApiParams) GetServerlessPrivateEndpointApiRequest
 
 	// Interface only available internally
-	getServerlessPrivateEndpointExecute(r GetServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
+	GetServerlessPrivateEndpointExecute(r GetServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
 
 	/*
 		ListServerlessPrivateEndpoints Return All Private Endpoints for One Serverless Instance
@@ -111,7 +111,7 @@ type ServerlessPrivateEndpointsApi interface {
 	ListServerlessPrivateEndpointsWithParams(ctx context.Context, args *ListServerlessPrivateEndpointsApiParams) ListServerlessPrivateEndpointsApiRequest
 
 	// Interface only available internally
-	listServerlessPrivateEndpointsExecute(r ListServerlessPrivateEndpointsApiRequest) ([]ServerlessTenantEndpoint, *http.Response, error)
+	ListServerlessPrivateEndpointsExecute(r ListServerlessPrivateEndpointsApiRequest) ([]ServerlessTenantEndpoint, *http.Response, error)
 
 	/*
 		UpdateServerlessPrivateEndpoint Update One Private Endpoint for One Serverless Instance
@@ -136,7 +136,7 @@ type ServerlessPrivateEndpointsApi interface {
 	UpdateServerlessPrivateEndpointWithParams(ctx context.Context, args *UpdateServerlessPrivateEndpointApiParams) UpdateServerlessPrivateEndpointApiRequest
 
 	// Interface only available internally
-	updateServerlessPrivateEndpointExecute(r UpdateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
+	UpdateServerlessPrivateEndpointExecute(r UpdateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
 }
 
 // ServerlessPrivateEndpointsApiService ServerlessPrivateEndpointsApi service
@@ -167,7 +167,7 @@ func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpointWi
 }
 
 func (r CreateServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
-	return r.ApiService.createServerlessPrivateEndpointExecute(r)
+	return r.ApiService.CreateServerlessPrivateEndpointExecute(r)
 }
 
 /*
@@ -195,7 +195,7 @@ func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpoint(c
 // Execute executes the request
 //
 //	@return ServerlessTenantEndpoint
-func (a *ServerlessPrivateEndpointsApiService) createServerlessPrivateEndpointExecute(r CreateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpointExecute(r CreateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -308,7 +308,7 @@ func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpointWi
 }
 
 func (r DeleteServerlessPrivateEndpointApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteServerlessPrivateEndpointExecute(r)
+	return r.ApiService.DeleteServerlessPrivateEndpointExecute(r)
 }
 
 /*
@@ -335,7 +335,7 @@ func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpoint(c
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *ServerlessPrivateEndpointsApiService) deleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -444,7 +444,7 @@ func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpointWithP
 }
 
 func (r GetServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
-	return r.ApiService.getServerlessPrivateEndpointExecute(r)
+	return r.ApiService.GetServerlessPrivateEndpointExecute(r)
 }
 
 /*
@@ -471,7 +471,7 @@ func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpoint(ctx 
 // Execute executes the request
 //
 //	@return ServerlessTenantEndpoint
-func (a *ServerlessPrivateEndpointsApiService) getServerlessPrivateEndpointExecute(r GetServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpointExecute(r GetServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -577,7 +577,7 @@ func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpointsWit
 }
 
 func (r ListServerlessPrivateEndpointsApiRequest) Execute() ([]ServerlessTenantEndpoint, *http.Response, error) {
-	return r.ApiService.listServerlessPrivateEndpointsExecute(r)
+	return r.ApiService.ListServerlessPrivateEndpointsExecute(r)
 }
 
 /*
@@ -602,7 +602,7 @@ func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpoints(ct
 // Execute executes the request
 //
 //	@return []ServerlessTenantEndpoint
-func (a *ServerlessPrivateEndpointsApiService) listServerlessPrivateEndpointsExecute(r ListServerlessPrivateEndpointsApiRequest) ([]ServerlessTenantEndpoint, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpointsExecute(r ListServerlessPrivateEndpointsApiRequest) ([]ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -713,7 +713,7 @@ func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpointWi
 }
 
 func (r UpdateServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
-	return r.ApiService.updateServerlessPrivateEndpointExecute(r)
+	return r.ApiService.UpdateServerlessPrivateEndpointExecute(r)
 }
 
 /*
@@ -741,7 +741,7 @@ func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpoint(c
 // Execute executes the request
 //
 //	@return ServerlessTenantEndpoint
-func (a *ServerlessPrivateEndpointsApiService) updateServerlessPrivateEndpointExecute(r UpdateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpointExecute(r UpdateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_serverless_private_endpoints.go
+++ b/admin/api_serverless_private_endpoints.go
@@ -36,7 +36,7 @@ type ServerlessPrivateEndpointsApi interface {
 	*/
 	CreateServerlessPrivateEndpointWithParams(ctx context.Context, args *CreateServerlessPrivateEndpointApiParams) CreateServerlessPrivateEndpointApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateServerlessPrivateEndpointExecute(r CreateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
 
 	/*
@@ -61,7 +61,7 @@ type ServerlessPrivateEndpointsApi interface {
 	*/
 	DeleteServerlessPrivateEndpointWithParams(ctx context.Context, args *DeleteServerlessPrivateEndpointApiParams) DeleteServerlessPrivateEndpointApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -86,7 +86,7 @@ type ServerlessPrivateEndpointsApi interface {
 	*/
 	GetServerlessPrivateEndpointWithParams(ctx context.Context, args *GetServerlessPrivateEndpointApiParams) GetServerlessPrivateEndpointApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetServerlessPrivateEndpointExecute(r GetServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
 
 	/*
@@ -110,7 +110,7 @@ type ServerlessPrivateEndpointsApi interface {
 	*/
 	ListServerlessPrivateEndpointsWithParams(ctx context.Context, args *ListServerlessPrivateEndpointsApiParams) ListServerlessPrivateEndpointsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListServerlessPrivateEndpointsExecute(r ListServerlessPrivateEndpointsApiRequest) ([]ServerlessTenantEndpoint, *http.Response, error)
 
 	/*
@@ -135,7 +135,7 @@ type ServerlessPrivateEndpointsApi interface {
 	*/
 	UpdateServerlessPrivateEndpointWithParams(ctx context.Context, args *UpdateServerlessPrivateEndpointApiParams) UpdateServerlessPrivateEndpointApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateServerlessPrivateEndpointExecute(r UpdateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
 }
 

--- a/admin/api_shared_tier_restore_jobs.go
+++ b/admin/api_shared_tier_restore_jobs.go
@@ -35,7 +35,7 @@ type SharedTierRestoreJobsApi interface {
 	CreateSharedClusterBackupRestoreJobWithParams(ctx context.Context, args *CreateSharedClusterBackupRestoreJobApiParams) CreateSharedClusterBackupRestoreJobApiRequest
 
 	// Interface only available internally
-	createSharedClusterBackupRestoreJobExecute(r CreateSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error)
+	CreateSharedClusterBackupRestoreJobExecute(r CreateSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error)
 
 	/*
 		GetSharedClusterBackupRestoreJob Return One Restore Job for One M2 or M5 Cluster
@@ -60,7 +60,7 @@ type SharedTierRestoreJobsApi interface {
 	GetSharedClusterBackupRestoreJobWithParams(ctx context.Context, args *GetSharedClusterBackupRestoreJobApiParams) GetSharedClusterBackupRestoreJobApiRequest
 
 	// Interface only available internally
-	getSharedClusterBackupRestoreJobExecute(r GetSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error)
+	GetSharedClusterBackupRestoreJobExecute(r GetSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error)
 
 	/*
 		ListSharedClusterBackupRestoreJobs Return All Restore Jobs for One M2 or M5 Cluster
@@ -84,7 +84,7 @@ type SharedTierRestoreJobsApi interface {
 	ListSharedClusterBackupRestoreJobsWithParams(ctx context.Context, args *ListSharedClusterBackupRestoreJobsApiParams) ListSharedClusterBackupRestoreJobsApiRequest
 
 	// Interface only available internally
-	listSharedClusterBackupRestoreJobsExecute(r ListSharedClusterBackupRestoreJobsApiRequest) (*PaginatedTenantRestore, *http.Response, error)
+	ListSharedClusterBackupRestoreJobsExecute(r ListSharedClusterBackupRestoreJobsApiRequest) (*PaginatedTenantRestore, *http.Response, error)
 }
 
 // SharedTierRestoreJobsApiService SharedTierRestoreJobsApi service
@@ -115,7 +115,7 @@ func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJobWit
 }
 
 func (r CreateSharedClusterBackupRestoreJobApiRequest) Execute() (*TenantRestore, *http.Response, error) {
-	return r.ApiService.createSharedClusterBackupRestoreJobExecute(r)
+	return r.ApiService.CreateSharedClusterBackupRestoreJobExecute(r)
 }
 
 /*
@@ -141,7 +141,7 @@ func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJob(ct
 // Execute executes the request
 //
 //	@return TenantRestore
-func (a *SharedTierRestoreJobsApiService) createSharedClusterBackupRestoreJobExecute(r CreateSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error) {
+func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJobExecute(r CreateSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -254,7 +254,7 @@ func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJobWithPa
 }
 
 func (r GetSharedClusterBackupRestoreJobApiRequest) Execute() (*TenantRestore, *http.Response, error) {
-	return r.ApiService.getSharedClusterBackupRestoreJobExecute(r)
+	return r.ApiService.GetSharedClusterBackupRestoreJobExecute(r)
 }
 
 /*
@@ -281,7 +281,7 @@ func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJob(ctx c
 // Execute executes the request
 //
 //	@return TenantRestore
-func (a *SharedTierRestoreJobsApiService) getSharedClusterBackupRestoreJobExecute(r GetSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error) {
+func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJobExecute(r GetSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -387,7 +387,7 @@ func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobsWith
 }
 
 func (r ListSharedClusterBackupRestoreJobsApiRequest) Execute() (*PaginatedTenantRestore, *http.Response, error) {
-	return r.ApiService.listSharedClusterBackupRestoreJobsExecute(r)
+	return r.ApiService.ListSharedClusterBackupRestoreJobsExecute(r)
 }
 
 /*
@@ -412,7 +412,7 @@ func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobs(ctx
 // Execute executes the request
 //
 //	@return PaginatedTenantRestore
-func (a *SharedTierRestoreJobsApiService) listSharedClusterBackupRestoreJobsExecute(r ListSharedClusterBackupRestoreJobsApiRequest) (*PaginatedTenantRestore, *http.Response, error) {
+func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobsExecute(r ListSharedClusterBackupRestoreJobsApiRequest) (*PaginatedTenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_shared_tier_restore_jobs.go
+++ b/admin/api_shared_tier_restore_jobs.go
@@ -34,7 +34,7 @@ type SharedTierRestoreJobsApi interface {
 	*/
 	CreateSharedClusterBackupRestoreJobWithParams(ctx context.Context, args *CreateSharedClusterBackupRestoreJobApiParams) CreateSharedClusterBackupRestoreJobApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateSharedClusterBackupRestoreJobExecute(r CreateSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error)
 
 	/*
@@ -59,7 +59,7 @@ type SharedTierRestoreJobsApi interface {
 	*/
 	GetSharedClusterBackupRestoreJobWithParams(ctx context.Context, args *GetSharedClusterBackupRestoreJobApiParams) GetSharedClusterBackupRestoreJobApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetSharedClusterBackupRestoreJobExecute(r GetSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error)
 
 	/*
@@ -83,7 +83,7 @@ type SharedTierRestoreJobsApi interface {
 	*/
 	ListSharedClusterBackupRestoreJobsWithParams(ctx context.Context, args *ListSharedClusterBackupRestoreJobsApiParams) ListSharedClusterBackupRestoreJobsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListSharedClusterBackupRestoreJobsExecute(r ListSharedClusterBackupRestoreJobsApiRequest) (*PaginatedTenantRestore, *http.Response, error)
 }
 

--- a/admin/api_shared_tier_snapshots.go
+++ b/admin/api_shared_tier_snapshots.go
@@ -34,7 +34,7 @@ type SharedTierSnapshotsApi interface {
 	*/
 	DownloadSharedClusterBackupWithParams(ctx context.Context, args *DownloadSharedClusterBackupApiParams) DownloadSharedClusterBackupApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DownloadSharedClusterBackupExecute(r DownloadSharedClusterBackupApiRequest) (*TenantRestore, *http.Response, error)
 
 	/*
@@ -59,7 +59,7 @@ type SharedTierSnapshotsApi interface {
 	*/
 	GetSharedClusterBackupWithParams(ctx context.Context, args *GetSharedClusterBackupApiParams) GetSharedClusterBackupApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetSharedClusterBackupExecute(r GetSharedClusterBackupApiRequest) (*BackupTenantSnapshot, *http.Response, error)
 
 	/*
@@ -83,7 +83,7 @@ type SharedTierSnapshotsApi interface {
 	*/
 	ListSharedClusterBackupsWithParams(ctx context.Context, args *ListSharedClusterBackupsApiParams) ListSharedClusterBackupsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListSharedClusterBackupsExecute(r ListSharedClusterBackupsApiRequest) (*PaginatedTenantSnapshot, *http.Response, error)
 }
 

--- a/admin/api_shared_tier_snapshots.go
+++ b/admin/api_shared_tier_snapshots.go
@@ -35,7 +35,7 @@ type SharedTierSnapshotsApi interface {
 	DownloadSharedClusterBackupWithParams(ctx context.Context, args *DownloadSharedClusterBackupApiParams) DownloadSharedClusterBackupApiRequest
 
 	// Interface only available internally
-	downloadSharedClusterBackupExecute(r DownloadSharedClusterBackupApiRequest) (*TenantRestore, *http.Response, error)
+	DownloadSharedClusterBackupExecute(r DownloadSharedClusterBackupApiRequest) (*TenantRestore, *http.Response, error)
 
 	/*
 		GetSharedClusterBackup Return One Snapshot for One M2 or M5 Cluster
@@ -60,7 +60,7 @@ type SharedTierSnapshotsApi interface {
 	GetSharedClusterBackupWithParams(ctx context.Context, args *GetSharedClusterBackupApiParams) GetSharedClusterBackupApiRequest
 
 	// Interface only available internally
-	getSharedClusterBackupExecute(r GetSharedClusterBackupApiRequest) (*BackupTenantSnapshot, *http.Response, error)
+	GetSharedClusterBackupExecute(r GetSharedClusterBackupApiRequest) (*BackupTenantSnapshot, *http.Response, error)
 
 	/*
 		ListSharedClusterBackups Return All Snapshots for One M2 or M5 Cluster
@@ -84,7 +84,7 @@ type SharedTierSnapshotsApi interface {
 	ListSharedClusterBackupsWithParams(ctx context.Context, args *ListSharedClusterBackupsApiParams) ListSharedClusterBackupsApiRequest
 
 	// Interface only available internally
-	listSharedClusterBackupsExecute(r ListSharedClusterBackupsApiRequest) (*PaginatedTenantSnapshot, *http.Response, error)
+	ListSharedClusterBackupsExecute(r ListSharedClusterBackupsApiRequest) (*PaginatedTenantSnapshot, *http.Response, error)
 }
 
 // SharedTierSnapshotsApiService SharedTierSnapshotsApi service
@@ -115,7 +115,7 @@ func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackupWithParams(ct
 }
 
 func (r DownloadSharedClusterBackupApiRequest) Execute() (*TenantRestore, *http.Response, error) {
-	return r.ApiService.downloadSharedClusterBackupExecute(r)
+	return r.ApiService.DownloadSharedClusterBackupExecute(r)
 }
 
 /*
@@ -141,7 +141,7 @@ func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackup(ctx context.
 // Execute executes the request
 //
 //	@return TenantRestore
-func (a *SharedTierSnapshotsApiService) downloadSharedClusterBackupExecute(r DownloadSharedClusterBackupApiRequest) (*TenantRestore, *http.Response, error) {
+func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackupExecute(r DownloadSharedClusterBackupApiRequest) (*TenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -254,7 +254,7 @@ func (a *SharedTierSnapshotsApiService) GetSharedClusterBackupWithParams(ctx con
 }
 
 func (r GetSharedClusterBackupApiRequest) Execute() (*BackupTenantSnapshot, *http.Response, error) {
-	return r.ApiService.getSharedClusterBackupExecute(r)
+	return r.ApiService.GetSharedClusterBackupExecute(r)
 }
 
 /*
@@ -281,7 +281,7 @@ func (a *SharedTierSnapshotsApiService) GetSharedClusterBackup(ctx context.Conte
 // Execute executes the request
 //
 //	@return BackupTenantSnapshot
-func (a *SharedTierSnapshotsApiService) getSharedClusterBackupExecute(r GetSharedClusterBackupApiRequest) (*BackupTenantSnapshot, *http.Response, error) {
+func (a *SharedTierSnapshotsApiService) GetSharedClusterBackupExecute(r GetSharedClusterBackupApiRequest) (*BackupTenantSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -387,7 +387,7 @@ func (a *SharedTierSnapshotsApiService) ListSharedClusterBackupsWithParams(ctx c
 }
 
 func (r ListSharedClusterBackupsApiRequest) Execute() (*PaginatedTenantSnapshot, *http.Response, error) {
-	return r.ApiService.listSharedClusterBackupsExecute(r)
+	return r.ApiService.ListSharedClusterBackupsExecute(r)
 }
 
 /*
@@ -412,7 +412,7 @@ func (a *SharedTierSnapshotsApiService) ListSharedClusterBackups(ctx context.Con
 // Execute executes the request
 //
 //	@return PaginatedTenantSnapshot
-func (a *SharedTierSnapshotsApiService) listSharedClusterBackupsExecute(r ListSharedClusterBackupsApiRequest) (*PaginatedTenantSnapshot, *http.Response, error) {
+func (a *SharedTierSnapshotsApiService) ListSharedClusterBackupsExecute(r ListSharedClusterBackupsApiRequest) (*PaginatedTenantSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_streams.go
+++ b/admin/api_streams.go
@@ -35,7 +35,7 @@ type StreamsApi interface {
 	CreateStreamConnectionWithParams(ctx context.Context, args *CreateStreamConnectionApiParams) CreateStreamConnectionApiRequest
 
 	// Interface only available internally
-	createStreamConnectionExecute(r CreateStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error)
+	CreateStreamConnectionExecute(r CreateStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error)
 
 	/*
 		CreateStreamInstance Create One Stream Instance
@@ -58,7 +58,7 @@ type StreamsApi interface {
 	CreateStreamInstanceWithParams(ctx context.Context, args *CreateStreamInstanceApiParams) CreateStreamInstanceApiRequest
 
 	// Interface only available internally
-	createStreamInstanceExecute(r CreateStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error)
+	CreateStreamInstanceExecute(r CreateStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error)
 
 	/*
 		DeleteStreamConnection Delete One Stream Connection
@@ -83,7 +83,7 @@ type StreamsApi interface {
 	DeleteStreamConnectionWithParams(ctx context.Context, args *DeleteStreamConnectionApiParams) DeleteStreamConnectionApiRequest
 
 	// Interface only available internally
-	deleteStreamConnectionExecute(r DeleteStreamConnectionApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteStreamConnectionExecute(r DeleteStreamConnectionApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		DeleteStreamInstance Delete One Stream Instance
@@ -107,7 +107,7 @@ type StreamsApi interface {
 	DeleteStreamInstanceWithParams(ctx context.Context, args *DeleteStreamInstanceApiParams) DeleteStreamInstanceApiRequest
 
 	// Interface only available internally
-	deleteStreamInstanceExecute(r DeleteStreamInstanceApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteStreamInstanceExecute(r DeleteStreamInstanceApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetStreamConnection Return One Stream Connection
@@ -132,7 +132,7 @@ type StreamsApi interface {
 	GetStreamConnectionWithParams(ctx context.Context, args *GetStreamConnectionApiParams) GetStreamConnectionApiRequest
 
 	// Interface only available internally
-	getStreamConnectionExecute(r GetStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error)
+	GetStreamConnectionExecute(r GetStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error)
 
 	/*
 		GetStreamInstance Return One Stream Instance
@@ -156,7 +156,7 @@ type StreamsApi interface {
 	GetStreamInstanceWithParams(ctx context.Context, args *GetStreamInstanceApiParams) GetStreamInstanceApiRequest
 
 	// Interface only available internally
-	getStreamInstanceExecute(r GetStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error)
+	GetStreamInstanceExecute(r GetStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error)
 
 	/*
 		ListStreamConnections Return All Connections Of The Stream Instances
@@ -180,7 +180,7 @@ type StreamsApi interface {
 	ListStreamConnectionsWithParams(ctx context.Context, args *ListStreamConnectionsApiParams) ListStreamConnectionsApiRequest
 
 	// Interface only available internally
-	listStreamConnectionsExecute(r ListStreamConnectionsApiRequest) (*PaginatedApiStreamsConnection, *http.Response, error)
+	ListStreamConnectionsExecute(r ListStreamConnectionsApiRequest) (*PaginatedApiStreamsConnection, *http.Response, error)
 
 	/*
 		ListStreamInstances Return All Project Stream Instances
@@ -203,7 +203,7 @@ type StreamsApi interface {
 	ListStreamInstancesWithParams(ctx context.Context, args *ListStreamInstancesApiParams) ListStreamInstancesApiRequest
 
 	// Interface only available internally
-	listStreamInstancesExecute(r ListStreamInstancesApiRequest) (*PaginatedApiStreamsTenant, *http.Response, error)
+	ListStreamInstancesExecute(r ListStreamInstancesApiRequest) (*PaginatedApiStreamsTenant, *http.Response, error)
 
 	/*
 		UpdateStreamConnection Update One Stream Connection
@@ -228,7 +228,7 @@ type StreamsApi interface {
 	UpdateStreamConnectionWithParams(ctx context.Context, args *UpdateStreamConnectionApiParams) UpdateStreamConnectionApiRequest
 
 	// Interface only available internally
-	updateStreamConnectionExecute(r UpdateStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error)
+	UpdateStreamConnectionExecute(r UpdateStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error)
 
 	/*
 		UpdateStreamInstance Update One Stream Instance
@@ -252,7 +252,7 @@ type StreamsApi interface {
 	UpdateStreamInstanceWithParams(ctx context.Context, args *UpdateStreamInstanceApiParams) UpdateStreamInstanceApiRequest
 
 	// Interface only available internally
-	updateStreamInstanceExecute(r UpdateStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error)
+	UpdateStreamInstanceExecute(r UpdateStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error)
 }
 
 // StreamsApiService StreamsApi service
@@ -283,7 +283,7 @@ func (a *StreamsApiService) CreateStreamConnectionWithParams(ctx context.Context
 }
 
 func (r CreateStreamConnectionApiRequest) Execute() (*StreamsConnection, *http.Response, error) {
-	return r.ApiService.createStreamConnectionExecute(r)
+	return r.ApiService.CreateStreamConnectionExecute(r)
 }
 
 /*
@@ -309,7 +309,7 @@ func (a *StreamsApiService) CreateStreamConnection(ctx context.Context, groupId 
 // Execute executes the request
 //
 //	@return StreamsConnection
-func (a *StreamsApiService) createStreamConnectionExecute(r CreateStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error) {
+func (a *StreamsApiService) CreateStreamConnectionExecute(r CreateStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -419,7 +419,7 @@ func (a *StreamsApiService) CreateStreamInstanceWithParams(ctx context.Context, 
 }
 
 func (r CreateStreamInstanceApiRequest) Execute() (*StreamsTenant, *http.Response, error) {
-	return r.ApiService.createStreamInstanceExecute(r)
+	return r.ApiService.CreateStreamInstanceExecute(r)
 }
 
 /*
@@ -443,7 +443,7 @@ func (a *StreamsApiService) CreateStreamInstance(ctx context.Context, groupId st
 // Execute executes the request
 //
 //	@return StreamsTenant
-func (a *StreamsApiService) createStreamInstanceExecute(r CreateStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error) {
+func (a *StreamsApiService) CreateStreamInstanceExecute(r CreateStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -555,7 +555,7 @@ func (a *StreamsApiService) DeleteStreamConnectionWithParams(ctx context.Context
 }
 
 func (r DeleteStreamConnectionApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteStreamConnectionExecute(r)
+	return r.ApiService.DeleteStreamConnectionExecute(r)
 }
 
 /*
@@ -582,7 +582,7 @@ func (a *StreamsApiService) DeleteStreamConnection(ctx context.Context, groupId 
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *StreamsApiService) deleteStreamConnectionExecute(r DeleteStreamConnectionApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *StreamsApiService) DeleteStreamConnectionExecute(r DeleteStreamConnectionApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -688,7 +688,7 @@ func (a *StreamsApiService) DeleteStreamInstanceWithParams(ctx context.Context, 
 }
 
 func (r DeleteStreamInstanceApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteStreamInstanceExecute(r)
+	return r.ApiService.DeleteStreamInstanceExecute(r)
 }
 
 /*
@@ -713,7 +713,7 @@ func (a *StreamsApiService) DeleteStreamInstance(ctx context.Context, groupId st
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *StreamsApiService) deleteStreamInstanceExecute(r DeleteStreamInstanceApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *StreamsApiService) DeleteStreamInstanceExecute(r DeleteStreamInstanceApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -821,7 +821,7 @@ func (a *StreamsApiService) GetStreamConnectionWithParams(ctx context.Context, a
 }
 
 func (r GetStreamConnectionApiRequest) Execute() (*StreamsConnection, *http.Response, error) {
-	return r.ApiService.getStreamConnectionExecute(r)
+	return r.ApiService.GetStreamConnectionExecute(r)
 }
 
 /*
@@ -848,7 +848,7 @@ func (a *StreamsApiService) GetStreamConnection(ctx context.Context, groupId str
 // Execute executes the request
 //
 //	@return StreamsConnection
-func (a *StreamsApiService) getStreamConnectionExecute(r GetStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error) {
+func (a *StreamsApiService) GetStreamConnectionExecute(r GetStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -963,7 +963,7 @@ func (r GetStreamInstanceApiRequest) IncludeConnections(includeConnections bool)
 }
 
 func (r GetStreamInstanceApiRequest) Execute() (*StreamsTenant, *http.Response, error) {
-	return r.ApiService.getStreamInstanceExecute(r)
+	return r.ApiService.GetStreamInstanceExecute(r)
 }
 
 /*
@@ -988,7 +988,7 @@ func (a *StreamsApiService) GetStreamInstance(ctx context.Context, groupId strin
 // Execute executes the request
 //
 //	@return StreamsTenant
-func (a *StreamsApiService) getStreamInstanceExecute(r GetStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error) {
+func (a *StreamsApiService) GetStreamInstanceExecute(r GetStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1114,7 +1114,7 @@ func (r ListStreamConnectionsApiRequest) PageNum(pageNum int) ListStreamConnecti
 }
 
 func (r ListStreamConnectionsApiRequest) Execute() (*PaginatedApiStreamsConnection, *http.Response, error) {
-	return r.ApiService.listStreamConnectionsExecute(r)
+	return r.ApiService.ListStreamConnectionsExecute(r)
 }
 
 /*
@@ -1139,7 +1139,7 @@ func (a *StreamsApiService) ListStreamConnections(ctx context.Context, groupId s
 // Execute executes the request
 //
 //	@return PaginatedApiStreamsConnection
-func (a *StreamsApiService) listStreamConnectionsExecute(r ListStreamConnectionsApiRequest) (*PaginatedApiStreamsConnection, *http.Response, error) {
+func (a *StreamsApiService) ListStreamConnectionsExecute(r ListStreamConnectionsApiRequest) (*PaginatedApiStreamsConnection, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1273,7 +1273,7 @@ func (r ListStreamInstancesApiRequest) PageNum(pageNum int) ListStreamInstancesA
 }
 
 func (r ListStreamInstancesApiRequest) Execute() (*PaginatedApiStreamsTenant, *http.Response, error) {
-	return r.ApiService.listStreamInstancesExecute(r)
+	return r.ApiService.ListStreamInstancesExecute(r)
 }
 
 /*
@@ -1296,7 +1296,7 @@ func (a *StreamsApiService) ListStreamInstances(ctx context.Context, groupId str
 // Execute executes the request
 //
 //	@return PaginatedApiStreamsTenant
-func (a *StreamsApiService) listStreamInstancesExecute(r ListStreamInstancesApiRequest) (*PaginatedApiStreamsTenant, *http.Response, error) {
+func (a *StreamsApiService) ListStreamInstancesExecute(r ListStreamInstancesApiRequest) (*PaginatedApiStreamsTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1420,7 +1420,7 @@ func (a *StreamsApiService) UpdateStreamConnectionWithParams(ctx context.Context
 }
 
 func (r UpdateStreamConnectionApiRequest) Execute() (*StreamsConnection, *http.Response, error) {
-	return r.ApiService.updateStreamConnectionExecute(r)
+	return r.ApiService.UpdateStreamConnectionExecute(r)
 }
 
 /*
@@ -1448,7 +1448,7 @@ func (a *StreamsApiService) UpdateStreamConnection(ctx context.Context, groupId 
 // Execute executes the request
 //
 //	@return StreamsConnection
-func (a *StreamsApiService) updateStreamConnectionExecute(r UpdateStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error) {
+func (a *StreamsApiService) UpdateStreamConnectionExecute(r UpdateStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -1562,7 +1562,7 @@ func (a *StreamsApiService) UpdateStreamInstanceWithParams(ctx context.Context, 
 }
 
 func (r UpdateStreamInstanceApiRequest) Execute() (*StreamsTenant, *http.Response, error) {
-	return r.ApiService.updateStreamInstanceExecute(r)
+	return r.ApiService.UpdateStreamInstanceExecute(r)
 }
 
 /*
@@ -1588,7 +1588,7 @@ func (a *StreamsApiService) UpdateStreamInstance(ctx context.Context, groupId st
 // Execute executes the request
 //
 //	@return StreamsTenant
-func (a *StreamsApiService) updateStreamInstanceExecute(r UpdateStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error) {
+func (a *StreamsApiService) UpdateStreamInstanceExecute(r UpdateStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_streams.go
+++ b/admin/api_streams.go
@@ -34,7 +34,7 @@ type StreamsApi interface {
 	*/
 	CreateStreamConnectionWithParams(ctx context.Context, args *CreateStreamConnectionApiParams) CreateStreamConnectionApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateStreamConnectionExecute(r CreateStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error)
 
 	/*
@@ -57,7 +57,7 @@ type StreamsApi interface {
 	*/
 	CreateStreamInstanceWithParams(ctx context.Context, args *CreateStreamInstanceApiParams) CreateStreamInstanceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateStreamInstanceExecute(r CreateStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error)
 
 	/*
@@ -82,7 +82,7 @@ type StreamsApi interface {
 	*/
 	DeleteStreamConnectionWithParams(ctx context.Context, args *DeleteStreamConnectionApiParams) DeleteStreamConnectionApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteStreamConnectionExecute(r DeleteStreamConnectionApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -106,7 +106,7 @@ type StreamsApi interface {
 	*/
 	DeleteStreamInstanceWithParams(ctx context.Context, args *DeleteStreamInstanceApiParams) DeleteStreamInstanceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteStreamInstanceExecute(r DeleteStreamInstanceApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -131,7 +131,7 @@ type StreamsApi interface {
 	*/
 	GetStreamConnectionWithParams(ctx context.Context, args *GetStreamConnectionApiParams) GetStreamConnectionApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetStreamConnectionExecute(r GetStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error)
 
 	/*
@@ -155,7 +155,7 @@ type StreamsApi interface {
 	*/
 	GetStreamInstanceWithParams(ctx context.Context, args *GetStreamInstanceApiParams) GetStreamInstanceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetStreamInstanceExecute(r GetStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error)
 
 	/*
@@ -179,7 +179,7 @@ type StreamsApi interface {
 	*/
 	ListStreamConnectionsWithParams(ctx context.Context, args *ListStreamConnectionsApiParams) ListStreamConnectionsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListStreamConnectionsExecute(r ListStreamConnectionsApiRequest) (*PaginatedApiStreamsConnection, *http.Response, error)
 
 	/*
@@ -202,7 +202,7 @@ type StreamsApi interface {
 	*/
 	ListStreamInstancesWithParams(ctx context.Context, args *ListStreamInstancesApiParams) ListStreamInstancesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListStreamInstancesExecute(r ListStreamInstancesApiRequest) (*PaginatedApiStreamsTenant, *http.Response, error)
 
 	/*
@@ -227,7 +227,7 @@ type StreamsApi interface {
 	*/
 	UpdateStreamConnectionWithParams(ctx context.Context, args *UpdateStreamConnectionApiParams) UpdateStreamConnectionApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateStreamConnectionExecute(r UpdateStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error)
 
 	/*
@@ -251,7 +251,7 @@ type StreamsApi interface {
 	*/
 	UpdateStreamInstanceWithParams(ctx context.Context, args *UpdateStreamInstanceApiParams) UpdateStreamInstanceApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateStreamInstanceExecute(r UpdateStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error)
 }
 

--- a/admin/api_teams.go
+++ b/admin/api_teams.go
@@ -33,7 +33,7 @@ type TeamsApi interface {
 	*/
 	AddAllTeamsToProjectWithParams(ctx context.Context, args *AddAllTeamsToProjectApiParams) AddAllTeamsToProjectApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	AddAllTeamsToProjectExecute(r AddAllTeamsToProjectApiRequest) (*PaginatedTeamRole, *http.Response, error)
 
 	/*
@@ -57,7 +57,7 @@ type TeamsApi interface {
 	*/
 	AddTeamUserWithParams(ctx context.Context, args *AddTeamUserApiParams) AddTeamUserApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	AddTeamUserExecute(r AddTeamUserApiRequest) (*PaginatedApiAppUser, *http.Response, error)
 
 	/*
@@ -80,7 +80,7 @@ type TeamsApi interface {
 	*/
 	CreateTeamWithParams(ctx context.Context, args *CreateTeamApiParams) CreateTeamApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateTeamExecute(r CreateTeamApiRequest) (*Team, *http.Response, error)
 
 	/*
@@ -104,7 +104,7 @@ type TeamsApi interface {
 	*/
 	DeleteTeamWithParams(ctx context.Context, args *DeleteTeamApiParams) DeleteTeamApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteTeamExecute(r DeleteTeamApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -128,7 +128,7 @@ type TeamsApi interface {
 	*/
 	GetTeamByIdWithParams(ctx context.Context, args *GetTeamByIdApiParams) GetTeamByIdApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetTeamByIdExecute(r GetTeamByIdApiRequest) (*TeamResponse, *http.Response, error)
 
 	/*
@@ -152,7 +152,7 @@ type TeamsApi interface {
 	*/
 	GetTeamByNameWithParams(ctx context.Context, args *GetTeamByNameApiParams) GetTeamByNameApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetTeamByNameExecute(r GetTeamByNameApiRequest) (*TeamResponse, *http.Response, error)
 
 	/*
@@ -175,7 +175,7 @@ type TeamsApi interface {
 	*/
 	ListOrganizationTeamsWithParams(ctx context.Context, args *ListOrganizationTeamsApiParams) ListOrganizationTeamsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListOrganizationTeamsExecute(r ListOrganizationTeamsApiRequest) (*PaginatedTeam, *http.Response, error)
 
 	/*
@@ -198,7 +198,7 @@ type TeamsApi interface {
 	*/
 	ListProjectTeamsWithParams(ctx context.Context, args *ListProjectTeamsApiParams) ListProjectTeamsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListProjectTeamsExecute(r ListProjectTeamsApiRequest) (*PaginatedTeamRole, *http.Response, error)
 
 	/*
@@ -222,7 +222,7 @@ type TeamsApi interface {
 	*/
 	ListTeamUsersWithParams(ctx context.Context, args *ListTeamUsersApiParams) ListTeamUsersApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListTeamUsersExecute(r ListTeamUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error)
 
 	/*
@@ -246,7 +246,7 @@ type TeamsApi interface {
 	*/
 	RemoveProjectTeamWithParams(ctx context.Context, args *RemoveProjectTeamApiParams) RemoveProjectTeamApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	RemoveProjectTeamExecute(r RemoveProjectTeamApiRequest) (*http.Response, error)
 
 	/*
@@ -271,7 +271,7 @@ type TeamsApi interface {
 	*/
 	RemoveTeamUserWithParams(ctx context.Context, args *RemoveTeamUserApiParams) RemoveTeamUserApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	RemoveTeamUserExecute(r RemoveTeamUserApiRequest) (*http.Response, error)
 
 	/*
@@ -295,7 +295,7 @@ type TeamsApi interface {
 	*/
 	RenameTeamWithParams(ctx context.Context, args *RenameTeamApiParams) RenameTeamApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	RenameTeamExecute(r RenameTeamApiRequest) (*TeamResponse, *http.Response, error)
 
 	/*
@@ -319,7 +319,7 @@ type TeamsApi interface {
 	*/
 	UpdateTeamRolesWithParams(ctx context.Context, args *UpdateTeamRolesApiParams) UpdateTeamRolesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateTeamRolesExecute(r UpdateTeamRolesApiRequest) (*PaginatedTeamRole, *http.Response, error)
 }
 

--- a/admin/api_teams.go
+++ b/admin/api_teams.go
@@ -34,7 +34,7 @@ type TeamsApi interface {
 	AddAllTeamsToProjectWithParams(ctx context.Context, args *AddAllTeamsToProjectApiParams) AddAllTeamsToProjectApiRequest
 
 	// Interface only available internally
-	addAllTeamsToProjectExecute(r AddAllTeamsToProjectApiRequest) (*PaginatedTeamRole, *http.Response, error)
+	AddAllTeamsToProjectExecute(r AddAllTeamsToProjectApiRequest) (*PaginatedTeamRole, *http.Response, error)
 
 	/*
 		AddTeamUser Assign MongoDB Cloud Users from One Organization to One Team
@@ -58,7 +58,7 @@ type TeamsApi interface {
 	AddTeamUserWithParams(ctx context.Context, args *AddTeamUserApiParams) AddTeamUserApiRequest
 
 	// Interface only available internally
-	addTeamUserExecute(r AddTeamUserApiRequest) (*PaginatedApiAppUser, *http.Response, error)
+	AddTeamUserExecute(r AddTeamUserApiRequest) (*PaginatedApiAppUser, *http.Response, error)
 
 	/*
 		CreateTeam Create One Team in One Organization
@@ -81,7 +81,7 @@ type TeamsApi interface {
 	CreateTeamWithParams(ctx context.Context, args *CreateTeamApiParams) CreateTeamApiRequest
 
 	// Interface only available internally
-	createTeamExecute(r CreateTeamApiRequest) (*Team, *http.Response, error)
+	CreateTeamExecute(r CreateTeamApiRequest) (*Team, *http.Response, error)
 
 	/*
 		DeleteTeam Remove One Team from One Organization
@@ -105,7 +105,7 @@ type TeamsApi interface {
 	DeleteTeamWithParams(ctx context.Context, args *DeleteTeamApiParams) DeleteTeamApiRequest
 
 	// Interface only available internally
-	deleteTeamExecute(r DeleteTeamApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteTeamExecute(r DeleteTeamApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetTeamById Return One Team using its ID
@@ -129,7 +129,7 @@ type TeamsApi interface {
 	GetTeamByIdWithParams(ctx context.Context, args *GetTeamByIdApiParams) GetTeamByIdApiRequest
 
 	// Interface only available internally
-	getTeamByIdExecute(r GetTeamByIdApiRequest) (*TeamResponse, *http.Response, error)
+	GetTeamByIdExecute(r GetTeamByIdApiRequest) (*TeamResponse, *http.Response, error)
 
 	/*
 		GetTeamByName Return One Team using its Name
@@ -153,7 +153,7 @@ type TeamsApi interface {
 	GetTeamByNameWithParams(ctx context.Context, args *GetTeamByNameApiParams) GetTeamByNameApiRequest
 
 	// Interface only available internally
-	getTeamByNameExecute(r GetTeamByNameApiRequest) (*TeamResponse, *http.Response, error)
+	GetTeamByNameExecute(r GetTeamByNameApiRequest) (*TeamResponse, *http.Response, error)
 
 	/*
 		ListOrganizationTeams Return All Teams in One Organization
@@ -176,7 +176,7 @@ type TeamsApi interface {
 	ListOrganizationTeamsWithParams(ctx context.Context, args *ListOrganizationTeamsApiParams) ListOrganizationTeamsApiRequest
 
 	// Interface only available internally
-	listOrganizationTeamsExecute(r ListOrganizationTeamsApiRequest) (*PaginatedTeam, *http.Response, error)
+	ListOrganizationTeamsExecute(r ListOrganizationTeamsApiRequest) (*PaginatedTeam, *http.Response, error)
 
 	/*
 		ListProjectTeams Return All Teams in One Project
@@ -199,7 +199,7 @@ type TeamsApi interface {
 	ListProjectTeamsWithParams(ctx context.Context, args *ListProjectTeamsApiParams) ListProjectTeamsApiRequest
 
 	// Interface only available internally
-	listProjectTeamsExecute(r ListProjectTeamsApiRequest) (*PaginatedTeamRole, *http.Response, error)
+	ListProjectTeamsExecute(r ListProjectTeamsApiRequest) (*PaginatedTeamRole, *http.Response, error)
 
 	/*
 		ListTeamUsers Return All MongoDB Cloud Users Assigned to One Team
@@ -223,7 +223,7 @@ type TeamsApi interface {
 	ListTeamUsersWithParams(ctx context.Context, args *ListTeamUsersApiParams) ListTeamUsersApiRequest
 
 	// Interface only available internally
-	listTeamUsersExecute(r ListTeamUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error)
+	ListTeamUsersExecute(r ListTeamUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error)
 
 	/*
 		RemoveProjectTeam Remove One Team from One Project
@@ -247,7 +247,7 @@ type TeamsApi interface {
 	RemoveProjectTeamWithParams(ctx context.Context, args *RemoveProjectTeamApiParams) RemoveProjectTeamApiRequest
 
 	// Interface only available internally
-	removeProjectTeamExecute(r RemoveProjectTeamApiRequest) (*http.Response, error)
+	RemoveProjectTeamExecute(r RemoveProjectTeamApiRequest) (*http.Response, error)
 
 	/*
 		RemoveTeamUser Remove One MongoDB Cloud User from One Team
@@ -272,7 +272,7 @@ type TeamsApi interface {
 	RemoveTeamUserWithParams(ctx context.Context, args *RemoveTeamUserApiParams) RemoveTeamUserApiRequest
 
 	// Interface only available internally
-	removeTeamUserExecute(r RemoveTeamUserApiRequest) (*http.Response, error)
+	RemoveTeamUserExecute(r RemoveTeamUserApiRequest) (*http.Response, error)
 
 	/*
 		RenameTeam Rename One Team
@@ -296,7 +296,7 @@ type TeamsApi interface {
 	RenameTeamWithParams(ctx context.Context, args *RenameTeamApiParams) RenameTeamApiRequest
 
 	// Interface only available internally
-	renameTeamExecute(r RenameTeamApiRequest) (*TeamResponse, *http.Response, error)
+	RenameTeamExecute(r RenameTeamApiRequest) (*TeamResponse, *http.Response, error)
 
 	/*
 		UpdateTeamRoles Update Team Roles in One Project
@@ -320,7 +320,7 @@ type TeamsApi interface {
 	UpdateTeamRolesWithParams(ctx context.Context, args *UpdateTeamRolesApiParams) UpdateTeamRolesApiRequest
 
 	// Interface only available internally
-	updateTeamRolesExecute(r UpdateTeamRolesApiRequest) (*PaginatedTeamRole, *http.Response, error)
+	UpdateTeamRolesExecute(r UpdateTeamRolesApiRequest) (*PaginatedTeamRole, *http.Response, error)
 }
 
 // TeamsApiService TeamsApi service
@@ -348,7 +348,7 @@ func (a *TeamsApiService) AddAllTeamsToProjectWithParams(ctx context.Context, ar
 }
 
 func (r AddAllTeamsToProjectApiRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
-	return r.ApiService.addAllTeamsToProjectExecute(r)
+	return r.ApiService.AddAllTeamsToProjectExecute(r)
 }
 
 /*
@@ -372,7 +372,7 @@ func (a *TeamsApiService) AddAllTeamsToProject(ctx context.Context, groupId stri
 // Execute executes the request
 //
 //	@return PaginatedTeamRole
-func (a *TeamsApiService) addAllTeamsToProjectExecute(r AddAllTeamsToProjectApiRequest) (*PaginatedTeamRole, *http.Response, error) {
+func (a *TeamsApiService) AddAllTeamsToProjectExecute(r AddAllTeamsToProjectApiRequest) (*PaginatedTeamRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -484,7 +484,7 @@ func (a *TeamsApiService) AddTeamUserWithParams(ctx context.Context, args *AddTe
 }
 
 func (r AddTeamUserApiRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
-	return r.ApiService.addTeamUserExecute(r)
+	return r.ApiService.AddTeamUserExecute(r)
 }
 
 /*
@@ -510,7 +510,7 @@ func (a *TeamsApiService) AddTeamUser(ctx context.Context, orgId string, teamId 
 // Execute executes the request
 //
 //	@return PaginatedApiAppUser
-func (a *TeamsApiService) addTeamUserExecute(r AddTeamUserApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
+func (a *TeamsApiService) AddTeamUserExecute(r AddTeamUserApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -620,7 +620,7 @@ func (a *TeamsApiService) CreateTeamWithParams(ctx context.Context, args *Create
 }
 
 func (r CreateTeamApiRequest) Execute() (*Team, *http.Response, error) {
-	return r.ApiService.createTeamExecute(r)
+	return r.ApiService.CreateTeamExecute(r)
 }
 
 /*
@@ -644,7 +644,7 @@ func (a *TeamsApiService) CreateTeam(ctx context.Context, orgId string, team *Te
 // Execute executes the request
 //
 //	@return Team
-func (a *TeamsApiService) createTeamExecute(r CreateTeamApiRequest) (*Team, *http.Response, error) {
+func (a *TeamsApiService) CreateTeamExecute(r CreateTeamApiRequest) (*Team, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -753,7 +753,7 @@ func (a *TeamsApiService) DeleteTeamWithParams(ctx context.Context, args *Delete
 }
 
 func (r DeleteTeamApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteTeamExecute(r)
+	return r.ApiService.DeleteTeamExecute(r)
 }
 
 /*
@@ -778,7 +778,7 @@ func (a *TeamsApiService) DeleteTeam(ctx context.Context, orgId string, teamId s
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *TeamsApiService) deleteTeamExecute(r DeleteTeamApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *TeamsApiService) DeleteTeamExecute(r DeleteTeamApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -883,7 +883,7 @@ func (a *TeamsApiService) GetTeamByIdWithParams(ctx context.Context, args *GetTe
 }
 
 func (r GetTeamByIdApiRequest) Execute() (*TeamResponse, *http.Response, error) {
-	return r.ApiService.getTeamByIdExecute(r)
+	return r.ApiService.GetTeamByIdExecute(r)
 }
 
 /*
@@ -908,7 +908,7 @@ func (a *TeamsApiService) GetTeamById(ctx context.Context, orgId string, teamId 
 // Execute executes the request
 //
 //	@return TeamResponse
-func (a *TeamsApiService) getTeamByIdExecute(r GetTeamByIdApiRequest) (*TeamResponse, *http.Response, error) {
+func (a *TeamsApiService) GetTeamByIdExecute(r GetTeamByIdApiRequest) (*TeamResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1013,7 +1013,7 @@ func (a *TeamsApiService) GetTeamByNameWithParams(ctx context.Context, args *Get
 }
 
 func (r GetTeamByNameApiRequest) Execute() (*TeamResponse, *http.Response, error) {
-	return r.ApiService.getTeamByNameExecute(r)
+	return r.ApiService.GetTeamByNameExecute(r)
 }
 
 /*
@@ -1038,7 +1038,7 @@ func (a *TeamsApiService) GetTeamByName(ctx context.Context, orgId string, teamN
 // Execute executes the request
 //
 //	@return TeamResponse
-func (a *TeamsApiService) getTeamByNameExecute(r GetTeamByNameApiRequest) (*TeamResponse, *http.Response, error) {
+func (a *TeamsApiService) GetTeamByNameExecute(r GetTeamByNameApiRequest) (*TeamResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1167,7 +1167,7 @@ func (r ListOrganizationTeamsApiRequest) PageNum(pageNum int) ListOrganizationTe
 }
 
 func (r ListOrganizationTeamsApiRequest) Execute() (*PaginatedTeam, *http.Response, error) {
-	return r.ApiService.listOrganizationTeamsExecute(r)
+	return r.ApiService.ListOrganizationTeamsExecute(r)
 }
 
 /*
@@ -1190,7 +1190,7 @@ func (a *TeamsApiService) ListOrganizationTeams(ctx context.Context, orgId strin
 // Execute executes the request
 //
 //	@return PaginatedTeam
-func (a *TeamsApiService) listOrganizationTeamsExecute(r ListOrganizationTeamsApiRequest) (*PaginatedTeam, *http.Response, error) {
+func (a *TeamsApiService) ListOrganizationTeamsExecute(r ListOrganizationTeamsApiRequest) (*PaginatedTeam, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1339,7 +1339,7 @@ func (r ListProjectTeamsApiRequest) PageNum(pageNum int) ListProjectTeamsApiRequ
 }
 
 func (r ListProjectTeamsApiRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
-	return r.ApiService.listProjectTeamsExecute(r)
+	return r.ApiService.ListProjectTeamsExecute(r)
 }
 
 /*
@@ -1362,7 +1362,7 @@ func (a *TeamsApiService) ListProjectTeams(ctx context.Context, groupId string) 
 // Execute executes the request
 //
 //	@return PaginatedTeamRole
-func (a *TeamsApiService) listProjectTeamsExecute(r ListProjectTeamsApiRequest) (*PaginatedTeamRole, *http.Response, error) {
+func (a *TeamsApiService) ListProjectTeamsExecute(r ListProjectTeamsApiRequest) (*PaginatedTeamRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1505,7 +1505,7 @@ func (r ListTeamUsersApiRequest) PageNum(pageNum int) ListTeamUsersApiRequest {
 }
 
 func (r ListTeamUsersApiRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
-	return r.ApiService.listTeamUsersExecute(r)
+	return r.ApiService.ListTeamUsersExecute(r)
 }
 
 /*
@@ -1530,7 +1530,7 @@ func (a *TeamsApiService) ListTeamUsers(ctx context.Context, orgId string, teamI
 // Execute executes the request
 //
 //	@return PaginatedApiAppUser
-func (a *TeamsApiService) listTeamUsersExecute(r ListTeamUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
+func (a *TeamsApiService) ListTeamUsersExecute(r ListTeamUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -1649,7 +1649,7 @@ func (a *TeamsApiService) RemoveProjectTeamWithParams(ctx context.Context, args 
 }
 
 func (r RemoveProjectTeamApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.removeProjectTeamExecute(r)
+	return r.ApiService.RemoveProjectTeamExecute(r)
 }
 
 /*
@@ -1672,7 +1672,7 @@ func (a *TeamsApiService) RemoveProjectTeam(ctx context.Context, groupId string,
 }
 
 // Execute executes the request
-func (a *TeamsApiService) removeProjectTeamExecute(r RemoveProjectTeamApiRequest) (*http.Response, error) {
+func (a *TeamsApiService) RemoveProjectTeamExecute(r RemoveProjectTeamApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1770,7 +1770,7 @@ func (a *TeamsApiService) RemoveTeamUserWithParams(ctx context.Context, args *Re
 }
 
 func (r RemoveTeamUserApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.removeTeamUserExecute(r)
+	return r.ApiService.RemoveTeamUserExecute(r)
 }
 
 /*
@@ -1795,7 +1795,7 @@ func (a *TeamsApiService) RemoveTeamUser(ctx context.Context, orgId string, team
 }
 
 // Execute executes the request
-func (a *TeamsApiService) removeTeamUserExecute(r RemoveTeamUserApiRequest) (*http.Response, error) {
+func (a *TeamsApiService) RemoveTeamUserExecute(r RemoveTeamUserApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1894,7 +1894,7 @@ func (a *TeamsApiService) RenameTeamWithParams(ctx context.Context, args *Rename
 }
 
 func (r RenameTeamApiRequest) Execute() (*TeamResponse, *http.Response, error) {
-	return r.ApiService.renameTeamExecute(r)
+	return r.ApiService.RenameTeamExecute(r)
 }
 
 /*
@@ -1920,7 +1920,7 @@ func (a *TeamsApiService) RenameTeam(ctx context.Context, orgId string, teamId s
 // Execute executes the request
 //
 //	@return TeamResponse
-func (a *TeamsApiService) renameTeamExecute(r RenameTeamApiRequest) (*TeamResponse, *http.Response, error) {
+func (a *TeamsApiService) RenameTeamExecute(r RenameTeamApiRequest) (*TeamResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}
@@ -2033,7 +2033,7 @@ func (a *TeamsApiService) UpdateTeamRolesWithParams(ctx context.Context, args *U
 }
 
 func (r UpdateTeamRolesApiRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
-	return r.ApiService.updateTeamRolesExecute(r)
+	return r.ApiService.UpdateTeamRolesExecute(r)
 }
 
 /*
@@ -2059,7 +2059,7 @@ func (a *TeamsApiService) UpdateTeamRoles(ctx context.Context, groupId string, t
 // Execute executes the request
 //
 //	@return PaginatedTeamRole
-func (a *TeamsApiService) updateTeamRolesExecute(r UpdateTeamRolesApiRequest) (*PaginatedTeamRole, *http.Response, error) {
+func (a *TeamsApiService) UpdateTeamRolesExecute(r UpdateTeamRolesApiRequest) (*PaginatedTeamRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    interface{}

--- a/admin/api_third_party_integrations.go
+++ b/admin/api_third_party_integrations.go
@@ -35,7 +35,7 @@ type ThirdPartyIntegrationsApi interface {
 	CreateThirdPartyIntegrationWithParams(ctx context.Context, args *CreateThirdPartyIntegrationApiParams) CreateThirdPartyIntegrationApiRequest
 
 	// Interface only available internally
-	createThirdPartyIntegrationExecute(r CreateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error)
+	CreateThirdPartyIntegrationExecute(r CreateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error)
 
 	/*
 		DeleteThirdPartyIntegration Remove One Third-Party Service Integration
@@ -59,7 +59,7 @@ type ThirdPartyIntegrationsApi interface {
 	DeleteThirdPartyIntegrationWithParams(ctx context.Context, args *DeleteThirdPartyIntegrationApiParams) DeleteThirdPartyIntegrationApiRequest
 
 	// Interface only available internally
-	deleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (map[string]interface{}, *http.Response, error)
+	DeleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
 		GetThirdPartyIntegration Return One Third-Party Service Integration
@@ -83,7 +83,7 @@ type ThirdPartyIntegrationsApi interface {
 	GetThirdPartyIntegrationWithParams(ctx context.Context, args *GetThirdPartyIntegrationApiParams) GetThirdPartyIntegrationApiRequest
 
 	// Interface only available internally
-	getThirdPartyIntegrationExecute(r GetThirdPartyIntegrationApiRequest) (*ThridPartyIntegration, *http.Response, error)
+	GetThirdPartyIntegrationExecute(r GetThirdPartyIntegrationApiRequest) (*ThridPartyIntegration, *http.Response, error)
 
 	/*
 		ListThirdPartyIntegrations Return All Active Third-Party Service Integrations
@@ -106,7 +106,7 @@ type ThirdPartyIntegrationsApi interface {
 	ListThirdPartyIntegrationsWithParams(ctx context.Context, args *ListThirdPartyIntegrationsApiParams) ListThirdPartyIntegrationsApiRequest
 
 	// Interface only available internally
-	listThirdPartyIntegrationsExecute(r ListThirdPartyIntegrationsApiRequest) (*PaginatedIntegration, *http.Response, error)
+	ListThirdPartyIntegrationsExecute(r ListThirdPartyIntegrationsApiRequest) (*PaginatedIntegration, *http.Response, error)
 
 	/*
 		UpdateThirdPartyIntegration Update One Third-Party Service Integration
@@ -130,7 +130,7 @@ type ThirdPartyIntegrationsApi interface {
 	UpdateThirdPartyIntegrationWithParams(ctx context.Context, args *UpdateThirdPartyIntegrationApiParams) UpdateThirdPartyIntegrationApiRequest
 
 	// Interface only available internally
-	updateThirdPartyIntegrationExecute(r UpdateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error)
+	UpdateThirdPartyIntegrationExecute(r UpdateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error)
 }
 
 // ThirdPartyIntegrationsApiService ThirdPartyIntegrationsApi service
@@ -188,7 +188,7 @@ func (r CreateThirdPartyIntegrationApiRequest) PageNum(pageNum int) CreateThirdP
 }
 
 func (r CreateThirdPartyIntegrationApiRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
-	return r.ApiService.createThirdPartyIntegrationExecute(r)
+	return r.ApiService.CreateThirdPartyIntegrationExecute(r)
 }
 
 /*
@@ -214,7 +214,7 @@ func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegration(ctx conte
 // Execute executes the request
 //
 //	@return PaginatedIntegration
-func (a *ThirdPartyIntegrationsApiService) createThirdPartyIntegrationExecute(r CreateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegrationExecute(r CreateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -345,7 +345,7 @@ func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegrationWithParams
 }
 
 func (r DeleteThirdPartyIntegrationApiRequest) Execute() (map[string]interface{}, *http.Response, error) {
-	return r.ApiService.deleteThirdPartyIntegrationExecute(r)
+	return r.ApiService.DeleteThirdPartyIntegrationExecute(r)
 }
 
 /*
@@ -370,7 +370,7 @@ func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegration(ctx conte
 // Execute executes the request
 //
 //	@return map[string]interface{}
-func (a *ThirdPartyIntegrationsApiService) deleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (map[string]interface{}, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -475,7 +475,7 @@ func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegrationWithParams(ct
 }
 
 func (r GetThirdPartyIntegrationApiRequest) Execute() (*ThridPartyIntegration, *http.Response, error) {
-	return r.ApiService.getThirdPartyIntegrationExecute(r)
+	return r.ApiService.GetThirdPartyIntegrationExecute(r)
 }
 
 /*
@@ -500,7 +500,7 @@ func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegration(ctx context.
 // Execute executes the request
 //
 //	@return ThridPartyIntegration
-func (a *ThirdPartyIntegrationsApiService) getThirdPartyIntegrationExecute(r GetThirdPartyIntegrationApiRequest) (*ThridPartyIntegration, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegrationExecute(r GetThirdPartyIntegrationApiRequest) (*ThridPartyIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -629,7 +629,7 @@ func (r ListThirdPartyIntegrationsApiRequest) PageNum(pageNum int) ListThirdPart
 }
 
 func (r ListThirdPartyIntegrationsApiRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
-	return r.ApiService.listThirdPartyIntegrationsExecute(r)
+	return r.ApiService.ListThirdPartyIntegrationsExecute(r)
 }
 
 /*
@@ -652,7 +652,7 @@ func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrations(ctx contex
 // Execute executes the request
 //
 //	@return PaginatedIntegration
-func (a *ThirdPartyIntegrationsApiService) listThirdPartyIntegrationsExecute(r ListThirdPartyIntegrationsApiRequest) (*PaginatedIntegration, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrationsExecute(r ListThirdPartyIntegrationsApiRequest) (*PaginatedIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -807,7 +807,7 @@ func (r UpdateThirdPartyIntegrationApiRequest) PageNum(pageNum int) UpdateThirdP
 }
 
 func (r UpdateThirdPartyIntegrationApiRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
-	return r.ApiService.updateThirdPartyIntegrationExecute(r)
+	return r.ApiService.UpdateThirdPartyIntegrationExecute(r)
 }
 
 /*
@@ -833,7 +833,7 @@ func (a *ThirdPartyIntegrationsApiService) UpdateThirdPartyIntegration(ctx conte
 // Execute executes the request
 //
 //	@return PaginatedIntegration
-func (a *ThirdPartyIntegrationsApiService) updateThirdPartyIntegrationExecute(r UpdateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) UpdateThirdPartyIntegrationExecute(r UpdateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
 		localVarPostBody    interface{}

--- a/admin/api_third_party_integrations.go
+++ b/admin/api_third_party_integrations.go
@@ -34,7 +34,7 @@ type ThirdPartyIntegrationsApi interface {
 	*/
 	CreateThirdPartyIntegrationWithParams(ctx context.Context, args *CreateThirdPartyIntegrationApiParams) CreateThirdPartyIntegrationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateThirdPartyIntegrationExecute(r CreateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error)
 
 	/*
@@ -58,7 +58,7 @@ type ThirdPartyIntegrationsApi interface {
 	*/
 	DeleteThirdPartyIntegrationWithParams(ctx context.Context, args *DeleteThirdPartyIntegrationApiParams) DeleteThirdPartyIntegrationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DeleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (map[string]interface{}, *http.Response, error)
 
 	/*
@@ -82,7 +82,7 @@ type ThirdPartyIntegrationsApi interface {
 	*/
 	GetThirdPartyIntegrationWithParams(ctx context.Context, args *GetThirdPartyIntegrationApiParams) GetThirdPartyIntegrationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	GetThirdPartyIntegrationExecute(r GetThirdPartyIntegrationApiRequest) (*ThridPartyIntegration, *http.Response, error)
 
 	/*
@@ -105,7 +105,7 @@ type ThirdPartyIntegrationsApi interface {
 	*/
 	ListThirdPartyIntegrationsWithParams(ctx context.Context, args *ListThirdPartyIntegrationsApiParams) ListThirdPartyIntegrationsApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListThirdPartyIntegrationsExecute(r ListThirdPartyIntegrationsApiRequest) (*PaginatedIntegration, *http.Response, error)
 
 	/*
@@ -129,7 +129,7 @@ type ThirdPartyIntegrationsApi interface {
 	*/
 	UpdateThirdPartyIntegrationWithParams(ctx context.Context, args *UpdateThirdPartyIntegrationApiParams) UpdateThirdPartyIntegrationApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	UpdateThirdPartyIntegrationExecute(r UpdateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error)
 }
 

--- a/admin/api_x509_authentication.go
+++ b/admin/api_x509_authentication.go
@@ -39,7 +39,7 @@ type X509AuthenticationApi interface {
 	CreateDatabaseUserCertificateWithParams(ctx context.Context, args *CreateDatabaseUserCertificateApiParams) CreateDatabaseUserCertificateApiRequest
 
 	// Interface only available internally
-	createDatabaseUserCertificateExecute(r CreateDatabaseUserCertificateApiRequest) (string, *http.Response, error)
+	CreateDatabaseUserCertificateExecute(r CreateDatabaseUserCertificateApiRequest) (string, *http.Response, error)
 
 	/*
 		DisableCustomerManagedX509 Disable Customer-Managed X.509
@@ -64,7 +64,7 @@ type X509AuthenticationApi interface {
 	DisableCustomerManagedX509WithParams(ctx context.Context, args *DisableCustomerManagedX509ApiParams) DisableCustomerManagedX509ApiRequest
 
 	// Interface only available internally
-	disableCustomerManagedX509Execute(r DisableCustomerManagedX509ApiRequest) (*UserSecurity, *http.Response, error)
+	DisableCustomerManagedX509Execute(r DisableCustomerManagedX509ApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
 		ListDatabaseUserCertificates Return All X.509 Certificates Assigned to One MongoDB User
@@ -88,7 +88,7 @@ type X509AuthenticationApi interface {
 	ListDatabaseUserCertificatesWithParams(ctx context.Context, args *ListDatabaseUserCertificatesApiParams) ListDatabaseUserCertificatesApiRequest
 
 	// Interface only available internally
-	listDatabaseUserCertificatesExecute(r ListDatabaseUserCertificatesApiRequest) (*PaginatedUserCert, *http.Response, error)
+	ListDatabaseUserCertificatesExecute(r ListDatabaseUserCertificatesApiRequest) (*PaginatedUserCert, *http.Response, error)
 }
 
 // X509AuthenticationApiService X509AuthenticationApi service
@@ -119,7 +119,7 @@ func (a *X509AuthenticationApiService) CreateDatabaseUserCertificateWithParams(c
 }
 
 func (r CreateDatabaseUserCertificateApiRequest) Execute() (string, *http.Response, error) {
-	return r.ApiService.createDatabaseUserCertificateExecute(r)
+	return r.ApiService.CreateDatabaseUserCertificateExecute(r)
 }
 
 /*
@@ -149,7 +149,7 @@ func (a *X509AuthenticationApiService) CreateDatabaseUserCertificate(ctx context
 // Execute executes the request
 //
 //	@return string
-func (a *X509AuthenticationApiService) createDatabaseUserCertificateExecute(r CreateDatabaseUserCertificateApiRequest) (string, *http.Response, error) {
+func (a *X509AuthenticationApiService) CreateDatabaseUserCertificateExecute(r CreateDatabaseUserCertificateApiRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
@@ -256,7 +256,7 @@ func (a *X509AuthenticationApiService) DisableCustomerManagedX509WithParams(ctx 
 }
 
 func (r DisableCustomerManagedX509ApiRequest) Execute() (*UserSecurity, *http.Response, error) {
-	return r.ApiService.disableCustomerManagedX509Execute(r)
+	return r.ApiService.DisableCustomerManagedX509Execute(r)
 }
 
 /*
@@ -281,7 +281,7 @@ func (a *X509AuthenticationApiService) DisableCustomerManagedX509(ctx context.Co
 // Execute executes the request
 //
 //	@return UserSecurity
-func (a *X509AuthenticationApiService) disableCustomerManagedX509Execute(r DisableCustomerManagedX509ApiRequest) (*UserSecurity, *http.Response, error) {
+func (a *X509AuthenticationApiService) DisableCustomerManagedX509Execute(r DisableCustomerManagedX509ApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
@@ -412,7 +412,7 @@ func (r ListDatabaseUserCertificatesApiRequest) PageNum(pageNum int) ListDatabas
 }
 
 func (r ListDatabaseUserCertificatesApiRequest) Execute() (*PaginatedUserCert, *http.Response, error) {
-	return r.ApiService.listDatabaseUserCertificatesExecute(r)
+	return r.ApiService.ListDatabaseUserCertificatesExecute(r)
 }
 
 /*
@@ -437,7 +437,7 @@ func (a *X509AuthenticationApiService) ListDatabaseUserCertificates(ctx context.
 // Execute executes the request
 //
 //	@return PaginatedUserCert
-func (a *X509AuthenticationApiService) listDatabaseUserCertificatesExecute(r ListDatabaseUserCertificatesApiRequest) (*PaginatedUserCert, *http.Response, error) {
+func (a *X509AuthenticationApiService) ListDatabaseUserCertificatesExecute(r ListDatabaseUserCertificatesApiRequest) (*PaginatedUserCert, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}

--- a/admin/api_x509_authentication.go
+++ b/admin/api_x509_authentication.go
@@ -38,7 +38,7 @@ type X509AuthenticationApi interface {
 	*/
 	CreateDatabaseUserCertificateWithParams(ctx context.Context, args *CreateDatabaseUserCertificateApiParams) CreateDatabaseUserCertificateApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	CreateDatabaseUserCertificateExecute(r CreateDatabaseUserCertificateApiRequest) (string, *http.Response, error)
 
 	/*
@@ -63,7 +63,7 @@ type X509AuthenticationApi interface {
 	*/
 	DisableCustomerManagedX509WithParams(ctx context.Context, args *DisableCustomerManagedX509ApiParams) DisableCustomerManagedX509ApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	DisableCustomerManagedX509Execute(r DisableCustomerManagedX509ApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
@@ -87,7 +87,7 @@ type X509AuthenticationApi interface {
 	*/
 	ListDatabaseUserCertificatesWithParams(ctx context.Context, args *ListDatabaseUserCertificatesApiParams) ListDatabaseUserCertificatesApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	ListDatabaseUserCertificatesExecute(r ListDatabaseUserCertificatesApiRequest) (*PaginatedUserCert, *http.Response, error)
 }
 

--- a/internal/core/version.go
+++ b/internal/core/version.go
@@ -5,7 +5,7 @@ package core
 // For more information please see: https://github.com/mongodb/atlas-sdk-go/blob/main/docs/doc_1_concepts.md
 const (
 	// SDK release tag version.
-	Version = "v20231115004.0.0"
+	Version = "v20231115004.1.0"
 	// Resource Version.
 	Resource = "20231115"
 )

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -47,7 +47,7 @@ type {{classname}} interface {
 	*/
 	{{nickname}}WithParams(ctx context.Context, args *{{operationId}}ApiParams) {{operationId}}ApiRequest
 
-	// Interface only available internally
+	// Method available only for mocking purposes
 	{{{nickname}}}Execute(r {{operationId}}ApiRequest) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error)
 	{{/operation}}
 }

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -48,7 +48,7 @@ type {{classname}} interface {
 	{{nickname}}WithParams(ctx context.Context, args *{{operationId}}ApiParams) {{operationId}}ApiRequest
 
 	// Interface only available internally
-	{{#lambda.camelcase}}{{{nickname}}}{{/lambda.camelcase}}Execute(r {{operationId}}ApiRequest) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error)
+	{{{nickname}}}Execute(r {{operationId}}ApiRequest) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error)
 	{{/operation}}
 }
 {{/generateInterfaces}}
@@ -102,7 +102,7 @@ func (r {{operationId}}ApiRequest) {{vendorExtensions.x-export-param-name}}({{pa
 {{/isPathParam}}
 {{/allParams}}
 func (r {{operationId}}ApiRequest) Execute() ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
-	return r.ApiService.{{#lambda.camelcase}}{{{nickname}}}{{/lambda.camelcase}}Execute(r)
+	return r.ApiService.{{{nickname}}}Execute(r)
 }
 
 /*
@@ -138,7 +138,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#pathParams
 {{#isDeprecated}}
 // Deprecated
 {{/isDeprecated}}
-func (a *{{{classname}}}Service) {{#lambda.camelcase}}{{{nickname}}}{{/lambda.camelcase}}Execute(r {{operationId}}ApiRequest) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
+func (a *{{{classname}}}Service) {{{nickname}}}Execute(r {{operationId}}ApiRequest) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.Method{{httpMethod}}
 		localVarPostBody     interface{}


### PR DESCRIPTION
## Description

We are adding ability to mock execute methods/interface in SDK.

Side effect: All interfaces methods must be public.
Since executor library uses interface we cannot have any private execute methods to be available on interface itself.


## Why

If we do not provide an public methods on interface generation of the mocks outside the SDK would not work as generators will not have access to private methods. 
Alternatively we could consider #232 as mocking solution in SDK but still some customers will likely prefer to use their own mocking.

## Review

Only *.mustache file matters. Rest of the changes are generations from mustache file
