### PR TITLE
task: cleanup breaking changes

### DIFF
--- a/tools/releaser/scripts/breaking-changes.sh
+++ b/tools/releaser/scripts/breaking-changes.sh
@@ -23,24 +23,18 @@ set +e
 BREAKING_CHANGES=$("$GOPATH/bin/go-apidiff" "$GIT_BASE_REF" --compare-imports="false" --print-compatible="false" )
 set -e
 popd || exit
-cmd_return_code=$?
-
-echo "Breaking changes finished with $cmd_return_code return code"
 
 if [ -z "$BREAKING_CHANGES" ]; then
     echo "No major breaking changes detected"
-    exit $cmd_return_code
-fi
-
-echo "Detected major breaking changes in the release"
-if [ -z "$TARGET_BREAKING_CHANGES_FILE" ]; then
-  echo "Breaking changes for the major release"
-  echo "$BREAKING_CHANGES"
 else
-  echo "Creating the breaking changes file with following breaking changes:"
-  echo "$BREAKING_CHANGES"
-  echo -e "# Breaking Changes\n## SDK changes\n$BREAKING_CHANGES\n## API Changelog\n https://www.mongodb.com/docs/atlas/reference/api-resources-spec/changelog" \
-  > "$script_path/../breaking_changes/${TARGET_BREAKING_CHANGES_FILE}.md"
+    echo "Detected major breaking changes in the release"
+    if [ -z "$TARGET_BREAKING_CHANGES_FILE" ]; then
+      echo "Breaking changes for the major release"
+      echo "$BREAKING_CHANGES"
+    else
+      echo "Creating the breaking changes file with following breaking changes:"
+      echo "$BREAKING_CHANGES"
+      echo -e "# Breaking Changes\n## SDK changes\n$BREAKING_CHANGES\n## API Changelog\n https://www.mongodb.com/docs/atlas/reference/api-resources-spec/changelog" \
+      > "$script_path/../breaking_changes/${TARGET_BREAKING_CHANGES_FILE}.md"
+    fi
 fi
- 
-exit $cmd_return_code


### PR DESCRIPTION
## Description

Minor cleanup for the breaking changes script from debug logging we added recently to understand breaking changes error codes.

## Conclusions from logging 

Breakingchanges cmd always returns 0 status independent from the breaking changes in github actions environment,
which is not desired behaviour: https://github.com/joelanford/go-apidiff/blob/main/action.yml#L64-L72
