### PR TITLE
task: change cron job for Autoupdate PRs to start earlier

### DIFF
--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -1,7 +1,7 @@
 name: Generate SDK
 on:
  schedule:
-   - cron: '30 8 * * *'
+   - cron: '30 5 * * *'
  workflow_dispatch:
   
 jobs:


### PR DESCRIPTION
## Description

Cron job can run during the night to enable other timezones.

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

