### PR TITLE
CLOUDP-252392: unify go imports installation

### DIFF
--- a/.github/workflows/autoupdate-preview.yaml
+++ b/.github/workflows/autoupdate-preview.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - run: go install golang.org/x/tools/cmd/goimports@v0.21.0
+      - run: make install-goimports
       - name: Fetch changes
         working-directory: ./tools
         run: make fetch_openapi

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - run: go install golang.org/x/tools/cmd/goimports@v0.21.0
+      - run: make install-goimports
       - name: Fetch changes
         working-directory: ./tools
         run: make fetch_openapi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,9 @@ Reviewers, please ensure that the CLA has been signed by referring to [the contr
 
 #### Prerequisite Tools
 - [Git](https://git-scm.com/)
-- [Go (at least Go 1.14)](https://golang.org/dl/)
+- [Golang (at least Go 1.21)](https://golang.org/dl/)
+    - Repository uses https://asdf-vm.com for golang version management
+- Run `make tools` to install all required binaries
 
 #### Environment
 - Fork the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Reviewers, please ensure that the CLA has been signed by referring to [the contr
 #### Prerequisite Tools
 - [Git](https://git-scm.com/)
 - [Golang (at least Go 1.21)](https://golang.org/dl/)
-    - Repository uses https://asdf-vm.com for golang version management
+    - Repository uses [asdf](https://asdf-vm.com) for golang version management
 - Run `make tools` to install all required binaries
 
 #### Environment

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SOURCE_FILES?=./...
 GOLANGCI_VERSION=v1.59.0
+GOIMPORTS_VERSION=v0.21.0
 COVERAGE=coverage.out
 
 export GO111MODULE := on
@@ -42,7 +43,7 @@ install-golangci-lint:
 
 .PHONY: install-goimports
 install-goimports:
-	go install golang.org/x/tools/cmd/goimports@v0.21.0
+	go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
 
 .PHONY: tools
 tools: install-golangci-lint install-goimports

--- a/tools/scripts/generate.sh
+++ b/tools/scripts/generate.sh
@@ -36,4 +36,11 @@ npm exec openapi-generator-cli -- generate \
     --type-mappings=file=io.ReadCloser \
     --ignore-file-override=config/.go-ignore
 
+# Check if goimports exists and is executable
+if ! command -v goimports &> /dev/null; then
+  echo "Error: goimports command not found. Please install goimports by running 'make install-goimports' before running this script."
+  exit 1
+fi
+
+
 goimports -w "$SDK_FOLDER"

--- a/tools/scripts/generate.sh
+++ b/tools/scripts/generate.sh
@@ -42,5 +42,4 @@ if ! command -v goimports &> /dev/null; then
   exit 1
 fi
 
-
 goimports -w "$SDK_FOLDER"


### PR DESCRIPTION
## Description

CLOUDP-252392

Reused existing make file and added documentation for goimports binary that is now integral part of the SDK.

## Verification

- Successfully run [autoupdate-preview job from](https://github.com/mongodb/atlas-sdk-go/actions/runs/9663629705) branch.
- Successfully run `make openapi-pipeline` in evergreen

## Documentation

Added documentation in order to install required tool on the developers machines

## Alternatives considered

- Initially implemented goimports installation during generate phase however this approach would have hidden this tool from developers can cause futher issues with local dev setup.
- Investigated embedding all binaries into go.mod with ability to install them:
```
tools=...
go install $tools
```