### PR TITLE
task: release note on automated PRs

### DIFF
--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -89,7 +89,11 @@ jobs:
             2. If PR contains breaking changes, review `./releaser/breaking_changes/{release_version}.md` file
             3. Approve and merge PR into the main branch 
             4. After the merge automated release process will be triggered. 
+
+            ## Troubleshooting 
+
+            To skip release process after merge please revert changes from `version.go` file.
+            Release can be triggered by restoring changes in version.go.
+
             
-          
-
-
+            


### PR DESCRIPTION
## Description

Adding note for the release PRs informing that there is a way to prevent automatic releases for the PR.
Automatic release might not be desired if:

- We know there would be subsequent releases coming in near future
- We have other SDK related PRs that should be also included in that release

Release PRs should not be blocked over the weeks period, but we should avoid multiple releases in the short timeframe or releaes that might have known flaws.


Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

