### PR TITLE
task: be strict on the node version we use

### DIFF
--- a/tools/.npmrc
+++ b/tools/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -18,8 +18,8 @@
         "replace-in-file": "^7.0.1"
       },
       "engines": {
-        "node": ">= 18",
-        "npm": ">= 9"
+        "node": ">= 16",
+        "npm": ">= 8"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -18,8 +18,8 @@
         "replace-in-file": "^7.0.1"
       },
       "engines": {
-        "node": ">= 14",
-        "npm": ">= 5"
+        "node": ">= 18",
+        "npm": ">= 9"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/tools/package.json
+++ b/tools/package.json
@@ -22,7 +22,7 @@
     "ci": "npm run test && npm run format:check"
   },
   "engines": {
-    "node": ">= 14",
-    "npm": ">= 5"
+    "node": ">= 18",
+    "npm": ">= 9"
   }
 }

--- a/tools/package.json
+++ b/tools/package.json
@@ -22,7 +22,7 @@
     "ci": "npm run test && npm run format:check"
   },
   "engines": {
-    "node": ">= 18",
-    "npm": ">= 9"
+    "node": ">= 16",
+    "npm": ">= 8"
   }
 }


### PR DESCRIPTION
## Description

Be strict on the node version 

if you don't have the correct version installed you'll get
```
npm install
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: openapi-generation-tools@0.1.0
npm ERR! notsup Not compatible with your version of node/npm: openapi-generation-tools@0.1.0
npm ERR! notsup Required: {"node":">= 18","npm":">= 10"}
npm ERR! notsup Actual:   {"npm":"9.8.1","node":"v18.18.2"}
```

