### PR TITLE
Adds a line break to prevent issues importing to docs

### DIFF
--- a/docs/doc_5_best_practices.md
+++ b/docs/doc_5_best_practices.md
@@ -44,6 +44,7 @@ The SDK provides a dedicated `HasFieldName` or `GetFieldName` function for each 
 
 - Use `time.Time` methods to compare date values:
 When you have confirmed that the `time.Time pointer` is non-nil, you can safely use `time.Time` methods to compare the actual date values. Commonly used methods for comparison include `Before`, `After`, and `Equal`:
+
 ```go
 // Surrounding code omitted for brevity
 


### PR DESCRIPTION
## Description

Due to the use of a code block within a bullet, we can't import the SDK docs without editing the downloaded file. This fixes that issue.

Link to any related issue(s): 

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

