### PR TITLE
CLOUDP-276381: adding formatting to SDK

### DIFF
--- a/admin/client.go
+++ b/admin/client.go
@@ -531,7 +531,7 @@ func (c *APIClient) makeApiError(res *http.Response, httpMethod, httpPath string
 		newErr.error = err.Error()
 		return newErr
 	}
-	newErr.error = formatErrorMessage(res.Status, httpMethod, httpPath, v)
+	newErr.error = FormatErrorMessageWithDetails(res.Status, httpMethod, httpPath, v)
 	newErr.model = v
 	return newErr
 }
@@ -691,9 +691,15 @@ func (e *GenericOpenAPIError) SetError(errorString string) {
 	e.error = errorString
 }
 
-// format error message using title and detail when model implements Error
-func formatErrorMessage(status, path, method string, v ApiError) string {
-	return fmt.Sprintf("%v %v: HTTP %v (Error code: %q) Detail: %v Reason: %v. Params: %v",
+// FormatErrorMessageWithDetails: format error message using error struct fields: Should be only used for testing
+func FormatErrorMessageWithDetails(status, path, method string, v ApiError) string {
+	detailString := ""
+	if v.BadRequestDetail != nil {
+		badRequestDetail, _ := json.Marshal(v.GetBadRequestDetail())
+		detailString = string(badRequestDetail)
+	}
+
+	return fmt.Sprintf("%v %v: HTTP %v (Error code: %q) Detail: %v Reason: %v. Params: %v, BadRequestDetail: %v",
 		method, path, status, v.GetErrorCode(),
-		v.GetDetail(), v.GetReason(), v.GetParameters())
+		v.GetDetail(), v.GetReason(), v.GetParameters(), detailString)
 }

--- a/admin/client.go
+++ b/admin/client.go
@@ -691,7 +691,7 @@ func (e *GenericOpenAPIError) SetError(errorString string) {
 	e.error = errorString
 }
 
-// FormatErrorMessageWithDetails: format error message using error struct fields: Should be only used for testing
+// FormatErrorMessageWithDetails formats error message using error struct fields. It should be only used for testing.
 func FormatErrorMessageWithDetails(status, path, method string, v ApiError) string {
 	detailString := ""
 	if v.BadRequestDetail != nil {

--- a/admin/client.go
+++ b/admin/client.go
@@ -693,13 +693,13 @@ func (e *GenericOpenAPIError) SetError(errorString string) {
 
 // FormatErrorMessageWithDetails formats error message using error struct fields. It should be only used for testing.
 func FormatErrorMessageWithDetails(status, path, method string, v ApiError) string {
-	detailString := ""
+	badRequestDetailString := ""
 	if v.BadRequestDetail != nil {
 		badRequestDetail, _ := json.Marshal(v.GetBadRequestDetail())
-		detailString = string(badRequestDetail)
+		badRequestDetailString = string(badRequestDetail)
 	}
 
 	return fmt.Sprintf("%v %v: HTTP %v (Error code: %q) Detail: %v Reason: %v. Params: %v, BadRequestDetail: %v",
 		method, path, status, v.GetErrorCode(),
-		v.GetDetail(), v.GetReason(), v.GetParameters(), detailString)
+		v.GetDetail(), v.GetReason(), v.GetParameters(), badRequestDetailString)
 }

--- a/test/example_error_test.go
+++ b/test/example_error_test.go
@@ -1,0 +1,56 @@
+package test
+
+import (
+	"fmt"
+
+	"go.mongodb.org/atlas-sdk/v20240805004/admin"
+)
+
+ 
+func ExampleNewError() {
+	label := "test";
+	
+	err := admin.ApiError{
+		BadRequestDetail: &admin.BadRequestDetail{Fields: &[]admin.FieldViolation{
+			{Description: &label, Field: &label},
+		}},
+		Detail:           new(string),
+		Error:            new(int),
+		ErrorCode:        new(string),
+		Parameters:       &[]interface{}{},
+		Reason:           new(string),
+	}
+	fmt.Printf("Violations: %+v\n", admin.FormatErrorMessageWithDetails("200", "/test","POST", err))
+	// Output:
+	// Violations: POST /test: HTTP 200 (Error code: "") Detail:  Reason: . Params: [], BadRequestDetail: {"fields":[{"description":"test","field":"test"}]}
+}
+
+ 
+func ExampleNewErrorMissingFieldViolations() {
+	err := admin.ApiError{
+		BadRequestDetail: &admin.BadRequestDetail{},
+		Detail:           new(string),
+		Error:            new(int),
+		ErrorCode:        new(string),
+		Parameters:       &[]interface{}{},
+		Reason:           new(string),
+	}
+	fmt.Printf("%+v\n", admin.FormatErrorMessageWithDetails("200", "/test","POST", err))
+	// Output:
+	// POST /test: HTTP 200 (Error code: "") Detail:  Reason: . Params: [], BadRequestDetail: {}
+}
+
+
+func ExampleNewErrorMissingDetail() {
+	err := admin.ApiError{
+		BadRequestDetail: nil,
+		Detail:           new(string),
+		Error:            new(int),
+		ErrorCode:        new(string),
+		Parameters:       &[]interface{}{},
+		Reason:           new(string),
+	}
+	fmt.Printf("%+v\n", admin.FormatErrorMessageWithDetails("200", "/test","POST", err))
+	// Output:
+	// POST /test: HTTP 200 (Error code: "") Detail:  Reason: . Params: [], BadRequestDetail:
+}

--- a/test/example_error_test.go
+++ b/test/example_error_test.go
@@ -7,7 +7,7 @@ import (
 )
 
  
-func ExampleNewError() {
+func ExampleFormatErrorMessageWithDetails_test() {
 	label := "test";
 	
 	err := admin.ApiError{
@@ -21,12 +21,12 @@ func ExampleNewError() {
 		Reason:           new(string),
 	}
 	fmt.Printf("Violations: %+v\n", admin.FormatErrorMessageWithDetails("200", "/test","POST", err))
+	
 	// Output:
 	// Violations: POST /test: HTTP 200 (Error code: "") Detail:  Reason: . Params: [], BadRequestDetail: {"fields":[{"description":"test","field":"test"}]}
 }
 
- 
-func ExampleNewErrorMissingFieldViolations() {
+func ExampleFormatErrorMessageWithDetails_empty() {
 	err := admin.ApiError{
 		BadRequestDetail: &admin.BadRequestDetail{},
 		Detail:           new(string),
@@ -36,12 +36,12 @@ func ExampleNewErrorMissingFieldViolations() {
 		Reason:           new(string),
 	}
 	fmt.Printf("%+v\n", admin.FormatErrorMessageWithDetails("200", "/test","POST", err))
+
 	// Output:
 	// POST /test: HTTP 200 (Error code: "") Detail:  Reason: . Params: [], BadRequestDetail: {}
 }
 
-
-func ExampleNewErrorMissingDetail() {
+func ExampleFormatErrorMessageWithDetails_missing() {
 	err := admin.ApiError{
 		BadRequestDetail: nil,
 		Detail:           new(string),

--- a/tools/config/go-templates/client.mustache
+++ b/tools/config/go-templates/client.mustache
@@ -492,7 +492,7 @@ func (c *APIClient) makeApiError(res *http.Response, httpMethod, httpPath string
 		newErr.error = err.Error()
 		return newErr
 	}
-	newErr.error = formatErrorMessage(res.Status, httpMethod, httpPath, v)
+	newErr.error = FormatErrorMessageWithDetails(res.Status, httpMethod, httpPath, v)
 	newErr.model = v
 	return newErr
 }
@@ -652,9 +652,16 @@ func (e *GenericOpenAPIError) SetError(errorString string) {
 	e.error = errorString;
 }
 
-// format error message using title and detail when model implements Error
-func formatErrorMessage(status, path, method string, v ApiError) string {
-	return fmt.Sprintf("%v %v: HTTP %v (Error code: %q) Detail: %v Reason: %v. Params: %v",
-			method, path, status, v.GetErrorCode(),
-	 		v.GetDetail(), v.GetReason(), v.GetParameters())
+// FormatErrorMessageWithDetails: format error message using error struct fields: Should be only used for testing
+func FormatErrorMessageWithDetails(status, path, method string, v ApiError) string {
+	detailString := "";
+	if v.BadRequestDetail != nil {
+		badRequestDetail, _ := json.Marshal(v.GetBadRequestDetail());
+		detailString = string(badRequestDetail);
+	}
+
+	return fmt.Sprintf("%v %v: HTTP %v (Error code: %q) Detail: %v Reason: %v. Params: %v, BadRequestDetail: %v",
+		method, path, status, v.GetErrorCode(),
+		v.GetDetail(), v.GetReason(), v.GetParameters(), detailString)
 }
+

--- a/tools/config/go-templates/client.mustache
+++ b/tools/config/go-templates/client.mustache
@@ -652,16 +652,15 @@ func (e *GenericOpenAPIError) SetError(errorString string) {
 	e.error = errorString;
 }
 
-// FormatErrorMessageWithDetails: format error message using error struct fields: Should be only used for testing
+// FormatErrorMessageWithDetails formats error message using error struct fields. It should be only used for testing.
 func FormatErrorMessageWithDetails(status, path, method string, v ApiError) string {
-	detailString := "";
+	badRequestDetailString := ""
 	if v.BadRequestDetail != nil {
-		badRequestDetail, _ := json.Marshal(v.GetBadRequestDetail());
-		detailString = string(badRequestDetail);
+		badRequestDetail, _ := json.Marshal(v.GetBadRequestDetail())
+		badRequestDetailString = string(badRequestDetail)
 	}
 
 	return fmt.Sprintf("%v %v: HTTP %v (Error code: %q) Detail: %v Reason: %v. Params: %v, BadRequestDetail: %v",
 		method, path, status, v.GetErrorCode(),
-		v.GetDetail(), v.GetReason(), v.GetParameters(), detailString)
+		v.GetDetail(), v.GetReason(), v.GetParameters(), badRequestDetailString)
 }
-


### PR DESCRIPTION
## Description

Adding missing SDK error formatting introduced recently by us in backend.

## Review details

1. Review example file 
2. Tests should be passing (example is an test)
3. Review template

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

