### PR TITLE
CLOUDP-243894: handle gzip content-type header in API response

### DIFF
--- a/tools/config/go-templates/client.mustache
+++ b/tools/config/go-templates/client.mustache
@@ -34,6 +34,7 @@ import (
 var (
 	jsonCheck = regexp.MustCompile(`(?i:(?:application|text)/(?:vnd\.[^;]+\+)?json)`)
 	xmlCheck  = regexp.MustCompile(`(?i:(?:application|text)/xml)`)
+	gzipCheck       = regexp.MustCompile(`(?i:(?:application|text)/(?:vnd\.[^;]+\+)?gzip)`)
 	queryParamSplit = regexp.MustCompile(`(^|&)([^&]+)`)
 	queryDescape    = strings.NewReplacer( "%5B", "[", "%5D", "]" )
 )
@@ -507,6 +508,20 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		}
 		return nil
 	}
+	if gzipCheck.MatchString(contentType) {
+		if actualObj, ok := v.(interface{ GetActualInstance() interface{} }); ok { // oneOf, anyOf schemas
+			if unmarshalObj, ok := actualObj.(interface{ UnmarshalJSON([]byte) error }); ok { // make sure it has UnmarshalJSON defined
+				if err = unmarshalObj.UnmarshalJSON(b); err != nil {
+					return err
+				}
+			} else {
+				return errors.New("unknown type with GetActualInstance but no unmarshalObj.UnmarshalJSON defined")
+			}
+		} else if err = json.Unmarshal(b, v); err != nil { // simple model
+			return err
+		}
+		return nil
+	}
 	return errors.New("undefined response type")
 }
 
@@ -554,7 +569,6 @@ func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err e
 	} else if xmlCheck.MatchString(contentType) {
 		err = xml.NewEncoder(bodyBuf).Encode(body)
 	}
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Ticket: CLOUDP-243894

Currently the SDK [only expects xml and json contentTypes](https://github.com/mongodb/atlas-sdk-go/blob/38bfaed83410503abf61e48dc3b7afe47fb7bfc8/admin/client.go#L511-L547) for 300+ responses
[MonitoringAndLogsApi.GetHostLogsWithParams](https://github.com/mongodb/atlas-sdk-go/blob/659fd11e78f4e65bb1e24a35486b32400255a46f/mockadmin/monitoring_and_logs_api.go#L731) is returning `Content-Type: application/vnd.atlas.2023-02-01+gzip;charset=utf-8` for 400 response code requests, omitting the helpful API error message

**Verified with method:** 
```
sdk.MonitoringAndLogsApi.GetHostLogsWithParams(ctx, params).Execute()
```

**SDK Output Before this change**
```
Error: undefined response type
2024/04/19 15:37:04 Error when performing SDK request: 
```

**SDK Output After this change**
```
https://{{env}}/api/atlas/v2/groups/{{groupId}}/clusters/a/logs/mongos.gz GET: HTTP 400 Bad Request (Error code: "INVALID_HOSTNAME") Detail: Invalid hostname a. Reason: Bad Request. Params: [a]
2024/04/19 15:39:54 Error when performing SDK request: Invalid hostname a.
```

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

