### PR TITLE
CLOUDP-268814 - Integrations team notified for the new atlas-sdk-go PR reviews.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Maintained by the API experience team
-* @mongodb/apix1
+* @mongodb/apix1 @mongodb/APIx-Integrations
 # Manual docs
 /docs @mongodb/docs-cloud-team
 


### PR DESCRIPTION
Change only for integrations team to get notifications on the automatic SDK PRs. 
o other impact as all integrations team members already have full write access on the repository and monitoring PRs.

This step is required for the integration team to get new PR notifications and shadow PR reviews.
Individual members can still manage their notification settings to adjust notifications.
On call rota determines person who should be reviewing PR (still APIx1 for the moment)
