### PR TITLE
task: move unused codebase to the new package

### DIFF
--- a/auth/code/device_flow.go
+++ b/auth/code/device_flow.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package auth
+package code
 
 import (
 	"context"

--- a/auth/code/device_flow_test.go
+++ b/auth/code/device_flow_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package auth
+package code
 
 import (
 	"fmt"

--- a/auth/code/doc.go
+++ b/auth/code/doc.go
@@ -41,4 +41,4 @@ pass cancellation signals and deadlines to various services of the client for
 handling a request. In case there is no context available, then context.Background()
 can be used as a starting point.
 */
-package auth
+package code

--- a/auth/code/oauth.go
+++ b/auth/code/oauth.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package auth
+package code
 
 import (
 	"bytes"

--- a/auth/code/oauth_test.go
+++ b/auth/code/oauth_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package auth
+package code
 
 import (
 	"context"

--- a/auth/code/token.go
+++ b/auth/code/token.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package auth
+package code
 
 import (
 	"net/http"


### PR DESCRIPTION
## Description

Cleanup in unused auth module. 
Auth Module were never used moving to subpackage. In the follow up PRs we will be introducing alternative authentication methods and we need auth module to be part of the subpackage.
For more info see: https://github.com/mongodb/atlas-sdk-go/pull/429
