### PR TITLE
task: remove search api from ignores

### DIFF
--- a/tools/transformer/src/duplicate.ignore.json
+++ b/tools/transformer/src/duplicate.ignore.json
@@ -1,8 +1,6 @@
 {
   "ignoredProperties": [
     "units",
-    "latestDefinition",
-    "definition",
     "threshold",
     "eventTypeName",
     "currentValue",


### PR DESCRIPTION
## Description

Since Search API is now transformed we do not need it to be ignored in detection of duplicates. 
This will prevent from introducing another set of duplicated models for search in the future.
The new resource version should no longer have those duplicates as well.

## Verification

CI/CD passes
