### PR TITLE
task: Rename interface{} to any

### DIFF
--- a/admin/api_access_tracking.go
+++ b/admin/api_access_tracking.go
@@ -159,7 +159,7 @@ func (a *AccessTrackingApiService) ListAccessLogsByClusterName(ctx context.Conte
 func (a *AccessTrackingApiService) ListAccessLogsByClusterNameExecute(r ListAccessLogsByClusterNameApiRequest) (*MongoDBAccessLogsList, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *MongoDBAccessLogsList
 	)
@@ -340,7 +340,7 @@ func (a *AccessTrackingApiService) ListAccessLogsByHostname(ctx context.Context,
 func (a *AccessTrackingApiService) ListAccessLogsByHostnameExecute(r ListAccessLogsByHostnameApiRequest) (*MongoDBAccessLogsList, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *MongoDBAccessLogsList
 	)

--- a/admin/api_alert_configurations.go
+++ b/admin/api_alert_configurations.go
@@ -276,7 +276,7 @@ func (a *AlertConfigurationsApiService) CreateAlertConfiguration(ctx context.Con
 func (a *AlertConfigurationsApiService) CreateAlertConfigurationExecute(r CreateAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupAlertsConfig
 	)
@@ -397,7 +397,7 @@ func (a *AlertConfigurationsApiService) DeleteAlertConfiguration(ctx context.Con
 func (a *AlertConfigurationsApiService) DeleteAlertConfigurationExecute(r DeleteAlertConfigurationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -501,7 +501,7 @@ func (a *AlertConfigurationsApiService) GetAlertConfiguration(ctx context.Contex
 func (a *AlertConfigurationsApiService) GetAlertConfigurationExecute(r GetAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupAlertsConfig
 	)
@@ -608,7 +608,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNames
 func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNamesExecute(r ListAlertConfigurationMatchersFieldNamesApiRequest) ([]string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []string
 	)
@@ -747,7 +747,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurations(ctx context.Cont
 func (a *AlertConfigurationsApiService) ListAlertConfigurationsExecute(r ListAlertConfigurationsApiRequest) (*PaginatedAlertConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedAlertConfig
 	)
@@ -913,7 +913,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertId(ctx con
 func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertIdExecute(r ListAlertConfigurationsByAlertIdApiRequest) (*PaginatedAlertConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedAlertConfig
 	)
@@ -1059,7 +1059,7 @@ func (a *AlertConfigurationsApiService) ToggleAlertConfiguration(ctx context.Con
 func (a *AlertConfigurationsApiService) ToggleAlertConfigurationExecute(r ToggleAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupAlertsConfig
 	)
@@ -1189,7 +1189,7 @@ func (a *AlertConfigurationsApiService) UpdateAlertConfiguration(ctx context.Con
 func (a *AlertConfigurationsApiService) UpdateAlertConfigurationExecute(r UpdateAlertConfigurationApiRequest) (*GroupAlertsConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupAlertsConfig
 	)

--- a/admin/api_alerts.go
+++ b/admin/api_alerts.go
@@ -176,7 +176,7 @@ func (a *AlertsApiService) AcknowledgeAlert(ctx context.Context, groupId string,
 func (a *AlertsApiService) AcknowledgeAlertExecute(r AcknowledgeAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *AlertViewForNdsGroup
 	)
@@ -300,7 +300,7 @@ func (a *AlertsApiService) GetAlert(ctx context.Context, groupId string, alertId
 func (a *AlertsApiService) GetAlertExecute(r GetAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *AlertViewForNdsGroup
 	)
@@ -450,7 +450,7 @@ func (a *AlertsApiService) ListAlerts(ctx context.Context, groupId string) ListA
 func (a *AlertsApiService) ListAlertsExecute(r ListAlertsApiRequest) (*PaginatedAlert, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedAlert
 	)
@@ -619,7 +619,7 @@ func (a *AlertsApiService) ListAlertsByAlertConfigurationId(ctx context.Context,
 func (a *AlertsApiService) ListAlertsByAlertConfigurationIdExecute(r ListAlertsByAlertConfigurationIdApiRequest) (*PaginatedAlert, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedAlert
 	)

--- a/admin/api_atlas_search.go
+++ b/admin/api_atlas_search.go
@@ -548,7 +548,7 @@ func (a *AtlasSearchApiService) CreateAtlasSearchDeployment(ctx context.Context,
 func (a *AtlasSearchApiService) CreateAtlasSearchDeploymentExecute(r CreateAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiSearchDeploymentResponse
 	)
@@ -674,7 +674,7 @@ func (a *AtlasSearchApiService) CreateAtlasSearchIndex(ctx context.Context, grou
 func (a *AtlasSearchApiService) CreateAtlasSearchIndexExecute(r CreateAtlasSearchIndexApiRequest) (*SearchIndexResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *SearchIndexResponse
 	)
@@ -804,7 +804,7 @@ func (a *AtlasSearchApiService) CreateAtlasSearchIndexDeprecated(ctx context.Con
 func (a *AtlasSearchApiService) CreateAtlasSearchIndexDeprecatedExecute(r CreateAtlasSearchIndexDeprecatedApiRequest) (*ClusterSearchIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ClusterSearchIndex
 	)
@@ -926,7 +926,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchDeployment(ctx context.Context,
 func (a *AtlasSearchApiService) DeleteAtlasSearchDeploymentExecute(r DeleteAtlasSearchDeploymentApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1048,7 +1048,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndex(ctx context.Context, grou
 func (a *AtlasSearchApiService) DeleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1181,7 +1181,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndexByName(ctx context.Context
 func (a *AtlasSearchApiService) DeleteAtlasSearchIndexByNameExecute(r DeleteAtlasSearchIndexByNameApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1310,7 +1310,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndexDeprecated(ctx context.Con
 func (a *AtlasSearchApiService) DeleteAtlasSearchIndexDeprecatedExecute(r DeleteAtlasSearchIndexDeprecatedApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1428,7 +1428,7 @@ func (a *AtlasSearchApiService) GetAtlasSearchDeployment(ctx context.Context, gr
 func (a *AtlasSearchApiService) GetAtlasSearchDeploymentExecute(r GetAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiSearchDeploymentResponse
 	)
@@ -1550,7 +1550,7 @@ func (a *AtlasSearchApiService) GetAtlasSearchIndex(ctx context.Context, groupId
 func (a *AtlasSearchApiService) GetAtlasSearchIndexExecute(r GetAtlasSearchIndexApiRequest) (*SearchIndexResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *SearchIndexResponse
 	)
@@ -1683,7 +1683,7 @@ func (a *AtlasSearchApiService) GetAtlasSearchIndexByName(ctx context.Context, g
 func (a *AtlasSearchApiService) GetAtlasSearchIndexByNameExecute(r GetAtlasSearchIndexByNameApiRequest) (*SearchIndexResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *SearchIndexResponse
 	)
@@ -1812,7 +1812,7 @@ func (a *AtlasSearchApiService) GetAtlasSearchIndexDeprecated(ctx context.Contex
 func (a *AtlasSearchApiService) GetAtlasSearchIndexDeprecatedExecute(r GetAtlasSearchIndexDeprecatedApiRequest) (*ClusterSearchIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ClusterSearchIndex
 	)
@@ -1940,7 +1940,7 @@ func (a *AtlasSearchApiService) ListAtlasSearchIndexes(ctx context.Context, grou
 func (a *AtlasSearchApiService) ListAtlasSearchIndexesExecute(r ListAtlasSearchIndexesApiRequest) ([]SearchIndexResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []SearchIndexResponse
 	)
@@ -2059,7 +2059,7 @@ func (a *AtlasSearchApiService) ListAtlasSearchIndexesCluster(ctx context.Contex
 func (a *AtlasSearchApiService) ListAtlasSearchIndexesClusterExecute(r ListAtlasSearchIndexesClusterApiRequest) ([]SearchIndexResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []SearchIndexResponse
 	)
@@ -2190,7 +2190,7 @@ func (a *AtlasSearchApiService) ListAtlasSearchIndexesDeprecated(ctx context.Con
 func (a *AtlasSearchApiService) ListAtlasSearchIndexesDeprecatedExecute(r ListAtlasSearchIndexesDeprecatedApiRequest) ([]ClusterSearchIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []ClusterSearchIndex
 	)
@@ -2313,7 +2313,7 @@ func (a *AtlasSearchApiService) UpdateAtlasSearchDeployment(ctx context.Context,
 func (a *AtlasSearchApiService) UpdateAtlasSearchDeploymentExecute(r UpdateAtlasSearchDeploymentApiRequest) (*ApiSearchDeploymentResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiSearchDeploymentResponse
 	)
@@ -2444,7 +2444,7 @@ func (a *AtlasSearchApiService) UpdateAtlasSearchIndex(ctx context.Context, grou
 func (a *AtlasSearchApiService) UpdateAtlasSearchIndexExecute(r UpdateAtlasSearchIndexApiRequest) (*SearchIndexResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *SearchIndexResponse
 	)
@@ -2586,7 +2586,7 @@ func (a *AtlasSearchApiService) UpdateAtlasSearchIndexByName(ctx context.Context
 func (a *AtlasSearchApiService) UpdateAtlasSearchIndexByNameExecute(r UpdateAtlasSearchIndexByNameApiRequest) (*SearchIndexResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *SearchIndexResponse
 	)
@@ -2724,7 +2724,7 @@ func (a *AtlasSearchApiService) UpdateAtlasSearchIndexDeprecated(ctx context.Con
 func (a *AtlasSearchApiService) UpdateAtlasSearchIndexDeprecatedExecute(r UpdateAtlasSearchIndexDeprecatedApiRequest) (*ClusterSearchIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ClusterSearchIndex
 	)

--- a/admin/api_atlas_search.go
+++ b/admin/api_atlas_search.go
@@ -113,7 +113,7 @@ type AtlasSearchApi interface {
 	DeleteAtlasSearchDeploymentWithParams(ctx context.Context, args *DeleteAtlasSearchDeploymentApiParams) DeleteAtlasSearchDeploymentApiRequest
 
 	// Method available only for mocking purposes
-	DeleteAtlasSearchDeploymentExecute(r DeleteAtlasSearchDeploymentApiRequest) (interface{}, *http.Response, error)
+	DeleteAtlasSearchDeploymentExecute(r DeleteAtlasSearchDeploymentApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteAtlasSearchIndex Remove One Atlas Search Index by Id
@@ -138,7 +138,7 @@ type AtlasSearchApi interface {
 	DeleteAtlasSearchIndexWithParams(ctx context.Context, args *DeleteAtlasSearchIndexApiParams) DeleteAtlasSearchIndexApiRequest
 
 	// Method available only for mocking purposes
-	DeleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (interface{}, *http.Response, error)
+	DeleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteAtlasSearchIndexByName Remove One Atlas Search Index by Name
@@ -165,7 +165,7 @@ type AtlasSearchApi interface {
 	DeleteAtlasSearchIndexByNameWithParams(ctx context.Context, args *DeleteAtlasSearchIndexByNameApiParams) DeleteAtlasSearchIndexByNameApiRequest
 
 	// Method available only for mocking purposes
-	DeleteAtlasSearchIndexByNameExecute(r DeleteAtlasSearchIndexByNameApiRequest) (interface{}, *http.Response, error)
+	DeleteAtlasSearchIndexByNameExecute(r DeleteAtlasSearchIndexByNameApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteAtlasSearchIndexDeprecated Remove One Atlas Search Index
@@ -194,7 +194,7 @@ type AtlasSearchApi interface {
 	DeleteAtlasSearchIndexDeprecatedWithParams(ctx context.Context, args *DeleteAtlasSearchIndexDeprecatedApiParams) DeleteAtlasSearchIndexDeprecatedApiRequest
 
 	// Method available only for mocking purposes
-	DeleteAtlasSearchIndexDeprecatedExecute(r DeleteAtlasSearchIndexDeprecatedApiRequest) (interface{}, *http.Response, error)
+	DeleteAtlasSearchIndexDeprecatedExecute(r DeleteAtlasSearchIndexDeprecatedApiRequest) (any, *http.Response, error)
 
 	/*
 		GetAtlasSearchDeployment Return Search Nodes
@@ -897,7 +897,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchDeploymentWithParams(ctx contex
 	}
 }
 
-func (r DeleteAtlasSearchDeploymentApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteAtlasSearchDeploymentApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteAtlasSearchDeploymentExecute(r)
 }
 
@@ -922,13 +922,13 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchDeployment(ctx context.Context,
 
 // DeleteAtlasSearchDeploymentExecute executes the request
 //
-//	@return interface{}
-func (a *AtlasSearchApiService) DeleteAtlasSearchDeploymentExecute(r DeleteAtlasSearchDeploymentApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *AtlasSearchApiService) DeleteAtlasSearchDeploymentExecute(r DeleteAtlasSearchDeploymentApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AtlasSearchApiService.DeleteAtlasSearchDeployment")
@@ -1017,7 +1017,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndexWithParams(ctx context.Con
 	}
 }
 
-func (r DeleteAtlasSearchIndexApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteAtlasSearchIndexApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteAtlasSearchIndexExecute(r)
 }
 
@@ -1044,13 +1044,13 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndex(ctx context.Context, grou
 
 // DeleteAtlasSearchIndexExecute executes the request
 //
-//	@return interface{}
-func (a *AtlasSearchApiService) DeleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *AtlasSearchApiService) DeleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AtlasSearchApiService.DeleteAtlasSearchIndex")
@@ -1146,7 +1146,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndexByNameWithParams(ctx conte
 	}
 }
 
-func (r DeleteAtlasSearchIndexByNameApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteAtlasSearchIndexByNameApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteAtlasSearchIndexByNameExecute(r)
 }
 
@@ -1177,13 +1177,13 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndexByName(ctx context.Context
 
 // DeleteAtlasSearchIndexByNameExecute executes the request
 //
-//	@return interface{}
-func (a *AtlasSearchApiService) DeleteAtlasSearchIndexByNameExecute(r DeleteAtlasSearchIndexByNameApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *AtlasSearchApiService) DeleteAtlasSearchIndexByNameExecute(r DeleteAtlasSearchIndexByNameApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AtlasSearchApiService.DeleteAtlasSearchIndexByName")
@@ -1275,7 +1275,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndexDeprecatedWithParams(ctx c
 	}
 }
 
-func (r DeleteAtlasSearchIndexDeprecatedApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteAtlasSearchIndexDeprecatedApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteAtlasSearchIndexDeprecatedExecute(r)
 }
 
@@ -1304,15 +1304,15 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndexDeprecated(ctx context.Con
 
 // DeleteAtlasSearchIndexDeprecatedExecute executes the request
 //
-//	@return interface{}
+//	@return any
 //
 // Deprecated
-func (a *AtlasSearchApiService) DeleteAtlasSearchIndexDeprecatedExecute(r DeleteAtlasSearchIndexDeprecatedApiRequest) (interface{}, *http.Response, error) {
+func (a *AtlasSearchApiService) DeleteAtlasSearchIndexDeprecatedExecute(r DeleteAtlasSearchIndexDeprecatedApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AtlasSearchApiService.DeleteAtlasSearchIndexDeprecated")

--- a/admin/api_auditing.go
+++ b/admin/api_auditing.go
@@ -108,7 +108,7 @@ func (a *AuditingApiService) GetAuditingConfiguration(ctx context.Context, group
 func (a *AuditingApiService) GetAuditingConfigurationExecute(r GetAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *AuditLog
 	)
@@ -223,7 +223,7 @@ func (a *AuditingApiService) UpdateAuditingConfiguration(ctx context.Context, gr
 func (a *AuditingApiService) UpdateAuditingConfigurationExecute(r UpdateAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *AuditLog
 	)

--- a/admin/api_aws_clusters_dns.go
+++ b/admin/api_aws_clusters_dns.go
@@ -108,7 +108,7 @@ func (a *AWSClustersDNSApiService) GetAWSCustomDNS(ctx context.Context, groupId 
 func (a *AWSClustersDNSApiService) GetAWSCustomDNSExecute(r GetAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *AWSCustomDNSEnabled
 	)
@@ -223,7 +223,7 @@ func (a *AWSClustersDNSApiService) ToggleAWSCustomDNS(ctx context.Context, group
 func (a *AWSClustersDNSApiService) ToggleAWSCustomDNSExecute(r ToggleAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *AWSCustomDNSEnabled
 	)

--- a/admin/api_cloud_backups.go
+++ b/admin/api_cloud_backups.go
@@ -785,7 +785,7 @@ func (a *CloudBackupsApiService) CancelBackupRestoreJob(ctx context.Context, gro
 func (a *CloudBackupsApiService) CancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -907,7 +907,7 @@ func (a *CloudBackupsApiService) CreateBackupExportJob(ctx context.Context, grou
 func (a *CloudBackupsApiService) CreateBackupExportJobExecute(r CreateBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupExportJob
 	)
@@ -1035,7 +1035,7 @@ func (a *CloudBackupsApiService) CreateBackupRestoreJob(ctx context.Context, gro
 func (a *CloudBackupsApiService) CreateBackupRestoreJobExecute(r CreateBackupRestoreJobApiRequest) (*DiskBackupSnapshotRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupSnapshotRestoreJob
 	)
@@ -1156,7 +1156,7 @@ func (a *CloudBackupsApiService) CreateExportBucket(ctx context.Context, groupId
 func (a *CloudBackupsApiService) CreateExportBucketExecute(r CreateExportBucketApiRequest) (*DiskBackupSnapshotExportBucket, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupSnapshotExportBucket
 	)
@@ -1281,7 +1281,7 @@ func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJob(ctx context.Co
 func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJobExecute(r CreateServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ServerlessBackupRestoreJob
 	)
@@ -1403,7 +1403,7 @@ func (a *CloudBackupsApiService) DeleteAllBackupSchedules(ctx context.Context, g
 func (a *CloudBackupsApiService) DeleteAllBackupSchedulesExecute(r DeleteAllBackupSchedulesApiRequest) (*DiskBackupSnapshotSchedule20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupSnapshotSchedule20240805
 	)
@@ -1520,7 +1520,7 @@ func (a *CloudBackupsApiService) DeleteExportBucket(ctx context.Context, groupId
 func (a *CloudBackupsApiService) DeleteExportBucketExecute(r DeleteExportBucketApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1642,7 +1642,7 @@ func (a *CloudBackupsApiService) DeleteReplicaSetBackup(ctx context.Context, gro
 func (a *CloudBackupsApiService) DeleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1765,7 +1765,7 @@ func (a *CloudBackupsApiService) DeleteShardedClusterBackup(ctx context.Context,
 func (a *CloudBackupsApiService) DeleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1888,7 +1888,7 @@ func (a *CloudBackupsApiService) GetBackupExportJob(ctx context.Context, groupId
 func (a *CloudBackupsApiService) GetBackupExportJobExecute(r GetBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupExportJob
 	)
@@ -2011,7 +2011,7 @@ func (a *CloudBackupsApiService) GetBackupRestoreJob(ctx context.Context, groupI
 func (a *CloudBackupsApiService) GetBackupRestoreJobExecute(r GetBackupRestoreJobApiRequest) (*DiskBackupSnapshotRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupSnapshotRestoreJob
 	)
@@ -2129,7 +2129,7 @@ func (a *CloudBackupsApiService) GetBackupSchedule(ctx context.Context, groupId 
 func (a *CloudBackupsApiService) GetBackupScheduleExecute(r GetBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupSnapshotSchedule20240805
 	)
@@ -2241,7 +2241,7 @@ func (a *CloudBackupsApiService) GetDataProtectionSettings(ctx context.Context, 
 func (a *CloudBackupsApiService) GetDataProtectionSettingsExecute(r GetDataProtectionSettingsApiRequest) (*DataProtectionSettings20231001, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataProtectionSettings20231001
 	)
@@ -2357,7 +2357,7 @@ func (a *CloudBackupsApiService) GetExportBucket(ctx context.Context, groupId st
 func (a *CloudBackupsApiService) GetExportBucketExecute(r GetExportBucketApiRequest) (*DiskBackupSnapshotExportBucket, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupSnapshotExportBucket
 	)
@@ -2479,7 +2479,7 @@ func (a *CloudBackupsApiService) GetReplicaSetBackup(ctx context.Context, groupI
 func (a *CloudBackupsApiService) GetReplicaSetBackupExecute(r GetReplicaSetBackupApiRequest) (*DiskBackupReplicaSet, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupReplicaSet
 	)
@@ -2602,7 +2602,7 @@ func (a *CloudBackupsApiService) GetServerlessBackup(ctx context.Context, groupI
 func (a *CloudBackupsApiService) GetServerlessBackupExecute(r GetServerlessBackupApiRequest) (*ServerlessBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ServerlessBackupSnapshot
 	)
@@ -2725,7 +2725,7 @@ func (a *CloudBackupsApiService) GetServerlessBackupRestoreJob(ctx context.Conte
 func (a *CloudBackupsApiService) GetServerlessBackupRestoreJobExecute(r GetServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ServerlessBackupRestoreJob
 	)
@@ -2848,7 +2848,7 @@ func (a *CloudBackupsApiService) GetShardedClusterBackup(ctx context.Context, gr
 func (a *CloudBackupsApiService) GetShardedClusterBackupExecute(r GetShardedClusterBackupApiRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupShardedClusterSnapshot
 	)
@@ -2993,7 +2993,7 @@ func (a *CloudBackupsApiService) ListBackupExportJobs(ctx context.Context, group
 func (a *CloudBackupsApiService) ListBackupExportJobsExecute(r ListBackupExportJobsApiRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiAtlasDiskBackupExportJob
 	)
@@ -3158,7 +3158,7 @@ func (a *CloudBackupsApiService) ListBackupRestoreJobs(ctx context.Context, grou
 func (a *CloudBackupsApiService) ListBackupRestoreJobsExecute(r ListBackupRestoreJobsApiRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedCloudBackupRestoreJob
 	)
@@ -3318,7 +3318,7 @@ func (a *CloudBackupsApiService) ListExportBuckets(ctx context.Context, groupId 
 func (a *CloudBackupsApiService) ListExportBucketsExecute(r ListExportBucketsApiRequest) (*PaginatedBackupSnapshotExportBuckets, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedBackupSnapshotExportBuckets
 	)
@@ -3482,7 +3482,7 @@ func (a *CloudBackupsApiService) ListReplicaSetBackups(ctx context.Context, grou
 func (a *CloudBackupsApiService) ListReplicaSetBackupsExecute(r ListReplicaSetBackupsApiRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedCloudBackupReplicaSet
 	)
@@ -3647,7 +3647,7 @@ func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobs(ctx context.Con
 func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobsExecute(r ListServerlessBackupRestoreJobsApiRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiAtlasServerlessBackupRestoreJob
 	)
@@ -3812,7 +3812,7 @@ func (a *CloudBackupsApiService) ListServerlessBackups(ctx context.Context, grou
 func (a *CloudBackupsApiService) ListServerlessBackupsExecute(r ListServerlessBackupsApiRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiAtlasServerlessBackupSnapshot
 	)
@@ -3950,7 +3950,7 @@ func (a *CloudBackupsApiService) ListShardedClusterBackups(ctx context.Context, 
 func (a *CloudBackupsApiService) ListShardedClusterBackupsExecute(r ListShardedClusterBackupsApiRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedCloudBackupShardedClusterSnapshot
 	)
@@ -4073,7 +4073,7 @@ func (a *CloudBackupsApiService) TakeSnapshot(ctx context.Context, groupId strin
 func (a *CloudBackupsApiService) TakeSnapshotExecute(r TakeSnapshotApiRequest) (*DiskBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupSnapshot
 	)
@@ -4199,7 +4199,7 @@ func (a *CloudBackupsApiService) UpdateBackupSchedule(ctx context.Context, group
 func (a *CloudBackupsApiService) UpdateBackupScheduleExecute(r UpdateBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupSnapshotSchedule20240805
 	)
@@ -4329,7 +4329,7 @@ func (a *CloudBackupsApiService) UpdateDataProtectionSettings(ctx context.Contex
 func (a *CloudBackupsApiService) UpdateDataProtectionSettingsExecute(r UpdateDataProtectionSettingsApiRequest) (*DataProtectionSettings20231001, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataProtectionSettings20231001
 	)
@@ -4466,7 +4466,7 @@ func (a *CloudBackupsApiService) UpdateSnapshotRetention(ctx context.Context, gr
 func (a *CloudBackupsApiService) UpdateSnapshotRetentionExecute(r UpdateSnapshotRetentionApiRequest) (*DiskBackupReplicaSet, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DiskBackupReplicaSet
 	)

--- a/admin/api_cloud_backups.go
+++ b/admin/api_cloud_backups.go
@@ -35,7 +35,7 @@ type CloudBackupsApi interface {
 	CancelBackupRestoreJobWithParams(ctx context.Context, args *CancelBackupRestoreJobApiParams) CancelBackupRestoreJobApiRequest
 
 	// Method available only for mocking purposes
-	CancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (interface{}, *http.Response, error)
+	CancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (any, *http.Response, error)
 
 	/*
 		CreateBackupExportJob Create One Cloud Backup Snapshot Export Job
@@ -184,7 +184,7 @@ type CloudBackupsApi interface {
 	DeleteExportBucketWithParams(ctx context.Context, args *DeleteExportBucketApiParams) DeleteExportBucketApiRequest
 
 	// Method available only for mocking purposes
-	DeleteExportBucketExecute(r DeleteExportBucketApiRequest) (interface{}, *http.Response, error)
+	DeleteExportBucketExecute(r DeleteExportBucketApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteReplicaSetBackup Remove One Replica Set Cloud Backup
@@ -209,7 +209,7 @@ type CloudBackupsApi interface {
 	DeleteReplicaSetBackupWithParams(ctx context.Context, args *DeleteReplicaSetBackupApiParams) DeleteReplicaSetBackupApiRequest
 
 	// Method available only for mocking purposes
-	DeleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (interface{}, *http.Response, error)
+	DeleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteShardedClusterBackup Remove One Sharded Cluster Cloud Backup
@@ -234,7 +234,7 @@ type CloudBackupsApi interface {
 	DeleteShardedClusterBackupWithParams(ctx context.Context, args *DeleteShardedClusterBackupApiParams) DeleteShardedClusterBackupApiRequest
 
 	// Method available only for mocking purposes
-	DeleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (interface{}, *http.Response, error)
+	DeleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (any, *http.Response, error)
 
 	/*
 		GetBackupExportJob Return One Cloud Backup Snapshot Export Job
@@ -754,7 +754,7 @@ func (a *CloudBackupsApiService) CancelBackupRestoreJobWithParams(ctx context.Co
 	}
 }
 
-func (r CancelBackupRestoreJobApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r CancelBackupRestoreJobApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.CancelBackupRestoreJobExecute(r)
 }
 
@@ -781,13 +781,13 @@ func (a *CloudBackupsApiService) CancelBackupRestoreJob(ctx context.Context, gro
 
 // CancelBackupRestoreJobExecute executes the request
 //
-//	@return interface{}
-func (a *CloudBackupsApiService) CancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *CloudBackupsApiService) CancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "CloudBackupsApiService.CancelBackupRestoreJob")
@@ -1491,7 +1491,7 @@ func (a *CloudBackupsApiService) DeleteExportBucketWithParams(ctx context.Contex
 	}
 }
 
-func (r DeleteExportBucketApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteExportBucketApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteExportBucketExecute(r)
 }
 
@@ -1516,13 +1516,13 @@ func (a *CloudBackupsApiService) DeleteExportBucket(ctx context.Context, groupId
 
 // DeleteExportBucketExecute executes the request
 //
-//	@return interface{}
-func (a *CloudBackupsApiService) DeleteExportBucketExecute(r DeleteExportBucketApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *CloudBackupsApiService) DeleteExportBucketExecute(r DeleteExportBucketApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "CloudBackupsApiService.DeleteExportBucket")
@@ -1611,7 +1611,7 @@ func (a *CloudBackupsApiService) DeleteReplicaSetBackupWithParams(ctx context.Co
 	}
 }
 
-func (r DeleteReplicaSetBackupApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteReplicaSetBackupApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteReplicaSetBackupExecute(r)
 }
 
@@ -1638,13 +1638,13 @@ func (a *CloudBackupsApiService) DeleteReplicaSetBackup(ctx context.Context, gro
 
 // DeleteReplicaSetBackupExecute executes the request
 //
-//	@return interface{}
-func (a *CloudBackupsApiService) DeleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *CloudBackupsApiService) DeleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "CloudBackupsApiService.DeleteReplicaSetBackup")
@@ -1734,7 +1734,7 @@ func (a *CloudBackupsApiService) DeleteShardedClusterBackupWithParams(ctx contex
 	}
 }
 
-func (r DeleteShardedClusterBackupApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteShardedClusterBackupApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteShardedClusterBackupExecute(r)
 }
 
@@ -1761,13 +1761,13 @@ func (a *CloudBackupsApiService) DeleteShardedClusterBackup(ctx context.Context,
 
 // DeleteShardedClusterBackupExecute executes the request
 //
-//	@return interface{}
-func (a *CloudBackupsApiService) DeleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *CloudBackupsApiService) DeleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "CloudBackupsApiService.DeleteShardedClusterBackup")

--- a/admin/api_cloud_migration_service.go
+++ b/admin/api_cloud_migration_service.go
@@ -111,7 +111,7 @@ type CloudMigrationServiceApi interface {
 	DeleteLinkTokenWithParams(ctx context.Context, args *DeleteLinkTokenApiParams) DeleteLinkTokenApiRequest
 
 	// Method available only for mocking purposes
-	DeleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (interface{}, *http.Response, error)
+	DeleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (any, *http.Response, error)
 
 	/*
 		GetPushMigration Return One Migration Job
@@ -576,7 +576,7 @@ func (a *CloudMigrationServiceApiService) DeleteLinkTokenWithParams(ctx context.
 	}
 }
 
-func (r DeleteLinkTokenApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteLinkTokenApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteLinkTokenExecute(r)
 }
 
@@ -599,13 +599,13 @@ func (a *CloudMigrationServiceApiService) DeleteLinkToken(ctx context.Context, o
 
 // DeleteLinkTokenExecute executes the request
 //
-//	@return interface{}
-func (a *CloudMigrationServiceApiService) DeleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *CloudMigrationServiceApiService) DeleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "CloudMigrationServiceApiService.DeleteLinkToken")

--- a/admin/api_cloud_migration_service.go
+++ b/admin/api_cloud_migration_service.go
@@ -261,7 +261,7 @@ func (a *CloudMigrationServiceApiService) CreateLinkToken(ctx context.Context, o
 func (a *CloudMigrationServiceApiService) CreateLinkTokenExecute(r CreateLinkTokenApiRequest) (*TargetOrg, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *TargetOrg
 	)
@@ -387,7 +387,7 @@ func (a *CloudMigrationServiceApiService) CreatePushMigration(ctx context.Contex
 func (a *CloudMigrationServiceApiService) CreatePushMigrationExecute(r CreatePushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *LiveMigrationResponse
 	)
@@ -506,7 +506,7 @@ func (a *CloudMigrationServiceApiService) CutoverMigration(ctx context.Context, 
 func (a *CloudMigrationServiceApiService) CutoverMigrationExecute(r CutoverMigrationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPut
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -603,7 +603,7 @@ func (a *CloudMigrationServiceApiService) DeleteLinkToken(ctx context.Context, o
 func (a *CloudMigrationServiceApiService) DeleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -719,7 +719,7 @@ func (a *CloudMigrationServiceApiService) GetPushMigration(ctx context.Context, 
 func (a *CloudMigrationServiceApiService) GetPushMigrationExecute(r GetPushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *LiveMigrationResponse
 	)
@@ -836,7 +836,7 @@ func (a *CloudMigrationServiceApiService) GetValidationStatus(ctx context.Contex
 func (a *CloudMigrationServiceApiService) GetValidationStatusExecute(r GetValidationStatusApiRequest) (*LiveImportValidation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *LiveImportValidation
 	)
@@ -948,7 +948,7 @@ func (a *CloudMigrationServiceApiService) ListSourceProjects(ctx context.Context
 func (a *CloudMigrationServiceApiService) ListSourceProjectsExecute(r ListSourceProjectsApiRequest) ([]LiveImportAvailableProject, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []LiveImportAvailableProject
 	)
@@ -1063,7 +1063,7 @@ func (a *CloudMigrationServiceApiService) ValidateMigration(ctx context.Context,
 func (a *CloudMigrationServiceApiService) ValidateMigrationExecute(r ValidateMigrationApiRequest) (*LiveImportValidation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *LiveImportValidation
 	)

--- a/admin/api_cloud_provider_access.go
+++ b/admin/api_cloud_provider_access.go
@@ -191,7 +191,7 @@ func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRole(ctx con
 func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRoleExecute(r AuthorizeCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudProviderAccessRole
 	)
@@ -312,7 +312,7 @@ func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRole(ctx contex
 func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRoleExecute(r CreateCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudProviderAccessRole
 	)
@@ -436,7 +436,7 @@ func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRole(ctx c
 func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRoleExecute(r DeauthorizeCloudProviderAccessRoleApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -539,7 +539,7 @@ func (a *CloudProviderAccessApiService) GetCloudProviderAccessRole(ctx context.C
 func (a *CloudProviderAccessApiService) GetCloudProviderAccessRoleExecute(r GetCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudProviderAccessRole
 	)
@@ -651,7 +651,7 @@ func (a *CloudProviderAccessApiService) ListCloudProviderAccessRoles(ctx context
 func (a *CloudProviderAccessApiService) ListCloudProviderAccessRolesExecute(r ListCloudProviderAccessRolesApiRequest) (*CloudProviderAccessRoles, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudProviderAccessRoles
 	)

--- a/admin/api_cluster_outage_simulation.go
+++ b/admin/api_cluster_outage_simulation.go
@@ -139,7 +139,7 @@ func (a *ClusterOutageSimulationApiService) EndOutageSimulation(ctx context.Cont
 func (a *ClusterOutageSimulationApiService) EndOutageSimulationExecute(r EndOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ClusterOutageSimulation
 	)
@@ -256,7 +256,7 @@ func (a *ClusterOutageSimulationApiService) GetOutageSimulation(ctx context.Cont
 func (a *ClusterOutageSimulationApiService) GetOutageSimulationExecute(r GetOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ClusterOutageSimulation
 	)
@@ -377,7 +377,7 @@ func (a *ClusterOutageSimulationApiService) StartOutageSimulation(ctx context.Co
 func (a *ClusterOutageSimulationApiService) StartOutageSimulationExecute(r StartOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ClusterOutageSimulation
 	)

--- a/admin/api_clusters.go
+++ b/admin/api_clusters.go
@@ -180,7 +180,7 @@ type ClustersApi interface {
 	GrantMongoDBEmployeeAccessWithParams(ctx context.Context, args *GrantMongoDBEmployeeAccessApiParams) GrantMongoDBEmployeeAccessApiRequest
 
 	// Method available only for mocking purposes
-	GrantMongoDBEmployeeAccessExecute(r GrantMongoDBEmployeeAccessApiRequest) (interface{}, *http.Response, error)
+	GrantMongoDBEmployeeAccessExecute(r GrantMongoDBEmployeeAccessApiRequest) (any, *http.Response, error)
 
 	/*
 		ListCloudProviderRegions Return All Cloud Provider Regions
@@ -297,7 +297,7 @@ type ClustersApi interface {
 	PinFeatureCompatibilityVersionWithParams(ctx context.Context, args *PinFeatureCompatibilityVersionApiParams) PinFeatureCompatibilityVersionApiRequest
 
 	// Method available only for mocking purposes
-	PinFeatureCompatibilityVersionExecute(r PinFeatureCompatibilityVersionApiRequest) (interface{}, *http.Response, error)
+	PinFeatureCompatibilityVersionExecute(r PinFeatureCompatibilityVersionApiRequest) (any, *http.Response, error)
 
 	/*
 		RevokeMongoDBEmployeeAccess Revoke granted MongoDB employee cluster access for one cluster.
@@ -321,7 +321,7 @@ type ClustersApi interface {
 	RevokeMongoDBEmployeeAccessWithParams(ctx context.Context, args *RevokeMongoDBEmployeeAccessApiParams) RevokeMongoDBEmployeeAccessApiRequest
 
 	// Method available only for mocking purposes
-	RevokeMongoDBEmployeeAccessExecute(r RevokeMongoDBEmployeeAccessApiRequest) (interface{}, *http.Response, error)
+	RevokeMongoDBEmployeeAccessExecute(r RevokeMongoDBEmployeeAccessApiRequest) (any, *http.Response, error)
 
 	/*
 		TestFailover Test Failover for One Cluster
@@ -369,7 +369,7 @@ type ClustersApi interface {
 	UnpinFeatureCompatibilityVersionWithParams(ctx context.Context, args *UnpinFeatureCompatibilityVersionApiParams) UnpinFeatureCompatibilityVersionApiRequest
 
 	// Method available only for mocking purposes
-	UnpinFeatureCompatibilityVersionExecute(r UnpinFeatureCompatibilityVersionApiRequest) (interface{}, *http.Response, error)
+	UnpinFeatureCompatibilityVersionExecute(r UnpinFeatureCompatibilityVersionApiRequest) (any, *http.Response, error)
 
 	/*
 		UpdateCluster Modify One Cluster from One Project
@@ -1197,7 +1197,7 @@ func (a *ClustersApiService) GrantMongoDBEmployeeAccessWithParams(ctx context.Co
 	}
 }
 
-func (r GrantMongoDBEmployeeAccessApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r GrantMongoDBEmployeeAccessApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.GrantMongoDBEmployeeAccessExecute(r)
 }
 
@@ -1223,13 +1223,13 @@ func (a *ClustersApiService) GrantMongoDBEmployeeAccess(ctx context.Context, gro
 
 // GrantMongoDBEmployeeAccessExecute executes the request
 //
-//	@return interface{}
-func (a *ClustersApiService) GrantMongoDBEmployeeAccessExecute(r GrantMongoDBEmployeeAccessApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ClustersApiService) GrantMongoDBEmployeeAccessExecute(r GrantMongoDBEmployeeAccessApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ClustersApiService.GrantMongoDBEmployeeAccess")
@@ -1955,7 +1955,7 @@ func (a *ClustersApiService) PinFeatureCompatibilityVersionWithParams(ctx contex
 	}
 }
 
-func (r PinFeatureCompatibilityVersionApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r PinFeatureCompatibilityVersionApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.PinFeatureCompatibilityVersionExecute(r)
 }
 
@@ -1981,13 +1981,13 @@ func (a *ClustersApiService) PinFeatureCompatibilityVersion(ctx context.Context,
 
 // PinFeatureCompatibilityVersionExecute executes the request
 //
-//	@return interface{}
-func (a *ClustersApiService) PinFeatureCompatibilityVersionExecute(r PinFeatureCompatibilityVersionApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ClustersApiService) PinFeatureCompatibilityVersionExecute(r PinFeatureCompatibilityVersionApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ClustersApiService.PinFeatureCompatibilityVersion")
@@ -2075,7 +2075,7 @@ func (a *ClustersApiService) RevokeMongoDBEmployeeAccessWithParams(ctx context.C
 	}
 }
 
-func (r RevokeMongoDBEmployeeAccessApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r RevokeMongoDBEmployeeAccessApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.RevokeMongoDBEmployeeAccessExecute(r)
 }
 
@@ -2100,13 +2100,13 @@ func (a *ClustersApiService) RevokeMongoDBEmployeeAccess(ctx context.Context, gr
 
 // RevokeMongoDBEmployeeAccessExecute executes the request
 //
-//	@return interface{}
-func (a *ClustersApiService) RevokeMongoDBEmployeeAccessExecute(r RevokeMongoDBEmployeeAccessApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ClustersApiService) RevokeMongoDBEmployeeAccessExecute(r RevokeMongoDBEmployeeAccessApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ClustersApiService.RevokeMongoDBEmployeeAccess")
@@ -2292,7 +2292,7 @@ func (a *ClustersApiService) UnpinFeatureCompatibilityVersionWithParams(ctx cont
 	}
 }
 
-func (r UnpinFeatureCompatibilityVersionApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r UnpinFeatureCompatibilityVersionApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.UnpinFeatureCompatibilityVersionExecute(r)
 }
 
@@ -2317,13 +2317,13 @@ func (a *ClustersApiService) UnpinFeatureCompatibilityVersion(ctx context.Contex
 
 // UnpinFeatureCompatibilityVersionExecute executes the request
 //
-//	@return interface{}
-func (a *ClustersApiService) UnpinFeatureCompatibilityVersionExecute(r UnpinFeatureCompatibilityVersionApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ClustersApiService) UnpinFeatureCompatibilityVersionExecute(r UnpinFeatureCompatibilityVersionApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ClustersApiService.UnpinFeatureCompatibilityVersion")

--- a/admin/api_clusters.go
+++ b/admin/api_clusters.go
@@ -522,7 +522,7 @@ func (a *ClustersApiService) CreateCluster(ctx context.Context, groupId string, 
 func (a *ClustersApiService) CreateClusterExecute(r CreateClusterApiRequest) (*ClusterDescription20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ClusterDescription20240805
 	)
@@ -650,7 +650,7 @@ func (a *ClustersApiService) DeleteCluster(ctx context.Context, groupId string, 
 func (a *ClustersApiService) DeleteClusterExecute(r DeleteClusterApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -755,7 +755,7 @@ func (a *ClustersApiService) GetCluster(ctx context.Context, groupId string, clu
 func (a *ClustersApiService) GetClusterExecute(r GetClusterApiRequest) (*ClusterDescription20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ClusterDescription20240805
 	)
@@ -872,7 +872,7 @@ func (a *ClustersApiService) GetClusterAdvancedConfiguration(ctx context.Context
 func (a *ClustersApiService) GetClusterAdvancedConfigurationExecute(r GetClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ClusterDescriptionProcessArgs20240805
 	)
@@ -989,7 +989,7 @@ func (a *ClustersApiService) GetClusterStatus(ctx context.Context, groupId strin
 func (a *ClustersApiService) GetClusterStatusExecute(r GetClusterStatusApiRequest) (*ClusterStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ClusterStatus
 	)
@@ -1106,7 +1106,7 @@ func (a *ClustersApiService) GetSampleDatasetLoadStatus(ctx context.Context, gro
 func (a *ClustersApiService) GetSampleDatasetLoadStatusExecute(r GetSampleDatasetLoadStatusApiRequest) (*SampleDatasetStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *SampleDatasetStatus
 	)
@@ -1227,7 +1227,7 @@ func (a *ClustersApiService) GrantMongoDBEmployeeAccess(ctx context.Context, gro
 func (a *ClustersApiService) GrantMongoDBEmployeeAccessExecute(r GrantMongoDBEmployeeAccessApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1389,7 +1389,7 @@ func (a *ClustersApiService) ListCloudProviderRegions(ctx context.Context, group
 func (a *ClustersApiService) ListCloudProviderRegionsExecute(r ListCloudProviderRegionsApiRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiAtlasProviderRegions
 	)
@@ -1567,7 +1567,7 @@ func (a *ClustersApiService) ListClusters(ctx context.Context, groupId string) L
 func (a *ClustersApiService) ListClustersExecute(r ListClustersApiRequest) (*PaginatedClusterDescription20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedClusterDescription20240805
 	)
@@ -1728,7 +1728,7 @@ func (a *ClustersApiService) ListClustersForAllProjects(ctx context.Context) Lis
 func (a *ClustersApiService) ListClustersForAllProjectsExecute(r ListClustersForAllProjectsApiRequest) (*PaginatedOrgGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedOrgGroup
 	)
@@ -1864,7 +1864,7 @@ func (a *ClustersApiService) LoadSampleDataset(ctx context.Context, groupId stri
 func (a *ClustersApiService) LoadSampleDatasetExecute(r LoadSampleDatasetApiRequest) (*SampleDatasetStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *SampleDatasetStatus
 	)
@@ -1985,7 +1985,7 @@ func (a *ClustersApiService) PinFeatureCompatibilityVersion(ctx context.Context,
 func (a *ClustersApiService) PinFeatureCompatibilityVersionExecute(r PinFeatureCompatibilityVersionApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -2104,7 +2104,7 @@ func (a *ClustersApiService) RevokeMongoDBEmployeeAccess(ctx context.Context, gr
 func (a *ClustersApiService) RevokeMongoDBEmployeeAccessExecute(r RevokeMongoDBEmployeeAccessApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -2219,7 +2219,7 @@ func (a *ClustersApiService) TestFailover(ctx context.Context, groupId string, c
 func (a *ClustersApiService) TestFailoverExecute(r TestFailoverApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -2321,7 +2321,7 @@ func (a *ClustersApiService) UnpinFeatureCompatibilityVersion(ctx context.Contex
 func (a *ClustersApiService) UnpinFeatureCompatibilityVersionExecute(r UnpinFeatureCompatibilityVersionApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -2442,7 +2442,7 @@ func (a *ClustersApiService) UpdateCluster(ctx context.Context, groupId string, 
 func (a *ClustersApiService) UpdateClusterExecute(r UpdateClusterApiRequest) (*ClusterDescription20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ClusterDescription20240805
 	)
@@ -2568,7 +2568,7 @@ func (a *ClustersApiService) UpdateClusterAdvancedConfiguration(ctx context.Cont
 func (a *ClustersApiService) UpdateClusterAdvancedConfigurationExecute(r UpdateClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ClusterDescriptionProcessArgs20240805
 	)
@@ -2689,7 +2689,7 @@ func (a *ClustersApiService) UpgradeSharedCluster(ctx context.Context, groupId s
 func (a *ClustersApiService) UpgradeSharedClusterExecute(r UpgradeSharedClusterApiRequest) (*LegacyAtlasCluster, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *LegacyAtlasCluster
 	)
@@ -2809,7 +2809,7 @@ func (a *ClustersApiService) UpgradeSharedClusterToServerless(ctx context.Contex
 func (a *ClustersApiService) UpgradeSharedClusterToServerlessExecute(r UpgradeSharedClusterToServerlessApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ServerlessInstanceDescription
 	)

--- a/admin/api_collection_level_metrics.go
+++ b/admin/api_collection_level_metrics.go
@@ -343,7 +343,7 @@ func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespaceClusterMe
 func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespaceClusterMeasurementsExecute(r GetCollStatsLatencyNamespaceClusterMeasurementsApiRequest) (*MeasurementsCollStatsLatencyCluster, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *MeasurementsCollStatsLatencyCluster
 	)
@@ -525,7 +525,7 @@ func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespaceHostMeasu
 func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespaceHostMeasurementsExecute(r GetCollStatsLatencyNamespaceHostMeasurementsApiRequest) (*MeasurementsCollStatsLatencyHost, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *MeasurementsCollStatsLatencyHost
 	)
@@ -655,7 +655,7 @@ func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespaceMetrics(c
 func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespaceMetricsExecute(r GetCollStatsLatencyNamespaceMetricsApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -803,7 +803,7 @@ func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespacesForClust
 func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespacesForClusterExecute(r GetCollStatsLatencyNamespacesForClusterApiRequest) (*CollStatsRankedNamespaces, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CollStatsRankedNamespaces
 	)
@@ -957,7 +957,7 @@ func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespacesForHost(
 func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespacesForHostExecute(r GetCollStatsLatencyNamespacesForHostApiRequest) (*CollStatsRankedNamespaces, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CollStatsRankedNamespaces
 	)
@@ -1083,7 +1083,7 @@ func (a *CollectionLevelMetricsApiService) GetPinnedNamespaces(ctx context.Conte
 func (a *CollectionLevelMetricsApiService) GetPinnedNamespacesExecute(r GetPinnedNamespacesApiRequest) (*PinnedNamespaces, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PinnedNamespaces
 	)
@@ -1204,7 +1204,7 @@ func (a *CollectionLevelMetricsApiService) PinNamespacesPatch(ctx context.Contex
 func (a *CollectionLevelMetricsApiService) PinNamespacesPatchExecute(r PinNamespacesPatchApiRequest) (*PinnedNamespaces, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PinnedNamespaces
 	)
@@ -1330,7 +1330,7 @@ func (a *CollectionLevelMetricsApiService) PinNamespacesPut(ctx context.Context,
 func (a *CollectionLevelMetricsApiService) PinNamespacesPutExecute(r PinNamespacesPutApiRequest) (*PinnedNamespaces, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PinnedNamespaces
 	)
@@ -1456,7 +1456,7 @@ func (a *CollectionLevelMetricsApiService) UnpinNamespaces(ctx context.Context, 
 func (a *CollectionLevelMetricsApiService) UnpinNamespacesExecute(r UnpinNamespacesApiRequest) (*PinnedNamespaces, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PinnedNamespaces
 	)

--- a/admin/api_collection_level_metrics.go
+++ b/admin/api_collection_level_metrics.go
@@ -88,7 +88,7 @@ type CollectionLevelMetricsApi interface {
 	GetCollStatsLatencyNamespaceMetricsWithParams(ctx context.Context, args *GetCollStatsLatencyNamespaceMetricsApiParams) GetCollStatsLatencyNamespaceMetricsApiRequest
 
 	// Method available only for mocking purposes
-	GetCollStatsLatencyNamespaceMetricsExecute(r GetCollStatsLatencyNamespaceMetricsApiRequest) (interface{}, *http.Response, error)
+	GetCollStatsLatencyNamespaceMetricsExecute(r GetCollStatsLatencyNamespaceMetricsApiRequest) (any, *http.Response, error)
 
 	/*
 		GetCollStatsLatencyNamespacesForCluster Return Ranked Namespaces from a Cluster
@@ -628,7 +628,7 @@ func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespaceMetricsWi
 	}
 }
 
-func (r GetCollStatsLatencyNamespaceMetricsApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r GetCollStatsLatencyNamespaceMetricsApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.GetCollStatsLatencyNamespaceMetricsExecute(r)
 }
 
@@ -651,13 +651,13 @@ func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespaceMetrics(c
 
 // GetCollStatsLatencyNamespaceMetricsExecute executes the request
 //
-//	@return interface{}
-func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespaceMetricsExecute(r GetCollStatsLatencyNamespaceMetricsApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *CollectionLevelMetricsApiService) GetCollStatsLatencyNamespaceMetricsExecute(r GetCollStatsLatencyNamespaceMetricsApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "CollectionLevelMetricsApiService.GetCollStatsLatencyNamespaceMetrics")

--- a/admin/api_custom_database_roles.go
+++ b/admin/api_custom_database_roles.go
@@ -185,7 +185,7 @@ func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRole(ctx context.Con
 func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRoleExecute(r CreateCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *UserCustomDBRole
 	)
@@ -304,7 +304,7 @@ func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRole(ctx context.Con
 func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRoleExecute(r DeleteCustomDatabaseRoleApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -406,7 +406,7 @@ func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRole(ctx context.Contex
 func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRoleExecute(r GetCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *UserCustomDBRole
 	)
@@ -518,7 +518,7 @@ func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRoles(ctx context.Cont
 func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRolesExecute(r ListCustomDatabaseRolesApiRequest) ([]UserCustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []UserCustomDBRole
 	)
@@ -638,7 +638,7 @@ func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRole(ctx context.Con
 func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRoleExecute(r UpdateCustomDatabaseRoleApiRequest) (*UserCustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *UserCustomDBRole
 	)

--- a/admin/api_data_federation.go
+++ b/admin/api_data_federation.go
@@ -440,7 +440,7 @@ func (a *DataFederationApiService) CreateDataFederationPrivateEndpoint(ctx conte
 func (a *DataFederationApiService) CreateDataFederationPrivateEndpointExecute(r CreateDataFederationPrivateEndpointApiRequest) (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedPrivateNetworkEndpointIdEntry
 	)
@@ -569,7 +569,7 @@ func (a *DataFederationApiService) CreateFederatedDatabase(ctx context.Context, 
 func (a *DataFederationApiService) CreateFederatedDatabaseExecute(r CreateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataLakeTenant
 	)
@@ -706,7 +706,7 @@ func (a *DataFederationApiService) CreateOneDataFederationQueryLimit(ctx context
 func (a *DataFederationApiService) CreateOneDataFederationQueryLimitExecute(r CreateOneDataFederationQueryLimitApiRequest) (*DataFederationTenantQueryLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataFederationTenantQueryLimit
 	)
@@ -829,7 +829,7 @@ func (a *DataFederationApiService) DeleteDataFederationPrivateEndpoint(ctx conte
 func (a *DataFederationApiService) DeleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -946,7 +946,7 @@ func (a *DataFederationApiService) DeleteFederatedDatabase(ctx context.Context, 
 func (a *DataFederationApiService) DeleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1068,7 +1068,7 @@ func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimit(ctx
 func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1204,7 +1204,7 @@ func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogs(ctx contex
 func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (io.ReadCloser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue io.ReadCloser
 	)
@@ -1327,7 +1327,7 @@ func (a *DataFederationApiService) GetDataFederationPrivateEndpoint(ctx context.
 func (a *DataFederationApiService) GetDataFederationPrivateEndpointExecute(r GetDataFederationPrivateEndpointApiRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PrivateNetworkEndpointIdEntry
 	)
@@ -1444,7 +1444,7 @@ func (a *DataFederationApiService) GetFederatedDatabase(ctx context.Context, gro
 func (a *DataFederationApiService) GetFederatedDatabaseExecute(r GetFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataLakeTenant
 	)
@@ -1583,7 +1583,7 @@ func (a *DataFederationApiService) ListDataFederationPrivateEndpoints(ctx contex
 func (a *DataFederationApiService) ListDataFederationPrivateEndpointsExecute(r ListDataFederationPrivateEndpointsApiRequest) (*PaginatedPrivateNetworkEndpointIdEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedPrivateNetworkEndpointIdEntry
 	)
@@ -1724,7 +1724,7 @@ func (a *DataFederationApiService) ListFederatedDatabases(ctx context.Context, g
 func (a *DataFederationApiService) ListFederatedDatabasesExecute(r ListFederatedDatabasesApiRequest) ([]DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []DataLakeTenant
 	)
@@ -1852,7 +1852,7 @@ func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimit(ctx context
 func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitExecute(r ReturnFederatedDatabaseQueryLimitApiRequest) (*DataFederationTenantQueryLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataFederationTenantQueryLimit
 	)
@@ -1970,7 +1970,7 @@ func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimits(ctx contex
 func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitsExecute(r ReturnFederatedDatabaseQueryLimitsApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []DataFederationTenantQueryLimit
 	)
@@ -2100,7 +2100,7 @@ func (a *DataFederationApiService) UpdateFederatedDatabase(ctx context.Context, 
 func (a *DataFederationApiService) UpdateFederatedDatabaseExecute(r UpdateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataLakeTenant
 	)

--- a/admin/api_data_federation.go
+++ b/admin/api_data_federation.go
@@ -126,7 +126,7 @@ type DataFederationApi interface {
 	DeleteDataFederationPrivateEndpointWithParams(ctx context.Context, args *DeleteDataFederationPrivateEndpointApiParams) DeleteDataFederationPrivateEndpointApiRequest
 
 	// Method available only for mocking purposes
-	DeleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (interface{}, *http.Response, error)
+	DeleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteFederatedDatabase Remove One Federated Database Instance from One Project
@@ -150,7 +150,7 @@ type DataFederationApi interface {
 	DeleteFederatedDatabaseWithParams(ctx context.Context, args *DeleteFederatedDatabaseApiParams) DeleteFederatedDatabaseApiRequest
 
 	// Method available only for mocking purposes
-	DeleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (interface{}, *http.Response, error)
+	DeleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteOneDataFederationInstanceQueryLimit Delete One Query Limit For One Federated Database Instance
@@ -175,7 +175,7 @@ type DataFederationApi interface {
 	DeleteOneDataFederationInstanceQueryLimitWithParams(ctx context.Context, args *DeleteOneDataFederationInstanceQueryLimitApiParams) DeleteOneDataFederationInstanceQueryLimitApiRequest
 
 	// Method available only for mocking purposes
-	DeleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (interface{}, *http.Response, error)
+	DeleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (any, *http.Response, error)
 
 	/*
 		DownloadFederatedDatabaseQueryLogs Download Query Logs for One Federated Database Instance
@@ -800,7 +800,7 @@ func (a *DataFederationApiService) DeleteDataFederationPrivateEndpointWithParams
 	}
 }
 
-func (r DeleteDataFederationPrivateEndpointApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteDataFederationPrivateEndpointApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteDataFederationPrivateEndpointExecute(r)
 }
 
@@ -825,13 +825,13 @@ func (a *DataFederationApiService) DeleteDataFederationPrivateEndpoint(ctx conte
 
 // DeleteDataFederationPrivateEndpointExecute executes the request
 //
-//	@return interface{}
-func (a *DataFederationApiService) DeleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *DataFederationApiService) DeleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DataFederationApiService.DeleteDataFederationPrivateEndpoint")
@@ -917,7 +917,7 @@ func (a *DataFederationApiService) DeleteFederatedDatabaseWithParams(ctx context
 	}
 }
 
-func (r DeleteFederatedDatabaseApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteFederatedDatabaseApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteFederatedDatabaseExecute(r)
 }
 
@@ -942,13 +942,13 @@ func (a *DataFederationApiService) DeleteFederatedDatabase(ctx context.Context, 
 
 // DeleteFederatedDatabaseExecute executes the request
 //
-//	@return interface{}
-func (a *DataFederationApiService) DeleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *DataFederationApiService) DeleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DataFederationApiService.DeleteFederatedDatabase")
@@ -1037,7 +1037,7 @@ func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimitWith
 	}
 }
 
-func (r DeleteOneDataFederationInstanceQueryLimitApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteOneDataFederationInstanceQueryLimitApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteOneDataFederationInstanceQueryLimitExecute(r)
 }
 
@@ -1064,13 +1064,13 @@ func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimit(ctx
 
 // DeleteOneDataFederationInstanceQueryLimitExecute executes the request
 //
-//	@return interface{}
-func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DataFederationApiService.DeleteOneDataFederationInstanceQueryLimit")

--- a/admin/api_data_lake_pipelines.go
+++ b/admin/api_data_lake_pipelines.go
@@ -67,7 +67,7 @@ type DataLakePipelinesApi interface {
 	DeletePipelineWithParams(ctx context.Context, args *DeletePipelineApiParams) DeletePipelineApiRequest
 
 	// Method available only for mocking purposes
-	DeletePipelineExecute(r DeletePipelineApiRequest) (interface{}, *http.Response, error)
+	DeletePipelineExecute(r DeletePipelineApiRequest) (any, *http.Response, error)
 
 	/*
 		DeletePipelineRunDataset Delete Pipeline Run Dataset
@@ -96,7 +96,7 @@ type DataLakePipelinesApi interface {
 	DeletePipelineRunDatasetWithParams(ctx context.Context, args *DeletePipelineRunDatasetApiParams) DeletePipelineRunDatasetApiRequest
 
 	// Method available only for mocking purposes
-	DeletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (interface{}, *http.Response, error)
+	DeletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (any, *http.Response, error)
 
 	/*
 		GetPipeline Return One Data Lake Pipeline
@@ -529,7 +529,7 @@ func (a *DataLakePipelinesApiService) DeletePipelineWithParams(ctx context.Conte
 	}
 }
 
-func (r DeletePipelineApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeletePipelineApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeletePipelineExecute(r)
 }
 
@@ -556,15 +556,15 @@ func (a *DataLakePipelinesApiService) DeletePipeline(ctx context.Context, groupI
 
 // DeletePipelineExecute executes the request
 //
-//	@return interface{}
+//	@return any
 //
 // Deprecated
-func (a *DataLakePipelinesApiService) DeletePipelineExecute(r DeletePipelineApiRequest) (interface{}, *http.Response, error) {
+func (a *DataLakePipelinesApiService) DeletePipelineExecute(r DeletePipelineApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DataLakePipelinesApiService.DeletePipeline")
@@ -653,7 +653,7 @@ func (a *DataLakePipelinesApiService) DeletePipelineRunDatasetWithParams(ctx con
 	}
 }
 
-func (r DeletePipelineRunDatasetApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeletePipelineRunDatasetApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeletePipelineRunDatasetExecute(r)
 }
 
@@ -682,15 +682,15 @@ func (a *DataLakePipelinesApiService) DeletePipelineRunDataset(ctx context.Conte
 
 // DeletePipelineRunDatasetExecute executes the request
 //
-//	@return interface{}
+//	@return any
 //
 // Deprecated
-func (a *DataLakePipelinesApiService) DeletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (interface{}, *http.Response, error) {
+func (a *DataLakePipelinesApiService) DeletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DataLakePipelinesApiService.DeletePipelineRunDataset")

--- a/admin/api_data_lake_pipelines.go
+++ b/admin/api_data_lake_pipelines.go
@@ -437,7 +437,7 @@ func (a *DataLakePipelinesApiService) CreatePipeline(ctx context.Context, groupI
 func (a *DataLakePipelinesApiService) CreatePipelineExecute(r CreatePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataLakeIngestionPipeline
 	)
@@ -562,7 +562,7 @@ func (a *DataLakePipelinesApiService) DeletePipeline(ctx context.Context, groupI
 func (a *DataLakePipelinesApiService) DeletePipelineExecute(r DeletePipelineApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -688,7 +688,7 @@ func (a *DataLakePipelinesApiService) DeletePipelineRunDataset(ctx context.Conte
 func (a *DataLakePipelinesApiService) DeletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -810,7 +810,7 @@ func (a *DataLakePipelinesApiService) GetPipeline(ctx context.Context, groupId s
 func (a *DataLakePipelinesApiService) GetPipelineExecute(r GetPipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataLakeIngestionPipeline
 	)
@@ -936,7 +936,7 @@ func (a *DataLakePipelinesApiService) GetPipelineRun(ctx context.Context, groupI
 func (a *DataLakePipelinesApiService) GetPipelineRunExecute(r GetPipelineRunApiRequest) (*IngestionPipelineRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *IngestionPipelineRun
 	)
@@ -1094,7 +1094,7 @@ func (a *DataLakePipelinesApiService) ListPipelineRuns(ctx context.Context, grou
 func (a *DataLakePipelinesApiService) ListPipelineRunsExecute(r ListPipelineRunsApiRequest) (*PaginatedPipelineRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedPipelineRun
 	)
@@ -1239,7 +1239,7 @@ func (a *DataLakePipelinesApiService) ListPipelineSchedules(ctx context.Context,
 func (a *DataLakePipelinesApiService) ListPipelineSchedulesExecute(r ListPipelineSchedulesApiRequest) ([]DiskBackupApiPolicyItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []DiskBackupApiPolicyItem
 	)
@@ -1396,7 +1396,7 @@ func (a *DataLakePipelinesApiService) ListPipelineSnapshots(ctx context.Context,
 func (a *DataLakePipelinesApiService) ListPipelineSnapshotsExecute(r ListPipelineSnapshotsApiRequest) (*PaginatedBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedBackupSnapshot
 	)
@@ -1536,7 +1536,7 @@ func (a *DataLakePipelinesApiService) ListPipelines(ctx context.Context, groupId
 func (a *DataLakePipelinesApiService) ListPipelinesExecute(r ListPipelinesApiRequest) ([]DataLakeIngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []DataLakeIngestionPipeline
 	)
@@ -1656,7 +1656,7 @@ func (a *DataLakePipelinesApiService) PausePipeline(ctx context.Context, groupId
 func (a *DataLakePipelinesApiService) PausePipelineExecute(r PausePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataLakeIngestionPipeline
 	)
@@ -1777,7 +1777,7 @@ func (a *DataLakePipelinesApiService) ResumePipeline(ctx context.Context, groupI
 func (a *DataLakePipelinesApiService) ResumePipelineExecute(r ResumePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataLakeIngestionPipeline
 	)
@@ -1902,7 +1902,7 @@ func (a *DataLakePipelinesApiService) TriggerSnapshotIngestion(ctx context.Conte
 func (a *DataLakePipelinesApiService) TriggerSnapshotIngestionExecute(r TriggerSnapshotIngestionApiRequest) (*IngestionPipelineRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *IngestionPipelineRun
 	)
@@ -2032,7 +2032,7 @@ func (a *DataLakePipelinesApiService) UpdatePipeline(ctx context.Context, groupI
 func (a *DataLakePipelinesApiService) UpdatePipelineExecute(r UpdatePipelineApiRequest) (*DataLakeIngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataLakeIngestionPipeline
 	)

--- a/admin/api_database_users.go
+++ b/admin/api_database_users.go
@@ -59,7 +59,7 @@ type DatabaseUsersApi interface {
 	DeleteDatabaseUserWithParams(ctx context.Context, args *DeleteDatabaseUserApiParams) DeleteDatabaseUserApiRequest
 
 	// Method available only for mocking purposes
-	DeleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (interface{}, *http.Response, error)
+	DeleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (any, *http.Response, error)
 
 	/*
 		GetDatabaseUser Return One Database User from One Project
@@ -283,7 +283,7 @@ func (a *DatabaseUsersApiService) DeleteDatabaseUserWithParams(ctx context.Conte
 	}
 }
 
-func (r DeleteDatabaseUserApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteDatabaseUserApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteDatabaseUserExecute(r)
 }
 
@@ -310,13 +310,13 @@ func (a *DatabaseUsersApiService) DeleteDatabaseUser(ctx context.Context, groupI
 
 // DeleteDatabaseUserExecute executes the request
 //
-//	@return interface{}
-func (a *DatabaseUsersApiService) DeleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *DatabaseUsersApiService) DeleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DatabaseUsersApiService.DeleteDatabaseUser")

--- a/admin/api_database_users.go
+++ b/admin/api_database_users.go
@@ -188,7 +188,7 @@ func (a *DatabaseUsersApiService) CreateDatabaseUser(ctx context.Context, groupI
 func (a *DatabaseUsersApiService) CreateDatabaseUserExecute(r CreateDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudDatabaseUser
 	)
@@ -314,7 +314,7 @@ func (a *DatabaseUsersApiService) DeleteDatabaseUser(ctx context.Context, groupI
 func (a *DatabaseUsersApiService) DeleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -437,7 +437,7 @@ func (a *DatabaseUsersApiService) GetDatabaseUser(ctx context.Context, groupId s
 func (a *DatabaseUsersApiService) GetDatabaseUserExecute(r GetDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudDatabaseUser
 	)
@@ -577,7 +577,7 @@ func (a *DatabaseUsersApiService) ListDatabaseUsers(ctx context.Context, groupId
 func (a *DatabaseUsersApiService) ListDatabaseUsersExecute(r ListDatabaseUsersApiRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiAtlasDatabaseUser
 	)
@@ -723,7 +723,7 @@ func (a *DatabaseUsersApiService) UpdateDatabaseUser(ctx context.Context, groupI
 func (a *DatabaseUsersApiService) UpdateDatabaseUserExecute(r UpdateDatabaseUserApiRequest) (*CloudDatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudDatabaseUser
 	)

--- a/admin/api_encryption_at_rest_using_customer_key_management.go
+++ b/admin/api_encryption_at_rest_using_customer_key_management.go
@@ -220,7 +220,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) CreateEncryptionA
 func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) CreateEncryptionAtRestPrivateEndpointExecute(r CreateEncryptionAtRestPrivateEndpointApiRequest) (*EARPrivateEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *EARPrivateEndpoint
 	)
@@ -339,7 +339,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRe
 func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRestExecute(r GetEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *EncryptionAtRest
 	)
@@ -460,7 +460,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRe
 func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRestPrivateEndpointExecute(r GetEncryptionAtRestPrivateEndpointApiRequest) (*EARPrivateEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *EARPrivateEndpoint
 	)
@@ -605,7 +605,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRe
 func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRestPrivateEndpointsForCloudProviderExecute(r GetEncryptionAtRestPrivateEndpointsForCloudProviderApiRequest) (*PaginatedApiAtlasEARPrivateEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiAtlasEARPrivateEndpoint
 	)
@@ -748,7 +748,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) RequestEncryption
 func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) RequestEncryptionAtRestPrivateEndpointDeletionExecute(r RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -867,7 +867,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionA
 func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionAtRestExecute(r UpdateEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *EncryptionAtRest
 	)

--- a/admin/api_encryption_at_rest_using_customer_key_management.go
+++ b/admin/api_encryption_at_rest_using_customer_key_management.go
@@ -134,7 +134,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi interface {
 	RequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx context.Context, args *RequestEncryptionAtRestPrivateEndpointDeletionApiParams) RequestEncryptionAtRestPrivateEndpointDeletionApiRequest
 
 	// Method available only for mocking purposes
-	RequestEncryptionAtRestPrivateEndpointDeletionExecute(r RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) (interface{}, *http.Response, error)
+	RequestEncryptionAtRestPrivateEndpointDeletionExecute(r RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) (any, *http.Response, error)
 
 	/*
 			UpdateEncryptionAtRest Update Configuration for Encryption at Rest using Customer-Managed Keys for One Project
@@ -717,7 +717,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) RequestEncryption
 	}
 }
 
-func (r RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.RequestEncryptionAtRestPrivateEndpointDeletionExecute(r)
 }
 
@@ -744,13 +744,13 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) RequestEncryption
 
 // RequestEncryptionAtRestPrivateEndpointDeletionExecute executes the request
 //
-//	@return interface{}
-func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) RequestEncryptionAtRestPrivateEndpointDeletionExecute(r RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) RequestEncryptionAtRestPrivateEndpointDeletionExecute(r RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "EncryptionAtRestUsingCustomerKeyManagementApiService.RequestEncryptionAtRestPrivateEndpointDeletion")

--- a/admin/api_events.go
+++ b/admin/api_events.go
@@ -203,7 +203,7 @@ func (a *EventsApiService) GetOrganizationEvent(ctx context.Context, orgId strin
 func (a *EventsApiService) GetOrganizationEventExecute(r GetOrganizationEventApiRequest) (*EventViewForOrg, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *EventViewForOrg
 	)
@@ -338,7 +338,7 @@ func (a *EventsApiService) GetProjectEvent(ctx context.Context, groupId string, 
 func (a *EventsApiService) GetProjectEventExecute(r GetProjectEventApiRequest) (*EventViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *EventViewForNdsGroup
 	)
@@ -479,7 +479,7 @@ func (a *EventsApiService) ListEventTypes(ctx context.Context) ListEventTypesApi
 func (a *EventsApiService) ListEventTypesExecute(r ListEventTypesApiRequest) (*PaginatedEventTypeDetailsResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedEventTypeDetailsResponse
 	)
@@ -675,7 +675,7 @@ func (a *EventsApiService) ListOrganizationEvents(ctx context.Context, orgId str
 func (a *EventsApiService) ListOrganizationEventsExecute(r ListOrganizationEventsApiRequest) (*OrgPaginatedEvent, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *OrgPaginatedEvent
 	)
@@ -910,7 +910,7 @@ func (a *EventsApiService) ListProjectEvents(ctx context.Context, groupId string
 func (a *EventsApiService) ListProjectEventsExecute(r ListProjectEventsApiRequest) (*GroupPaginatedEvent, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupPaginatedEvent
 	)

--- a/admin/api_federated_authentication.go
+++ b/admin/api_federated_authentication.go
@@ -350,7 +350,7 @@ type FederatedAuthenticationApi interface {
 	RemoveConnectedOrgConfigWithParams(ctx context.Context, args *RemoveConnectedOrgConfigApiParams) RemoveConnectedOrgConfigApiRequest
 
 	// Method available only for mocking purposes
-	RemoveConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (interface{}, *http.Response, error)
+	RemoveConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (any, *http.Response, error)
 
 	/*
 			RevokeJwksFromIdentityProvider Revoke the JWKS from One OIDC Identity Provider
@@ -2059,7 +2059,7 @@ func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfigWithParams(c
 	}
 }
 
-func (r RemoveConnectedOrgConfigApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r RemoveConnectedOrgConfigApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.RemoveConnectedOrgConfigExecute(r)
 }
 
@@ -2084,13 +2084,13 @@ func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfig(ctx context
 
 // RemoveConnectedOrgConfigExecute executes the request
 //
-//	@return interface{}
-func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FederatedAuthenticationApiService.RemoveConnectedOrgConfig")

--- a/admin/api_federated_authentication.go
+++ b/admin/api_federated_authentication.go
@@ -519,7 +519,7 @@ func (a *FederatedAuthenticationApiService) CreateIdentityProvider(ctx context.C
 func (a *FederatedAuthenticationApiService) CreateIdentityProviderExecute(r CreateIdentityProviderApiRequest) (*FederationOidcIdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *FederationOidcIdentityProvider
 	)
@@ -644,7 +644,7 @@ func (a *FederatedAuthenticationApiService) CreateRoleMapping(ctx context.Contex
 func (a *FederatedAuthenticationApiService) CreateRoleMappingExecute(r CreateRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *AuthFederationRoleMapping
 	)
@@ -759,7 +759,7 @@ func (a *FederatedAuthenticationApiService) DeleteFederationApp(ctx context.Cont
 func (a *FederatedAuthenticationApiService) DeleteFederationAppExecute(r DeleteFederationAppApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -860,7 +860,7 @@ func (a *FederatedAuthenticationApiService) DeleteIdentityProvider(ctx context.C
 func (a *FederatedAuthenticationApiService) DeleteIdentityProviderExecute(r DeleteIdentityProviderApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -965,7 +965,7 @@ func (a *FederatedAuthenticationApiService) DeleteRoleMapping(ctx context.Contex
 func (a *FederatedAuthenticationApiService) DeleteRoleMappingExecute(r DeleteRoleMappingApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -1068,7 +1068,7 @@ func (a *FederatedAuthenticationApiService) GetConnectedOrgConfig(ctx context.Co
 func (a *FederatedAuthenticationApiService) GetConnectedOrgConfigExecute(r GetConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ConnectedOrgConfig
 	)
@@ -1180,7 +1180,7 @@ func (a *FederatedAuthenticationApiService) GetFederationSettings(ctx context.Co
 func (a *FederatedAuthenticationApiService) GetFederationSettingsExecute(r GetFederationSettingsApiRequest) (*OrgFederationSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *OrgFederationSettings
 	)
@@ -1296,7 +1296,7 @@ func (a *FederatedAuthenticationApiService) GetIdentityProvider(ctx context.Cont
 func (a *FederatedAuthenticationApiService) GetIdentityProviderExecute(r GetIdentityProviderApiRequest) (*FederationIdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *FederationIdentityProvider
 	)
@@ -1413,7 +1413,7 @@ func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadata(ctx cont
 func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadataExecute(r GetIdentityProviderMetadataApiRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue string
 	)
@@ -1535,7 +1535,7 @@ func (a *FederatedAuthenticationApiService) GetRoleMapping(ctx context.Context, 
 func (a *FederatedAuthenticationApiService) GetRoleMappingExecute(r GetRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *AuthFederationRoleMapping
 	)
@@ -1666,7 +1666,7 @@ func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigs(ctx context.
 func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigsExecute(r ListConnectedOrgConfigsApiRequest) (*PaginatedConnectedOrgConfigs, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedConnectedOrgConfigs
 	)
@@ -1827,7 +1827,7 @@ func (a *FederatedAuthenticationApiService) ListIdentityProviders(ctx context.Co
 func (a *FederatedAuthenticationApiService) ListIdentityProvidersExecute(r ListIdentityProvidersApiRequest) (*PaginatedFederationIdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedFederationIdentityProvider
 	)
@@ -1971,7 +1971,7 @@ func (a *FederatedAuthenticationApiService) ListRoleMappings(ctx context.Context
 func (a *FederatedAuthenticationApiService) ListRoleMappingsExecute(r ListRoleMappingsApiRequest) (*PaginatedRoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedRoleMapping
 	)
@@ -2088,7 +2088,7 @@ func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfig(ctx context
 func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -2205,7 +2205,7 @@ func (a *FederatedAuthenticationApiService) RevokeJwksFromIdentityProvider(ctx c
 func (a *FederatedAuthenticationApiService) RevokeJwksFromIdentityProviderExecute(r RevokeJwksFromIdentityProviderApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -2319,7 +2319,7 @@ func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfig(ctx context
 func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfigExecute(r UpdateConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ConnectedOrgConfig
 	)
@@ -2447,7 +2447,7 @@ func (a *FederatedAuthenticationApiService) UpdateIdentityProvider(ctx context.C
 func (a *FederatedAuthenticationApiService) UpdateIdentityProviderExecute(r UpdateIdentityProviderApiRequest) (*FederationIdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *FederationIdentityProvider
 	)
@@ -2578,7 +2578,7 @@ func (a *FederatedAuthenticationApiService) UpdateRoleMapping(ctx context.Contex
 func (a *FederatedAuthenticationApiService) UpdateRoleMappingExecute(r UpdateRoleMappingApiRequest) (*AuthFederationRoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *AuthFederationRoleMapping
 	)

--- a/admin/api_global_clusters.go
+++ b/admin/api_global_clusters.go
@@ -192,7 +192,7 @@ func (a *GlobalClustersApiService) CreateCustomZoneMapping(ctx context.Context, 
 func (a *GlobalClustersApiService) CreateCustomZoneMappingExecute(r CreateCustomZoneMappingApiRequest) (*GeoSharding20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GeoSharding20240805
 	)
@@ -318,7 +318,7 @@ func (a *GlobalClustersApiService) CreateManagedNamespace(ctx context.Context, g
 func (a *GlobalClustersApiService) CreateManagedNamespaceExecute(r CreateManagedNamespaceApiRequest) (*GeoSharding20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GeoSharding20240805
 	)
@@ -440,7 +440,7 @@ func (a *GlobalClustersApiService) DeleteAllCustomZoneMappings(ctx context.Conte
 func (a *GlobalClustersApiService) DeleteAllCustomZoneMappingsExecute(r DeleteAllCustomZoneMappingsApiRequest) (*GeoSharding20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GeoSharding20240805
 	)
@@ -575,7 +575,7 @@ func (a *GlobalClustersApiService) DeleteManagedNamespace(ctx context.Context, c
 func (a *GlobalClustersApiService) DeleteManagedNamespaceExecute(r DeleteManagedNamespaceApiRequest) (*GeoSharding20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GeoSharding20240805
 	)
@@ -698,7 +698,7 @@ func (a *GlobalClustersApiService) GetManagedNamespace(ctx context.Context, grou
 func (a *GlobalClustersApiService) GetManagedNamespaceExecute(r GetManagedNamespaceApiRequest) (*GeoSharding20240805, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GeoSharding20240805
 	)

--- a/admin/api_invoices.go
+++ b/admin/api_invoices.go
@@ -236,7 +236,7 @@ func (a *InvoicesApiService) CreateCostExplorerQueryProcess(ctx context.Context,
 func (a *InvoicesApiService) CreateCostExplorerQueryProcessExecute(r CreateCostExplorerQueryProcessApiRequest) (*CostExplorerFilterResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CostExplorerFilterResponse
 	)
@@ -357,7 +357,7 @@ func (a *InvoicesApiService) CreateCostExplorerQueryProcess1(ctx context.Context
 func (a *InvoicesApiService) CreateCostExplorerQueryProcess1Execute(r CreateCostExplorerQueryProcess1ApiRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue string
 	)
@@ -476,7 +476,7 @@ func (a *InvoicesApiService) DownloadInvoiceCSV(ctx context.Context, orgId strin
 func (a *InvoicesApiService) DownloadInvoiceCSVExecute(r DownloadInvoiceCSVApiRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue string
 	)
@@ -594,7 +594,7 @@ func (a *InvoicesApiService) GetInvoice(ctx context.Context, orgId string, invoi
 func (a *InvoicesApiService) GetInvoiceExecute(r GetInvoiceApiRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue string
 	)
@@ -788,7 +788,7 @@ func (a *InvoicesApiService) ListInvoices(ctx context.Context, orgId string) Lis
 func (a *InvoicesApiService) ListInvoicesExecute(r ListInvoicesApiRequest) (*PaginatedApiInvoiceMetadata, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiInvoiceMetadata
 	)
@@ -954,7 +954,7 @@ func (a *InvoicesApiService) ListPendingInvoices(ctx context.Context, orgId stri
 func (a *InvoicesApiService) ListPendingInvoicesExecute(r ListPendingInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiInvoice
 	)
@@ -1092,7 +1092,7 @@ func (a *InvoicesApiService) QueryLineItemsFromSingleInvoice(ctx context.Context
 func (a *InvoicesApiService) QueryLineItemsFromSingleInvoiceExecute(r QueryLineItemsFromSingleInvoiceApiRequest) (*PaginatedPublicApiUsageDetailsLineItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedPublicApiUsageDetailsLineItem
 	)

--- a/admin/api_ldap_configuration.go
+++ b/admin/api_ldap_configuration.go
@@ -181,7 +181,7 @@ func (a *LDAPConfigurationApiService) DeleteLDAPConfiguration(ctx context.Contex
 func (a *LDAPConfigurationApiService) DeleteLDAPConfigurationExecute(r DeleteLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *UserSecurity
 	)
@@ -292,7 +292,7 @@ func (a *LDAPConfigurationApiService) GetLDAPConfiguration(ctx context.Context, 
 func (a *LDAPConfigurationApiService) GetLDAPConfigurationExecute(r GetLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *UserSecurity
 	)
@@ -408,7 +408,7 @@ func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatus(ctx context.Con
 func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatusExecute(r GetLDAPConfigurationStatusApiRequest) (*LDAPVerifyConnectivityJobRequest, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *LDAPVerifyConnectivityJobRequest
 	)
@@ -526,7 +526,7 @@ func (a *LDAPConfigurationApiService) SaveLDAPConfiguration(ctx context.Context,
 func (a *LDAPConfigurationApiService) SaveLDAPConfigurationExecute(r SaveLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *UserSecurity
 	)
@@ -646,7 +646,7 @@ func (a *LDAPConfigurationApiService) VerifyLDAPConfiguration(ctx context.Contex
 func (a *LDAPConfigurationApiService) VerifyLDAPConfigurationExecute(r VerifyLDAPConfigurationApiRequest) (*LDAPVerifyConnectivityJobRequest, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *LDAPVerifyConnectivityJobRequest
 	)

--- a/admin/api_legacy_backup.go
+++ b/admin/api_legacy_backup.go
@@ -68,7 +68,7 @@ type LegacyBackupApi interface {
 	DeleteLegacySnapshotWithParams(ctx context.Context, args *DeleteLegacySnapshotApiParams) DeleteLegacySnapshotApiRequest
 
 	// Method available only for mocking purposes
-	DeleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (interface{}, *http.Response, error)
+	DeleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (any, *http.Response, error)
 
 	/*
 		GetLegacyBackupCheckpoint Return One Legacy Backup Checkpoint
@@ -494,7 +494,7 @@ func (a *LegacyBackupApiService) DeleteLegacySnapshotWithParams(ctx context.Cont
 	}
 }
 
-func (r DeleteLegacySnapshotApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteLegacySnapshotApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteLegacySnapshotExecute(r)
 }
 
@@ -523,15 +523,15 @@ func (a *LegacyBackupApiService) DeleteLegacySnapshot(ctx context.Context, group
 
 // DeleteLegacySnapshotExecute executes the request
 //
-//	@return interface{}
+//	@return any
 //
 // Deprecated
-func (a *LegacyBackupApiService) DeleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (interface{}, *http.Response, error) {
+func (a *LegacyBackupApiService) DeleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "LegacyBackupApiService.DeleteLegacySnapshot")

--- a/admin/api_legacy_backup.go
+++ b/admin/api_legacy_backup.go
@@ -398,7 +398,7 @@ func (a *LegacyBackupApiService) CreateLegacyBackupRestoreJob(ctx context.Contex
 func (a *LegacyBackupApiService) CreateLegacyBackupRestoreJobExecute(r CreateLegacyBackupRestoreJobApiRequest) (*PaginatedRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedRestoreJob
 	)
@@ -529,7 +529,7 @@ func (a *LegacyBackupApiService) DeleteLegacySnapshot(ctx context.Context, group
 func (a *LegacyBackupApiService) DeleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -656,7 +656,7 @@ func (a *LegacyBackupApiService) GetLegacyBackupCheckpoint(ctx context.Context, 
 func (a *LegacyBackupApiService) GetLegacyBackupCheckpointExecute(r GetLegacyBackupCheckpointApiRequest) (*ApiAtlasCheckpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiAtlasCheckpoint
 	)
@@ -785,7 +785,7 @@ func (a *LegacyBackupApiService) GetLegacyBackupRestoreJob(ctx context.Context, 
 func (a *LegacyBackupApiService) GetLegacyBackupRestoreJobExecute(r GetLegacyBackupRestoreJobApiRequest) (*BackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *BackupRestoreJob
 	)
@@ -912,7 +912,7 @@ func (a *LegacyBackupApiService) GetLegacySnapshot(ctx context.Context, groupId 
 func (a *LegacyBackupApiService) GetLegacySnapshotExecute(r GetLegacySnapshotApiRequest) (*BackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *BackupSnapshot
 	)
@@ -1036,7 +1036,7 @@ func (a *LegacyBackupApiService) GetLegacySnapshotSchedule(ctx context.Context, 
 func (a *LegacyBackupApiService) GetLegacySnapshotScheduleExecute(r GetLegacySnapshotScheduleApiRequest) (*ApiAtlasSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiAtlasSnapshotSchedule
 	)
@@ -1184,7 +1184,7 @@ func (a *LegacyBackupApiService) ListLegacyBackupCheckpoints(ctx context.Context
 func (a *LegacyBackupApiService) ListLegacyBackupCheckpointsExecute(r ListLegacyBackupCheckpointsApiRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiAtlasCheckpoint
 	)
@@ -1364,7 +1364,7 @@ func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobs(ctx context.Context
 func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobsExecute(r ListLegacyBackupRestoreJobsApiRequest) (*PaginatedRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedRestoreJob
 	)
@@ -1545,7 +1545,7 @@ func (a *LegacyBackupApiService) ListLegacySnapshots(ctx context.Context, groupI
 func (a *LegacyBackupApiService) ListLegacySnapshotsExecute(r ListLegacySnapshotsApiRequest) (*PaginatedSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedSnapshot
 	)
@@ -1703,7 +1703,7 @@ func (a *LegacyBackupApiService) UpdateLegacySnapshotRetention(ctx context.Conte
 func (a *LegacyBackupApiService) UpdateLegacySnapshotRetentionExecute(r UpdateLegacySnapshotRetentionApiRequest) (*BackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *BackupSnapshot
 	)
@@ -1836,7 +1836,7 @@ func (a *LegacyBackupApiService) UpdateLegacySnapshotSchedule(ctx context.Contex
 func (a *LegacyBackupApiService) UpdateLegacySnapshotScheduleExecute(r UpdateLegacySnapshotScheduleApiRequest) (*ApiAtlasSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiAtlasSnapshotSchedule
 	)

--- a/admin/api_maintenance_windows_.go
+++ b/admin/api_maintenance_windows_.go
@@ -175,7 +175,7 @@ func (a *MaintenanceWindowsApiService) DeferMaintenanceWindow(ctx context.Contex
 func (a *MaintenanceWindowsApiService) DeferMaintenanceWindowExecute(r DeferMaintenanceWindowApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -271,7 +271,7 @@ func (a *MaintenanceWindowsApiService) GetMaintenanceWindow(ctx context.Context,
 func (a *MaintenanceWindowsApiService) GetMaintenanceWindowExecute(r GetMaintenanceWindowApiRequest) (*GroupMaintenanceWindow, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupMaintenanceWindow
 	)
@@ -380,7 +380,7 @@ func (a *MaintenanceWindowsApiService) ResetMaintenanceWindow(ctx context.Contex
 func (a *MaintenanceWindowsApiService) ResetMaintenanceWindowExecute(r ResetMaintenanceWindowApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -474,7 +474,7 @@ func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDefer(ctx context.Co
 func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDeferExecute(r ToggleMaintenanceAutoDeferApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -574,7 +574,7 @@ func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindow(ctx context.Conte
 func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)

--- a/admin/api_maintenance_windows_.go
+++ b/admin/api_maintenance_windows_.go
@@ -126,7 +126,7 @@ type MaintenanceWindowsApi interface {
 	UpdateMaintenanceWindowWithParams(ctx context.Context, args *UpdateMaintenanceWindowApiParams) UpdateMaintenanceWindowApiRequest
 
 	// Method available only for mocking purposes
-	UpdateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (interface{}, *http.Response, error)
+	UpdateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (any, *http.Response, error)
 }
 
 // MaintenanceWindowsApiService MaintenanceWindowsApi service
@@ -546,7 +546,7 @@ func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindowWithParams(ctx con
 	}
 }
 
-func (r UpdateMaintenanceWindowApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r UpdateMaintenanceWindowApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.UpdateMaintenanceWindowExecute(r)
 }
 
@@ -570,13 +570,13 @@ func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindow(ctx context.Conte
 
 // UpdateMaintenanceWindowExecute executes the request
 //
-//	@return interface{}
-func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "MaintenanceWindowsApiService.UpdateMaintenanceWindow")

--- a/admin/api_mongo_db_cloud_users.go
+++ b/admin/api_mongo_db_cloud_users.go
@@ -137,7 +137,7 @@ func (a *MongoDBCloudUsersApiService) CreateUser(ctx context.Context, cloudAppUs
 func (a *MongoDBCloudUsersApiService) CreateUserExecute(r CreateUserApiRequest) (*CloudAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudAppUser
 	)
@@ -252,7 +252,7 @@ func (a *MongoDBCloudUsersApiService) GetUser(ctx context.Context, userId string
 func (a *MongoDBCloudUsersApiService) GetUserExecute(r GetUserApiRequest) (*CloudAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudAppUser
 	)
@@ -363,7 +363,7 @@ func (a *MongoDBCloudUsersApiService) GetUserByUsername(ctx context.Context, use
 func (a *MongoDBCloudUsersApiService) GetUserByUsernameExecute(r GetUserByUsernameApiRequest) (*CloudAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudAppUser
 	)

--- a/admin/api_monitoring_and_logs.go
+++ b/admin/api_monitoring_and_logs.go
@@ -426,7 +426,7 @@ func (a *MonitoringAndLogsApiService) GetAtlasProcess(ctx context.Context, group
 func (a *MonitoringAndLogsApiService) GetAtlasProcessExecute(r GetAtlasProcessApiRequest) (*ApiHostViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiHostViewAtlas
 	)
@@ -548,7 +548,7 @@ func (a *MonitoringAndLogsApiService) GetDatabase(ctx context.Context, groupId s
 func (a *MonitoringAndLogsApiService) GetDatabaseExecute(r GetDatabaseApiRequest) (*MesurementsDatabase, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *MesurementsDatabase
 	)
@@ -716,7 +716,7 @@ func (a *MonitoringAndLogsApiService) GetDatabaseMeasurements(ctx context.Contex
 func (a *MonitoringAndLogsApiService) GetDatabaseMeasurementsExecute(r GetDatabaseMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiMeasurementsGeneralViewAtlas
 	)
@@ -910,7 +910,7 @@ func (a *MonitoringAndLogsApiService) GetDiskMeasurements(ctx context.Context, g
 func (a *MonitoringAndLogsApiService) GetDiskMeasurementsExecute(r GetDiskMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiMeasurementsGeneralViewAtlas
 	)
@@ -1071,7 +1071,7 @@ func (a *MonitoringAndLogsApiService) GetHostLogs(ctx context.Context, groupId s
 func (a *MonitoringAndLogsApiService) GetHostLogsExecute(r GetHostLogsApiRequest) (io.ReadCloser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue io.ReadCloser
 	)
@@ -1247,7 +1247,7 @@ func (a *MonitoringAndLogsApiService) GetHostMeasurements(ctx context.Context, g
 func (a *MonitoringAndLogsApiService) GetHostMeasurementsExecute(r GetHostMeasurementsApiRequest) (*ApiMeasurementsGeneralViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiMeasurementsGeneralViewAtlas
 	)
@@ -1444,7 +1444,7 @@ func (a *MonitoringAndLogsApiService) GetIndexMetrics(ctx context.Context, proce
 func (a *MonitoringAndLogsApiService) GetIndexMetricsExecute(r GetIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *MeasurementsIndexes
 	)
@@ -1631,7 +1631,7 @@ func (a *MonitoringAndLogsApiService) GetMeasurements(ctx context.Context, proce
 func (a *MonitoringAndLogsApiService) GetMeasurementsExecute(r GetMeasurementsApiRequest) (*MeasurementsNonIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *MeasurementsNonIndex
 	)
@@ -1792,7 +1792,7 @@ func (a *MonitoringAndLogsApiService) ListAtlasProcesses(ctx context.Context, gr
 func (a *MonitoringAndLogsApiService) ListAtlasProcessesExecute(r ListAtlasProcessesApiRequest) (*PaginatedHostViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedHostViewAtlas
 	)
@@ -1956,7 +1956,7 @@ func (a *MonitoringAndLogsApiService) ListDatabases(ctx context.Context, groupId
 func (a *MonitoringAndLogsApiService) ListDatabasesExecute(r ListDatabasesApiRequest) (*PaginatedDatabase, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedDatabase
 	)
@@ -2099,7 +2099,7 @@ func (a *MonitoringAndLogsApiService) ListDiskMeasurements(ctx context.Context, 
 func (a *MonitoringAndLogsApiService) ListDiskMeasurementsExecute(r ListDiskMeasurementsApiRequest) (*MeasurementDiskPartition, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *MeasurementDiskPartition
 	)
@@ -2244,7 +2244,7 @@ func (a *MonitoringAndLogsApiService) ListDiskPartitions(ctx context.Context, gr
 func (a *MonitoringAndLogsApiService) ListDiskPartitionsExecute(r ListDiskPartitionsApiRequest) (*PaginatedDiskPartition, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedDiskPartition
 	)
@@ -2437,7 +2437,7 @@ func (a *MonitoringAndLogsApiService) ListIndexMetrics(ctx context.Context, proc
 func (a *MonitoringAndLogsApiService) ListIndexMetricsExecute(r ListIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *MeasurementsIndexes
 	)
@@ -2578,7 +2578,7 @@ func (a *MonitoringAndLogsApiService) ListMetricTypes(ctx context.Context, proce
 func (a *MonitoringAndLogsApiService) ListMetricTypesExecute(r ListMetricTypesApiRequest) (*CloudSearchMetrics, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudSearchMetrics
 	)

--- a/admin/api_network_peering.go
+++ b/admin/api_network_peering.go
@@ -383,7 +383,7 @@ func (a *NetworkPeeringApiService) CreatePeeringConnection(ctx context.Context, 
 func (a *NetworkPeeringApiService) CreatePeeringConnectionExecute(r CreatePeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *BaseNetworkPeeringConnectionSettings
 	)
@@ -503,7 +503,7 @@ func (a *NetworkPeeringApiService) CreatePeeringContainer(ctx context.Context, g
 func (a *NetworkPeeringApiService) CreatePeeringContainerExecute(r CreatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudProviderContainer
 	)
@@ -624,7 +624,7 @@ func (a *NetworkPeeringApiService) DeletePeeringConnection(ctx context.Context, 
 func (a *NetworkPeeringApiService) DeletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -741,7 +741,7 @@ func (a *NetworkPeeringApiService) DeletePeeringContainer(ctx context.Context, g
 func (a *NetworkPeeringApiService) DeletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -861,7 +861,7 @@ func (a *NetworkPeeringApiService) DisablePeering(ctx context.Context, groupId s
 func (a *NetworkPeeringApiService) DisablePeeringExecute(r DisablePeeringApiRequest) (*PrivateIPMode, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PrivateIPMode
 	)
@@ -982,7 +982,7 @@ func (a *NetworkPeeringApiService) GetPeeringConnection(ctx context.Context, gro
 func (a *NetworkPeeringApiService) GetPeeringConnectionExecute(r GetPeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *BaseNetworkPeeringConnectionSettings
 	)
@@ -1099,7 +1099,7 @@ func (a *NetworkPeeringApiService) GetPeeringContainer(ctx context.Context, grou
 func (a *NetworkPeeringApiService) GetPeeringContainerExecute(r GetPeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudProviderContainer
 	)
@@ -1247,7 +1247,7 @@ func (a *NetworkPeeringApiService) ListPeeringConnections(ctx context.Context, g
 func (a *NetworkPeeringApiService) ListPeeringConnectionsExecute(r ListPeeringConnectionsApiRequest) (*PaginatedContainerPeer, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedContainerPeer
 	)
@@ -1422,7 +1422,7 @@ func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProvider(ctx conte
 func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProviderExecute(r ListPeeringContainerByCloudProviderApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedCloudProviderContainer
 	)
@@ -1585,7 +1585,7 @@ func (a *NetworkPeeringApiService) ListPeeringContainers(ctx context.Context, gr
 func (a *NetworkPeeringApiService) ListPeeringContainersExecute(r ListPeeringContainersApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedCloudProviderContainer
 	)
@@ -1726,7 +1726,7 @@ func (a *NetworkPeeringApiService) UpdatePeeringConnection(ctx context.Context, 
 func (a *NetworkPeeringApiService) UpdatePeeringConnectionExecute(r UpdatePeeringConnectionApiRequest) (*BaseNetworkPeeringConnectionSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *BaseNetworkPeeringConnectionSettings
 	)
@@ -1852,7 +1852,7 @@ func (a *NetworkPeeringApiService) UpdatePeeringContainer(ctx context.Context, g
 func (a *NetworkPeeringApiService) UpdatePeeringContainerExecute(r UpdatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CloudProviderContainer
 	)
@@ -1973,7 +1973,7 @@ func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProject(
 func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) (*PrivateIPMode, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PrivateIPMode
 	)

--- a/admin/api_network_peering.go
+++ b/admin/api_network_peering.go
@@ -82,7 +82,7 @@ type NetworkPeeringApi interface {
 	DeletePeeringConnectionWithParams(ctx context.Context, args *DeletePeeringConnectionApiParams) DeletePeeringConnectionApiRequest
 
 	// Method available only for mocking purposes
-	DeletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (interface{}, *http.Response, error)
+	DeletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (any, *http.Response, error)
 
 	/*
 		DeletePeeringContainer Remove One Network Peering Container
@@ -106,7 +106,7 @@ type NetworkPeeringApi interface {
 	DeletePeeringContainerWithParams(ctx context.Context, args *DeletePeeringContainerApiParams) DeletePeeringContainerApiRequest
 
 	// Method available only for mocking purposes
-	DeletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (interface{}, *http.Response, error)
+	DeletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (any, *http.Response, error)
 
 	/*
 		DisablePeering Disable Connect via Peering Only Mode for One Project
@@ -595,7 +595,7 @@ func (a *NetworkPeeringApiService) DeletePeeringConnectionWithParams(ctx context
 	}
 }
 
-func (r DeletePeeringConnectionApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeletePeeringConnectionApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeletePeeringConnectionExecute(r)
 }
 
@@ -620,13 +620,13 @@ func (a *NetworkPeeringApiService) DeletePeeringConnection(ctx context.Context, 
 
 // DeletePeeringConnectionExecute executes the request
 //
-//	@return interface{}
-func (a *NetworkPeeringApiService) DeletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *NetworkPeeringApiService) DeletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "NetworkPeeringApiService.DeletePeeringConnection")
@@ -712,7 +712,7 @@ func (a *NetworkPeeringApiService) DeletePeeringContainerWithParams(ctx context.
 	}
 }
 
-func (r DeletePeeringContainerApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeletePeeringContainerApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeletePeeringContainerExecute(r)
 }
 
@@ -737,13 +737,13 @@ func (a *NetworkPeeringApiService) DeletePeeringContainer(ctx context.Context, g
 
 // DeletePeeringContainerExecute executes the request
 //
-//	@return interface{}
-func (a *NetworkPeeringApiService) DeletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *NetworkPeeringApiService) DeletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "NetworkPeeringApiService.DeletePeeringContainer")

--- a/admin/api_online_archive.go
+++ b/admin/api_online_archive.go
@@ -60,7 +60,7 @@ type OnlineArchiveApi interface {
 	DeleteOnlineArchiveWithParams(ctx context.Context, args *DeleteOnlineArchiveApiParams) DeleteOnlineArchiveApiRequest
 
 	// Method available only for mocking purposes
-	DeleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (interface{}, *http.Response, error)
+	DeleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (any, *http.Response, error)
 
 	/*
 		DownloadOnlineArchiveQueryLogs Download Online Archive Query Logs
@@ -315,7 +315,7 @@ func (a *OnlineArchiveApiService) DeleteOnlineArchiveWithParams(ctx context.Cont
 	}
 }
 
-func (r DeleteOnlineArchiveApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteOnlineArchiveApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteOnlineArchiveExecute(r)
 }
 
@@ -342,13 +342,13 @@ func (a *OnlineArchiveApiService) DeleteOnlineArchive(ctx context.Context, group
 
 // DeleteOnlineArchiveExecute executes the request
 //
-//	@return interface{}
-func (a *OnlineArchiveApiService) DeleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *OnlineArchiveApiService) DeleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OnlineArchiveApiService.DeleteOnlineArchive")

--- a/admin/api_online_archive.go
+++ b/admin/api_online_archive.go
@@ -219,7 +219,7 @@ func (a *OnlineArchiveApiService) CreateOnlineArchive(ctx context.Context, group
 func (a *OnlineArchiveApiService) CreateOnlineArchiveExecute(r CreateOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *BackupOnlineArchive
 	)
@@ -346,7 +346,7 @@ func (a *OnlineArchiveApiService) DeleteOnlineArchive(ctx context.Context, group
 func (a *OnlineArchiveApiService) DeleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -491,7 +491,7 @@ func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogs(ctx context.Con
 func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (io.ReadCloser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue io.ReadCloser
 	)
@@ -626,7 +626,7 @@ func (a *OnlineArchiveApiService) GetOnlineArchive(ctx context.Context, groupId 
 func (a *OnlineArchiveApiService) GetOnlineArchiveExecute(r GetOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *BackupOnlineArchive
 	)
@@ -771,7 +771,7 @@ func (a *OnlineArchiveApiService) ListOnlineArchives(ctx context.Context, groupI
 func (a *OnlineArchiveApiService) ListOnlineArchivesExecute(r ListOnlineArchivesApiRequest) (*PaginatedOnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedOnlineArchive
 	)
@@ -918,7 +918,7 @@ func (a *OnlineArchiveApiService) UpdateOnlineArchive(ctx context.Context, group
 func (a *OnlineArchiveApiService) UpdateOnlineArchiveExecute(r UpdateOnlineArchiveApiRequest) (*BackupOnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *BackupOnlineArchive
 	)

--- a/admin/api_organizations.go
+++ b/admin/api_organizations.go
@@ -472,7 +472,7 @@ func (a *OrganizationsApiService) CreateOrganization(ctx context.Context, create
 func (a *OrganizationsApiService) CreateOrganizationExecute(r CreateOrganizationApiRequest) (*CreateOrganizationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *CreateOrganizationResponse
 	)
@@ -591,7 +591,7 @@ func (a *OrganizationsApiService) CreateOrganizationInvitation(ctx context.Conte
 func (a *OrganizationsApiService) CreateOrganizationInvitationExecute(r CreateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *OrganizationInvitation
 	)
@@ -712,7 +712,7 @@ func (a *OrganizationsApiService) DeleteOrganization(ctx context.Context, orgId 
 func (a *OrganizationsApiService) DeleteOrganizationExecute(r DeleteOrganizationApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -828,7 +828,7 @@ func (a *OrganizationsApiService) DeleteOrganizationInvitation(ctx context.Conte
 func (a *OrganizationsApiService) DeleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -940,7 +940,7 @@ func (a *OrganizationsApiService) GetOrganization(ctx context.Context, orgId str
 func (a *OrganizationsApiService) GetOrganizationExecute(r GetOrganizationApiRequest) (*AtlasOrganization, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *AtlasOrganization
 	)
@@ -1056,7 +1056,7 @@ func (a *OrganizationsApiService) GetOrganizationInvitation(ctx context.Context,
 func (a *OrganizationsApiService) GetOrganizationInvitationExecute(r GetOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *OrganizationInvitation
 	)
@@ -1168,7 +1168,7 @@ func (a *OrganizationsApiService) GetOrganizationSettings(ctx context.Context, o
 func (a *OrganizationsApiService) GetOrganizationSettingsExecute(r GetOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *OrganizationSettings
 	)
@@ -1288,7 +1288,7 @@ func (a *OrganizationsApiService) ListOrganizationInvitations(ctx context.Contex
 func (a *OrganizationsApiService) ListOrganizationInvitationsExecute(r ListOrganizationInvitationsApiRequest) ([]OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []OrganizationInvitation
 	)
@@ -1445,7 +1445,7 @@ func (a *OrganizationsApiService) ListOrganizationProjects(ctx context.Context, 
 func (a *OrganizationsApiService) ListOrganizationProjectsExecute(r ListOrganizationProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedAtlasGroup
 	)
@@ -1607,7 +1607,7 @@ func (a *OrganizationsApiService) ListOrganizationUsers(ctx context.Context, org
 func (a *OrganizationsApiService) ListOrganizationUsersExecute(r ListOrganizationUsersApiRequest) (*PaginatedAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedAppUser
 	)
@@ -1770,7 +1770,7 @@ func (a *OrganizationsApiService) ListOrganizations(ctx context.Context) ListOrg
 func (a *OrganizationsApiService) ListOrganizationsExecute(r ListOrganizationsApiRequest) (*PaginatedOrganization, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedOrganization
 	)
@@ -1909,7 +1909,7 @@ func (a *OrganizationsApiService) RemoveOrganizationUser(ctx context.Context, or
 func (a *OrganizationsApiService) RemoveOrganizationUserExecute(r RemoveOrganizationUserApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -2025,7 +2025,7 @@ func (a *OrganizationsApiService) RenameOrganization(ctx context.Context, orgId 
 func (a *OrganizationsApiService) RenameOrganizationExecute(r RenameOrganizationApiRequest) (*AtlasOrganization, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *AtlasOrganization
 	)
@@ -2145,7 +2145,7 @@ func (a *OrganizationsApiService) UpdateOrganizationInvitation(ctx context.Conte
 func (a *OrganizationsApiService) UpdateOrganizationInvitationExecute(r UpdateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *OrganizationInvitation
 	)
@@ -2270,7 +2270,7 @@ func (a *OrganizationsApiService) UpdateOrganizationInvitationById(ctx context.C
 func (a *OrganizationsApiService) UpdateOrganizationInvitationByIdExecute(r UpdateOrganizationInvitationByIdApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *OrganizationInvitation
 	)
@@ -2396,7 +2396,7 @@ func (a *OrganizationsApiService) UpdateOrganizationRoles(ctx context.Context, o
 func (a *OrganizationsApiService) UpdateOrganizationRolesExecute(r UpdateOrganizationRolesApiRequest) (*UpdateOrgRolesForUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *UpdateOrgRolesForUser
 	)
@@ -2517,7 +2517,7 @@ func (a *OrganizationsApiService) UpdateOrganizationSettings(ctx context.Context
 func (a *OrganizationsApiService) UpdateOrganizationSettingsExecute(r UpdateOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *OrganizationSettings
 	)

--- a/admin/api_organizations.go
+++ b/admin/api_organizations.go
@@ -84,7 +84,7 @@ type OrganizationsApi interface {
 	DeleteOrganizationWithParams(ctx context.Context, args *DeleteOrganizationApiParams) DeleteOrganizationApiRequest
 
 	// Method available only for mocking purposes
-	DeleteOrganizationExecute(r DeleteOrganizationApiRequest) (interface{}, *http.Response, error)
+	DeleteOrganizationExecute(r DeleteOrganizationApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteOrganizationInvitation Cancel One Organization Invitation
@@ -108,7 +108,7 @@ type OrganizationsApi interface {
 	DeleteOrganizationInvitationWithParams(ctx context.Context, args *DeleteOrganizationInvitationApiParams) DeleteOrganizationInvitationApiRequest
 
 	// Method available only for mocking purposes
-	DeleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (interface{}, *http.Response, error)
+	DeleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (any, *http.Response, error)
 
 	/*
 		GetOrganization Return One Organization
@@ -300,7 +300,7 @@ type OrganizationsApi interface {
 	RemoveOrganizationUserWithParams(ctx context.Context, args *RemoveOrganizationUserApiParams) RemoveOrganizationUserApiRequest
 
 	// Method available only for mocking purposes
-	RemoveOrganizationUserExecute(r RemoveOrganizationUserApiRequest) (interface{}, *http.Response, error)
+	RemoveOrganizationUserExecute(r RemoveOrganizationUserApiRequest) (any, *http.Response, error)
 
 	/*
 		RenameOrganization Rename One Organization
@@ -680,7 +680,7 @@ func (a *OrganizationsApiService) DeleteOrganizationWithParams(ctx context.Conte
 	}
 }
 
-func (r DeleteOrganizationApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteOrganizationApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteOrganizationExecute(r)
 }
 
@@ -708,13 +708,13 @@ func (a *OrganizationsApiService) DeleteOrganization(ctx context.Context, orgId 
 
 // DeleteOrganizationExecute executes the request
 //
-//	@return interface{}
-func (a *OrganizationsApiService) DeleteOrganizationExecute(r DeleteOrganizationApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *OrganizationsApiService) DeleteOrganizationExecute(r DeleteOrganizationApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.DeleteOrganization")
@@ -799,7 +799,7 @@ func (a *OrganizationsApiService) DeleteOrganizationInvitationWithParams(ctx con
 	}
 }
 
-func (r DeleteOrganizationInvitationApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteOrganizationInvitationApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteOrganizationInvitationExecute(r)
 }
 
@@ -824,13 +824,13 @@ func (a *OrganizationsApiService) DeleteOrganizationInvitation(ctx context.Conte
 
 // DeleteOrganizationInvitationExecute executes the request
 //
-//	@return interface{}
-func (a *OrganizationsApiService) DeleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *OrganizationsApiService) DeleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.DeleteOrganizationInvitation")
@@ -1880,7 +1880,7 @@ func (a *OrganizationsApiService) RemoveOrganizationUserWithParams(ctx context.C
 	}
 }
 
-func (r RemoveOrganizationUserApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r RemoveOrganizationUserApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.RemoveOrganizationUserExecute(r)
 }
 
@@ -1905,13 +1905,13 @@ func (a *OrganizationsApiService) RemoveOrganizationUser(ctx context.Context, or
 
 // RemoveOrganizationUserExecute executes the request
 //
-//	@return interface{}
-func (a *OrganizationsApiService) RemoveOrganizationUserExecute(r RemoveOrganizationUserApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *OrganizationsApiService) RemoveOrganizationUserExecute(r RemoveOrganizationUserApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.RemoveOrganizationUser")

--- a/admin/api_performance_advisor.go
+++ b/admin/api_performance_advisor.go
@@ -200,7 +200,7 @@ type PerformanceAdvisorApi interface {
 	SetServerlessAutoIndexingWithParams(ctx context.Context, args *SetServerlessAutoIndexingApiParams) SetServerlessAutoIndexingApiRequest
 
 	// Method available only for mocking purposes
-	SetServerlessAutoIndexingExecute(r SetServerlessAutoIndexingApiRequest) (interface{}, *http.Response, error)
+	SetServerlessAutoIndexingExecute(r SetServerlessAutoIndexingApiRequest) (any, *http.Response, error)
 }
 
 // PerformanceAdvisorApiService PerformanceAdvisorApi service
@@ -1182,7 +1182,7 @@ func (r SetServerlessAutoIndexingApiRequest) Enable(enable bool) SetServerlessAu
 	return r
 }
 
-func (r SetServerlessAutoIndexingApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r SetServerlessAutoIndexingApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.SetServerlessAutoIndexingExecute(r)
 }
 
@@ -1207,13 +1207,13 @@ func (a *PerformanceAdvisorApiService) SetServerlessAutoIndexing(ctx context.Con
 
 // SetServerlessAutoIndexingExecute executes the request
 //
-//	@return interface{}
-func (a *PerformanceAdvisorApiService) SetServerlessAutoIndexingExecute(r SetServerlessAutoIndexingApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *PerformanceAdvisorApiService) SetServerlessAutoIndexingExecute(r SetServerlessAutoIndexingApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PerformanceAdvisorApiService.SetServerlessAutoIndexing")

--- a/admin/api_performance_advisor.go
+++ b/admin/api_performance_advisor.go
@@ -249,7 +249,7 @@ func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholding(ctx cont
 func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholdingExecute(r DisableSlowOperationThresholdingApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -343,7 +343,7 @@ func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholding(ctx conte
 func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholdingExecute(r EnableSlowOperationThresholdingApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -437,7 +437,7 @@ func (a *PerformanceAdvisorApiService) GetManagedSlowMs(ctx context.Context, gro
 func (a *PerformanceAdvisorApiService) GetManagedSlowMsExecute(r GetManagedSlowMsApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -538,7 +538,7 @@ func (a *PerformanceAdvisorApiService) GetServerlessAutoIndexing(ctx context.Con
 func (a *PerformanceAdvisorApiService) GetServerlessAutoIndexingExecute(r GetServerlessAutoIndexingApiRequest) (bool, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue bool
 	)
@@ -691,7 +691,7 @@ func (a *PerformanceAdvisorApiService) ListSlowQueries(ctx context.Context, grou
 func (a *PerformanceAdvisorApiService) ListSlowQueriesExecute(r ListSlowQueriesApiRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PerformanceAdvisorSlowQueryList
 	)
@@ -846,7 +846,7 @@ func (a *PerformanceAdvisorApiService) ListSlowQueryNamespaces(ctx context.Conte
 func (a *PerformanceAdvisorApiService) ListSlowQueryNamespacesExecute(r ListSlowQueryNamespacesApiRequest) (*Namespaces, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *Namespaces
 	)
@@ -1041,7 +1041,7 @@ func (a *PerformanceAdvisorApiService) ListSuggestedIndexes(ctx context.Context,
 func (a *PerformanceAdvisorApiService) ListSuggestedIndexesExecute(r ListSuggestedIndexesApiRequest) (*PerformanceAdvisorResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PerformanceAdvisorResponse
 	)
@@ -1211,7 +1211,7 @@ func (a *PerformanceAdvisorApiService) SetServerlessAutoIndexing(ctx context.Con
 func (a *PerformanceAdvisorApiService) SetServerlessAutoIndexingExecute(r SetServerlessAutoIndexingApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)

--- a/admin/api_private_endpoint_services.go
+++ b/admin/api_private_endpoint_services.go
@@ -298,7 +298,7 @@ func (a *PrivateEndpointServicesApiService) CreatePrivateEndpoint(ctx context.Co
 func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointExecute(r CreatePrivateEndpointApiRequest) (*PrivateLinkEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PrivateLinkEndpoint
 	)
@@ -420,7 +420,7 @@ func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointService(ctx con
 func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointServiceExecute(r CreatePrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *EndpointService
 	)
@@ -551,7 +551,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpoint(ctx context.Co
 func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -675,7 +675,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointService(ctx con
 func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -803,7 +803,7 @@ func (a *PrivateEndpointServicesApiService) GetPrivateEndpoint(ctx context.Conte
 func (a *PrivateEndpointServicesApiService) GetPrivateEndpointExecute(r GetPrivateEndpointApiRequest) (*PrivateLinkEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PrivateLinkEndpoint
 	)
@@ -927,7 +927,7 @@ func (a *PrivateEndpointServicesApiService) GetPrivateEndpointService(ctx contex
 func (a *PrivateEndpointServicesApiService) GetPrivateEndpointServiceExecute(r GetPrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *EndpointService
 	)
@@ -1040,7 +1040,7 @@ func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSettin
 func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSettingExecute(r GetRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ProjectSettingItem
 	)
@@ -1156,7 +1156,7 @@ func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServices(ctx cont
 func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServicesExecute(r ListPrivateEndpointServicesApiRequest) ([]EndpointService, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []EndpointService
 	)
@@ -1272,7 +1272,7 @@ func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSet
 func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSettingExecute(r ToggleRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ProjectSettingItem
 	)

--- a/admin/api_private_endpoint_services.go
+++ b/admin/api_private_endpoint_services.go
@@ -86,7 +86,7 @@ type PrivateEndpointServicesApi interface {
 	DeletePrivateEndpointWithParams(ctx context.Context, args *DeletePrivateEndpointApiParams) DeletePrivateEndpointApiRequest
 
 	// Method available only for mocking purposes
-	DeletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (interface{}, *http.Response, error)
+	DeletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (any, *http.Response, error)
 
 	/*
 		DeletePrivateEndpointService Remove One Private Endpoint Service for One Provider
@@ -111,7 +111,7 @@ type PrivateEndpointServicesApi interface {
 	DeletePrivateEndpointServiceWithParams(ctx context.Context, args *DeletePrivateEndpointServiceApiParams) DeletePrivateEndpointServiceApiRequest
 
 	// Method available only for mocking purposes
-	DeletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (interface{}, *http.Response, error)
+	DeletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (any, *http.Response, error)
 
 	/*
 		GetPrivateEndpoint Return One Private Endpoint for One Provider
@@ -518,7 +518,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointWithParams(ctx 
 	}
 }
 
-func (r DeletePrivateEndpointApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeletePrivateEndpointApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeletePrivateEndpointExecute(r)
 }
 
@@ -547,13 +547,13 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpoint(ctx context.Co
 
 // DeletePrivateEndpointExecute executes the request
 //
-//	@return interface{}
-func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PrivateEndpointServicesApiService.DeletePrivateEndpoint")
@@ -644,7 +644,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointServiceWithPara
 	}
 }
 
-func (r DeletePrivateEndpointServiceApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeletePrivateEndpointServiceApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeletePrivateEndpointServiceExecute(r)
 }
 
@@ -671,13 +671,13 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointService(ctx con
 
 // DeletePrivateEndpointServiceExecute executes the request
 //
-//	@return interface{}
-func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PrivateEndpointServicesApiService.DeletePrivateEndpointService")

--- a/admin/api_programmatic_api_keys.go
+++ b/admin/api_programmatic_api_keys.go
@@ -35,7 +35,7 @@ type ProgrammaticAPIKeysApi interface {
 	AddProjectApiKeyWithParams(ctx context.Context, args *AddProjectApiKeyApiParams) AddProjectApiKeyApiRequest
 
 	// Method available only for mocking purposes
-	AddProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (interface{}, *http.Response, error)
+	AddProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (any, *http.Response, error)
 
 	/*
 		CreateApiKey Create One Organization API Key
@@ -132,7 +132,7 @@ type ProgrammaticAPIKeysApi interface {
 	DeleteApiKeyWithParams(ctx context.Context, args *DeleteApiKeyApiParams) DeleteApiKeyApiRequest
 
 	// Method available only for mocking purposes
-	DeleteApiKeyExecute(r DeleteApiKeyApiRequest) (interface{}, *http.Response, error)
+	DeleteApiKeyExecute(r DeleteApiKeyApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteApiKeyAccessListEntry Remove One Access List Entry for One Organization API Key
@@ -157,7 +157,7 @@ type ProgrammaticAPIKeysApi interface {
 	DeleteApiKeyAccessListEntryWithParams(ctx context.Context, args *DeleteApiKeyAccessListEntryApiParams) DeleteApiKeyAccessListEntryApiRequest
 
 	// Method available only for mocking purposes
-	DeleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (interface{}, *http.Response, error)
+	DeleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (any, *http.Response, error)
 
 	/*
 		GetApiKey Return One Organization API Key
@@ -300,7 +300,7 @@ type ProgrammaticAPIKeysApi interface {
 	RemoveProjectApiKeyWithParams(ctx context.Context, args *RemoveProjectApiKeyApiParams) RemoveProjectApiKeyApiRequest
 
 	// Method available only for mocking purposes
-	RemoveProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (interface{}, *http.Response, error)
+	RemoveProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (any, *http.Response, error)
 
 	/*
 		UpdateApiKey Update One Organization API Key
@@ -380,7 +380,7 @@ func (a *ProgrammaticAPIKeysApiService) AddProjectApiKeyWithParams(ctx context.C
 	}
 }
 
-func (r AddProjectApiKeyApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r AddProjectApiKeyApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.AddProjectApiKeyExecute(r)
 }
 
@@ -406,13 +406,13 @@ func (a *ProgrammaticAPIKeysApiService) AddProjectApiKey(ctx context.Context, gr
 
 // AddProjectApiKeyExecute executes the request
 //
-//	@return interface{}
-func (a *ProgrammaticAPIKeysApiService) AddProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ProgrammaticAPIKeysApiService) AddProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProgrammaticAPIKeysApiService.AddProjectApiKey")
@@ -917,7 +917,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyWithParams(ctx context.Conte
 	}
 }
 
-func (r DeleteApiKeyApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteApiKeyApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteApiKeyExecute(r)
 }
 
@@ -942,13 +942,13 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKey(ctx context.Context, orgId 
 
 // DeleteApiKeyExecute executes the request
 //
-//	@return interface{}
-func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyExecute(r DeleteApiKeyApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyExecute(r DeleteApiKeyApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProgrammaticAPIKeysApiService.DeleteApiKey")
@@ -1037,7 +1037,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntryWithParams(ct
 	}
 }
 
-func (r DeleteApiKeyAccessListEntryApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteApiKeyAccessListEntryApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteApiKeyAccessListEntryExecute(r)
 }
 
@@ -1064,13 +1064,13 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntry(ctx context.
 
 // DeleteApiKeyAccessListEntryExecute executes the request
 //
-//	@return interface{}
-func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProgrammaticAPIKeysApiService.DeleteApiKeyAccessListEntry")
@@ -1880,7 +1880,7 @@ func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKeyWithParams(ctx contex
 	}
 }
 
-func (r RemoveProjectApiKeyApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r RemoveProjectApiKeyApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.RemoveProjectApiKeyExecute(r)
 }
 
@@ -1905,13 +1905,13 @@ func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKey(ctx context.Context,
 
 // RemoveProjectApiKeyExecute executes the request
 //
-//	@return interface{}
-func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProgrammaticAPIKeysApiService.RemoveProjectApiKey")

--- a/admin/api_programmatic_api_keys.go
+++ b/admin/api_programmatic_api_keys.go
@@ -410,7 +410,7 @@ func (a *ProgrammaticAPIKeysApiService) AddProjectApiKey(ctx context.Context, gr
 func (a *ProgrammaticAPIKeysApiService) AddProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -531,7 +531,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateApiKey(ctx context.Context, orgId 
 func (a *ProgrammaticAPIKeysApiService) CreateApiKeyExecute(r CreateApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiKeyUserDetails
 	)
@@ -683,7 +683,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessList(ctx context.Conte
 func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessListExecute(r CreateApiKeyAccessListApiRequest) (*PaginatedApiUserAccessListResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiUserAccessListResponse
 	)
@@ -825,7 +825,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKey(ctx context.Context,
 func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKeyExecute(r CreateProjectApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiKeyUserDetails
 	)
@@ -946,7 +946,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKey(ctx context.Context, orgId 
 func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyExecute(r DeleteApiKeyApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1068,7 +1068,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntry(ctx context.
 func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1186,7 +1186,7 @@ func (a *ProgrammaticAPIKeysApiService) GetApiKey(ctx context.Context, orgId str
 func (a *ProgrammaticAPIKeysApiService) GetApiKeyExecute(r GetApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiKeyUserDetails
 	)
@@ -1308,7 +1308,7 @@ func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessList(ctx context.Context,
 func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessListExecute(r GetApiKeyAccessListApiRequest) (*UserAccessListResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *UserAccessListResponse
 	)
@@ -1453,7 +1453,7 @@ func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntries(ctx context
 func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntriesExecute(r ListApiKeyAccessListsEntriesApiRequest) (*PaginatedApiUserAccessListResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiUserAccessListResponse
 	)
@@ -1613,7 +1613,7 @@ func (a *ProgrammaticAPIKeysApiService) ListApiKeys(ctx context.Context, orgId s
 func (a *ProgrammaticAPIKeysApiService) ListApiKeysExecute(r ListApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiApiUser
 	)
@@ -1772,7 +1772,7 @@ func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeys(ctx context.Context, 
 func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeysExecute(r ListProjectApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiApiUser
 	)
@@ -1909,7 +1909,7 @@ func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKey(ctx context.Context,
 func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -2030,7 +2030,7 @@ func (a *ProgrammaticAPIKeysApiService) UpdateApiKey(ctx context.Context, orgId 
 func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyExecute(r UpdateApiKeyApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiKeyUserDetails
 	)
@@ -2183,7 +2183,7 @@ func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyRoles(ctx context.Context, g
 func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyRolesExecute(r UpdateApiKeyRolesApiRequest) (*ApiKeyUserDetails, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiKeyUserDetails
 	)

--- a/admin/api_project_ip_access_list.go
+++ b/admin/api_project_ip_access_list.go
@@ -58,7 +58,7 @@ type ProjectIPAccessListApi interface {
 	DeleteProjectIpAccessListWithParams(ctx context.Context, args *DeleteProjectIpAccessListApiParams) DeleteProjectIpAccessListApiRequest
 
 	// Method available only for mocking purposes
-	DeleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (interface{}, *http.Response, error)
+	DeleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (any, *http.Response, error)
 
 	/*
 		GetProjectIpAccessListStatus Return Status of One Project IP Access List Entry
@@ -324,7 +324,7 @@ func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessListWithParams(ctx 
 	}
 }
 
-func (r DeleteProjectIpAccessListApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteProjectIpAccessListApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteProjectIpAccessListExecute(r)
 }
 
@@ -349,13 +349,13 @@ func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessList(ctx context.Co
 
 // DeleteProjectIpAccessListExecute executes the request
 //
-//	@return interface{}
-func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProjectIPAccessListApiService.DeleteProjectIpAccessList")

--- a/admin/api_project_ip_access_list.go
+++ b/admin/api_project_ip_access_list.go
@@ -211,7 +211,7 @@ func (a *ProjectIPAccessListApiService) CreateProjectIpAccessList(ctx context.Co
 func (a *ProjectIPAccessListApiService) CreateProjectIpAccessListExecute(r CreateProjectIpAccessListApiRequest) (*PaginatedNetworkAccess, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedNetworkAccess
 	)
@@ -353,7 +353,7 @@ func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessList(ctx context.Co
 func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -470,7 +470,7 @@ func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatus(ctx context
 func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatusExecute(r GetProjectIpAccessListStatusApiRequest) (*NetworkPermissionEntryStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *NetworkPermissionEntryStatus
 	)
@@ -587,7 +587,7 @@ func (a *ProjectIPAccessListApiService) GetProjectIpList(ctx context.Context, gr
 func (a *ProjectIPAccessListApiService) GetProjectIpListExecute(r GetProjectIpListApiRequest) (*NetworkPermissionEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *NetworkPermissionEntry
 	)
@@ -726,7 +726,7 @@ func (a *ProjectIPAccessListApiService) ListProjectIpAccessLists(ctx context.Con
 func (a *ProjectIPAccessListApiService) ListProjectIpAccessListsExecute(r ListProjectIpAccessListsApiRequest) (*PaginatedNetworkAccess, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedNetworkAccess
 	)

--- a/admin/api_projects.go
+++ b/admin/api_projects.go
@@ -108,7 +108,7 @@ type ProjectsApi interface {
 	DeleteProjectWithParams(ctx context.Context, args *DeleteProjectApiParams) DeleteProjectApiRequest
 
 	// Method available only for mocking purposes
-	DeleteProjectExecute(r DeleteProjectApiRequest) (interface{}, *http.Response, error)
+	DeleteProjectExecute(r DeleteProjectApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteProjectInvitation Cancel One Project Invitation
@@ -136,7 +136,7 @@ type ProjectsApi interface {
 	DeleteProjectInvitationWithParams(ctx context.Context, args *DeleteProjectInvitationApiParams) DeleteProjectInvitationApiRequest
 
 	// Method available only for mocking purposes
-	DeleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (interface{}, *http.Response, error)
+	DeleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteProjectLimit Remove One Project Limit
@@ -160,7 +160,7 @@ type ProjectsApi interface {
 	DeleteProjectLimitWithParams(ctx context.Context, args *DeleteProjectLimitApiParams) DeleteProjectLimitApiRequest
 
 	// Method available only for mocking purposes
-	DeleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (interface{}, *http.Response, error)
+	DeleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (any, *http.Response, error)
 
 	/*
 		GetProject Return One Project
@@ -1021,7 +1021,7 @@ func (a *ProjectsApiService) DeleteProjectWithParams(ctx context.Context, args *
 	}
 }
 
-func (r DeleteProjectApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteProjectApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteProjectExecute(r)
 }
 
@@ -1044,13 +1044,13 @@ func (a *ProjectsApiService) DeleteProject(ctx context.Context, groupId string) 
 
 // DeleteProjectExecute executes the request
 //
-//	@return interface{}
-func (a *ProjectsApiService) DeleteProjectExecute(r DeleteProjectApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ProjectsApiService) DeleteProjectExecute(r DeleteProjectApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProjectsApiService.DeleteProject")
@@ -1135,7 +1135,7 @@ func (a *ProjectsApiService) DeleteProjectInvitationWithParams(ctx context.Conte
 	}
 }
 
-func (r DeleteProjectInvitationApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteProjectInvitationApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteProjectInvitationExecute(r)
 }
 
@@ -1162,15 +1162,15 @@ func (a *ProjectsApiService) DeleteProjectInvitation(ctx context.Context, groupI
 
 // DeleteProjectInvitationExecute executes the request
 //
-//	@return interface{}
+//	@return any
 //
 // Deprecated
-func (a *ProjectsApiService) DeleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (interface{}, *http.Response, error) {
+func (a *ProjectsApiService) DeleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProjectsApiService.DeleteProjectInvitation")
@@ -1256,7 +1256,7 @@ func (a *ProjectsApiService) DeleteProjectLimitWithParams(ctx context.Context, a
 	}
 }
 
-func (r DeleteProjectLimitApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteProjectLimitApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteProjectLimitExecute(r)
 }
 
@@ -1281,13 +1281,13 @@ func (a *ProjectsApiService) DeleteProjectLimit(ctx context.Context, limitName s
 
 // DeleteProjectLimitExecute executes the request
 //
-//	@return interface{}
-func (a *ProjectsApiService) DeleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ProjectsApiService) DeleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProjectsApiService.DeleteProjectLimit")

--- a/admin/api_projects.go
+++ b/admin/api_projects.go
@@ -682,7 +682,7 @@ func (a *ProjectsApiService) AddUserToProject(ctx context.Context, groupId strin
 func (a *ProjectsApiService) AddUserToProjectExecute(r AddUserToProjectApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *OrganizationInvitation
 	)
@@ -806,7 +806,7 @@ func (a *ProjectsApiService) CreateProject(ctx context.Context, group *Group) Cr
 func (a *ProjectsApiService) CreateProjectExecute(r CreateProjectApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *Group
 	)
@@ -932,7 +932,7 @@ func (a *ProjectsApiService) CreateProjectInvitation(ctx context.Context, groupI
 func (a *ProjectsApiService) CreateProjectInvitationExecute(r CreateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupInvitation
 	)
@@ -1048,7 +1048,7 @@ func (a *ProjectsApiService) DeleteProject(ctx context.Context, groupId string) 
 func (a *ProjectsApiService) DeleteProjectExecute(r DeleteProjectApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1168,7 +1168,7 @@ func (a *ProjectsApiService) DeleteProjectInvitation(ctx context.Context, groupI
 func (a *ProjectsApiService) DeleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1285,7 +1285,7 @@ func (a *ProjectsApiService) DeleteProjectLimit(ctx context.Context, limitName s
 func (a *ProjectsApiService) DeleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1397,7 +1397,7 @@ func (a *ProjectsApiService) GetProject(ctx context.Context, groupId string) Get
 func (a *ProjectsApiService) GetProjectExecute(r GetProjectApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *Group
 	)
@@ -1508,7 +1508,7 @@ func (a *ProjectsApiService) GetProjectByName(ctx context.Context, groupName str
 func (a *ProjectsApiService) GetProjectByNameExecute(r GetProjectByNameApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *Group
 	)
@@ -1628,7 +1628,7 @@ func (a *ProjectsApiService) GetProjectInvitation(ctx context.Context, groupId s
 func (a *ProjectsApiService) GetProjectInvitationExecute(r GetProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupInvitation
 	)
@@ -1785,7 +1785,7 @@ func (a *ProjectsApiService) GetProjectLTSVersions(ctx context.Context, groupId 
 func (a *ProjectsApiService) GetProjectLTSVersionsExecute(r GetProjectLTSVersionsApiRequest) (*PaginatedAvailableVersion, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedAvailableVersion
 	)
@@ -1924,7 +1924,7 @@ func (a *ProjectsApiService) GetProjectLimit(ctx context.Context, limitName stri
 func (a *ProjectsApiService) GetProjectLimitExecute(r GetProjectLimitApiRequest) (*DataFederationLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataFederationLimit
 	)
@@ -2036,7 +2036,7 @@ func (a *ProjectsApiService) GetProjectSettings(ctx context.Context, groupId str
 func (a *ProjectsApiService) GetProjectSettingsExecute(r GetProjectSettingsApiRequest) (*GroupSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupSettings
 	)
@@ -2160,7 +2160,7 @@ func (a *ProjectsApiService) ListProjectInvitations(ctx context.Context, groupId
 func (a *ProjectsApiService) ListProjectInvitationsExecute(r ListProjectInvitationsApiRequest) ([]GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []GroupInvitation
 	)
@@ -2274,7 +2274,7 @@ func (a *ProjectsApiService) ListProjectLimits(ctx context.Context, groupId stri
 func (a *ProjectsApiService) ListProjectLimitsExecute(r ListProjectLimitsApiRequest) ([]DataFederationLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []DataFederationLimit
 	)
@@ -2430,7 +2430,7 @@ func (a *ProjectsApiService) ListProjectUsers(ctx context.Context, groupId strin
 func (a *ProjectsApiService) ListProjectUsersExecute(r ListProjectUsersApiRequest) (*PaginatedAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedAppUser
 	)
@@ -2598,7 +2598,7 @@ func (a *ProjectsApiService) ListProjects(ctx context.Context) ListProjectsApiRe
 func (a *ProjectsApiService) ListProjectsExecute(r ListProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedAtlasGroup
 	)
@@ -2733,7 +2733,7 @@ func (a *ProjectsApiService) MigrateProjectToAnotherOrg(ctx context.Context, gro
 func (a *ProjectsApiService) MigrateProjectToAnotherOrgExecute(r MigrateProjectToAnotherOrgApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *Group
 	)
@@ -2852,7 +2852,7 @@ func (a *ProjectsApiService) RemoveProjectUser(ctx context.Context, groupId stri
 func (a *ProjectsApiService) RemoveProjectUserExecute(r RemoveProjectUserApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -2949,7 +2949,7 @@ func (a *ProjectsApiService) ReturnAllIPAddresses(ctx context.Context, groupId s
 func (a *ProjectsApiService) ReturnAllIPAddressesExecute(r ReturnAllIPAddressesApiRequest) (*GroupIPAddresses, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupIPAddresses
 	)
@@ -3071,7 +3071,7 @@ func (a *ProjectsApiService) SetProjectLimit(ctx context.Context, limitName stri
 func (a *ProjectsApiService) SetProjectLimitExecute(r SetProjectLimitApiRequest) (*DataFederationLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *DataFederationLimit
 	)
@@ -3192,7 +3192,7 @@ func (a *ProjectsApiService) UpdateProject(ctx context.Context, groupId string, 
 func (a *ProjectsApiService) UpdateProjectExecute(r UpdateProjectApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *Group
 	)
@@ -3316,7 +3316,7 @@ func (a *ProjectsApiService) UpdateProjectInvitation(ctx context.Context, groupI
 func (a *ProjectsApiService) UpdateProjectInvitationExecute(r UpdateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupInvitation
 	)
@@ -3445,7 +3445,7 @@ func (a *ProjectsApiService) UpdateProjectInvitationById(ctx context.Context, gr
 func (a *ProjectsApiService) UpdateProjectInvitationByIdExecute(r UpdateProjectInvitationByIdApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupInvitation
 	)
@@ -3571,7 +3571,7 @@ func (a *ProjectsApiService) UpdateProjectRoles(ctx context.Context, groupId str
 func (a *ProjectsApiService) UpdateProjectRolesExecute(r UpdateProjectRolesApiRequest) (*UpdateGroupRolesForUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *UpdateGroupRolesForUser
 	)
@@ -3692,7 +3692,7 @@ func (a *ProjectsApiService) UpdateProjectSettings(ctx context.Context, groupId 
 func (a *ProjectsApiService) UpdateProjectSettingsExecute(r UpdateProjectSettingsApiRequest) (*GroupSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *GroupSettings
 	)

--- a/admin/api_push_based_log_export.go
+++ b/admin/api_push_based_log_export.go
@@ -157,7 +157,7 @@ func (a *PushBasedLogExportApiService) CreatePushBasedLogConfiguration(ctx conte
 func (a *PushBasedLogExportApiService) CreatePushBasedLogConfigurationExecute(r CreatePushBasedLogConfigurationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -256,7 +256,7 @@ func (a *PushBasedLogExportApiService) DeletePushBasedLogConfiguration(ctx conte
 func (a *PushBasedLogExportApiService) DeletePushBasedLogConfigurationExecute(r DeletePushBasedLogConfigurationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -352,7 +352,7 @@ func (a *PushBasedLogExportApiService) GetPushBasedLogConfiguration(ctx context.
 func (a *PushBasedLogExportApiService) GetPushBasedLogConfigurationExecute(r GetPushBasedLogConfigurationApiRequest) (*PushBasedLogExportProject, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PushBasedLogExportProject
 	)
@@ -465,7 +465,7 @@ func (a *PushBasedLogExportApiService) UpdatePushBasedLogConfiguration(ctx conte
 func (a *PushBasedLogExportApiService) UpdatePushBasedLogConfigurationExecute(r UpdatePushBasedLogConfigurationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPatch
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 

--- a/admin/api_resource_policies.go
+++ b/admin/api_resource_policies.go
@@ -232,7 +232,7 @@ func (a *ResourcePoliciesApiService) CreateAtlasResourcePolicy(ctx context.Conte
 func (a *ResourcePoliciesApiService) CreateAtlasResourcePolicyExecute(r CreateAtlasResourcePolicyApiRequest) (*ApiAtlasResourcePolicy, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiAtlasResourcePolicy
 	)
@@ -353,7 +353,7 @@ func (a *ResourcePoliciesApiService) DeleteAtlasResourcePolicy(ctx context.Conte
 func (a *ResourcePoliciesApiService) DeleteAtlasResourcePolicyExecute(r DeleteAtlasResourcePolicyApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -465,7 +465,7 @@ func (a *ResourcePoliciesApiService) GetAtlasResourcePolicies(ctx context.Contex
 func (a *ResourcePoliciesApiService) GetAtlasResourcePoliciesExecute(r GetAtlasResourcePoliciesApiRequest) ([]ApiAtlasResourcePolicy, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []ApiAtlasResourcePolicy
 	)
@@ -581,7 +581,7 @@ func (a *ResourcePoliciesApiService) GetAtlasResourcePolicy(ctx context.Context,
 func (a *ResourcePoliciesApiService) GetAtlasResourcePolicyExecute(r GetAtlasResourcePolicyApiRequest) (*ApiAtlasResourcePolicy, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiAtlasResourcePolicy
 	)
@@ -693,7 +693,7 @@ func (a *ResourcePoliciesApiService) GetResourcesNonCompliant(ctx context.Contex
 func (a *ResourcePoliciesApiService) GetResourcesNonCompliantExecute(r GetResourcesNonCompliantApiRequest) ([]ApiAtlasNonCompliantResource, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []ApiAtlasNonCompliantResource
 	)
@@ -813,7 +813,7 @@ func (a *ResourcePoliciesApiService) UpdateAtlasResourcePolicy(ctx context.Conte
 func (a *ResourcePoliciesApiService) UpdateAtlasResourcePolicyExecute(r UpdateAtlasResourcePolicyApiRequest) (*ApiAtlasResourcePolicy, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiAtlasResourcePolicy
 	)
@@ -934,7 +934,7 @@ func (a *ResourcePoliciesApiService) ValidateAtlasResourcePolicy(ctx context.Con
 func (a *ResourcePoliciesApiService) ValidateAtlasResourcePolicyExecute(r ValidateAtlasResourcePolicyApiRequest) (*ApiAtlasResourcePolicy, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ApiAtlasResourcePolicy
 	)

--- a/admin/api_resource_policies.go
+++ b/admin/api_resource_policies.go
@@ -58,7 +58,7 @@ type ResourcePoliciesApi interface {
 	DeleteAtlasResourcePolicyWithParams(ctx context.Context, args *DeleteAtlasResourcePolicyApiParams) DeleteAtlasResourcePolicyApiRequest
 
 	// Method available only for mocking purposes
-	DeleteAtlasResourcePolicyExecute(r DeleteAtlasResourcePolicyApiRequest) (interface{}, *http.Response, error)
+	DeleteAtlasResourcePolicyExecute(r DeleteAtlasResourcePolicyApiRequest) (any, *http.Response, error)
 
 	/*
 		GetAtlasResourcePolicies Return all Atlas Resource Policies
@@ -324,7 +324,7 @@ func (a *ResourcePoliciesApiService) DeleteAtlasResourcePolicyWithParams(ctx con
 	}
 }
 
-func (r DeleteAtlasResourcePolicyApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteAtlasResourcePolicyApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteAtlasResourcePolicyExecute(r)
 }
 
@@ -349,13 +349,13 @@ func (a *ResourcePoliciesApiService) DeleteAtlasResourcePolicy(ctx context.Conte
 
 // DeleteAtlasResourcePolicyExecute executes the request
 //
-//	@return interface{}
-func (a *ResourcePoliciesApiService) DeleteAtlasResourcePolicyExecute(r DeleteAtlasResourcePolicyApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ResourcePoliciesApiService) DeleteAtlasResourcePolicyExecute(r DeleteAtlasResourcePolicyApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ResourcePoliciesApiService.DeleteAtlasResourcePolicy")

--- a/admin/api_rolling_index.go
+++ b/admin/api_rolling_index.go
@@ -92,7 +92,7 @@ func (a *RollingIndexApiService) CreateRollingIndex(ctx context.Context, groupId
 func (a *RollingIndexApiService) CreateRollingIndexExecute(r CreateRollingIndexApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 

--- a/admin/api_root.go
+++ b/admin/api_root.go
@@ -99,7 +99,7 @@ func (a *RootApiService) GetSystemStatus(ctx context.Context) GetSystemStatusApi
 func (a *RootApiService) GetSystemStatusExecute(r GetSystemStatusApiRequest) (*SystemStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *SystemStatus
 	)
@@ -204,7 +204,7 @@ func (a *RootApiService) ReturnAllControlPlaneIPAddresses(ctx context.Context) R
 func (a *RootApiService) ReturnAllControlPlaneIPAddressesExecute(r ReturnAllControlPlaneIPAddressesApiRequest) (*ControlPlaneIPAddresses, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ControlPlaneIPAddresses
 	)

--- a/admin/api_serverless_instances.go
+++ b/admin/api_serverless_instances.go
@@ -185,7 +185,7 @@ func (a *ServerlessInstancesApiService) CreateServerlessInstance(ctx context.Con
 func (a *ServerlessInstancesApiService) CreateServerlessInstanceExecute(r CreateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ServerlessInstanceDescription
 	)
@@ -306,7 +306,7 @@ func (a *ServerlessInstancesApiService) DeleteServerlessInstance(ctx context.Con
 func (a *ServerlessInstancesApiService) DeleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -423,7 +423,7 @@ func (a *ServerlessInstancesApiService) GetServerlessInstance(ctx context.Contex
 func (a *ServerlessInstancesApiService) GetServerlessInstanceExecute(r GetServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ServerlessInstanceDescription
 	)
@@ -562,7 +562,7 @@ func (a *ServerlessInstancesApiService) ListServerlessInstances(ctx context.Cont
 func (a *ServerlessInstancesApiService) ListServerlessInstancesExecute(r ListServerlessInstancesApiRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedServerlessInstanceDescription
 	)
@@ -703,7 +703,7 @@ func (a *ServerlessInstancesApiService) UpdateServerlessInstance(ctx context.Con
 func (a *ServerlessInstancesApiService) UpdateServerlessInstanceExecute(r UpdateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ServerlessInstanceDescription
 	)

--- a/admin/api_serverless_instances.go
+++ b/admin/api_serverless_instances.go
@@ -58,7 +58,7 @@ type ServerlessInstancesApi interface {
 	DeleteServerlessInstanceWithParams(ctx context.Context, args *DeleteServerlessInstanceApiParams) DeleteServerlessInstanceApiRequest
 
 	// Method available only for mocking purposes
-	DeleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (interface{}, *http.Response, error)
+	DeleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (any, *http.Response, error)
 
 	/*
 		GetServerlessInstance Return One Serverless Instance from One Project
@@ -277,7 +277,7 @@ func (a *ServerlessInstancesApiService) DeleteServerlessInstanceWithParams(ctx c
 	}
 }
 
-func (r DeleteServerlessInstanceApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteServerlessInstanceApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteServerlessInstanceExecute(r)
 }
 
@@ -302,13 +302,13 @@ func (a *ServerlessInstancesApiService) DeleteServerlessInstance(ctx context.Con
 
 // DeleteServerlessInstanceExecute executes the request
 //
-//	@return interface{}
-func (a *ServerlessInstancesApiService) DeleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ServerlessInstancesApiService) DeleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ServerlessInstancesApiService.DeleteServerlessInstance")

--- a/admin/api_serverless_private_endpoints.go
+++ b/admin/api_serverless_private_endpoints.go
@@ -199,7 +199,7 @@ func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpoint(c
 func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpointExecute(r CreateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ServerlessTenantEndpoint
 	)
@@ -326,7 +326,7 @@ func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpoint(c
 func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -449,7 +449,7 @@ func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpoint(ctx 
 func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpointExecute(r GetServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ServerlessTenantEndpoint
 	)
@@ -567,7 +567,7 @@ func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpoints(ct
 func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpointsExecute(r ListServerlessPrivateEndpointsApiRequest) ([]ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue []ServerlessTenantEndpoint
 	)
@@ -693,7 +693,7 @@ func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpoint(c
 func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpointExecute(r UpdateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ServerlessTenantEndpoint
 	)

--- a/admin/api_serverless_private_endpoints.go
+++ b/admin/api_serverless_private_endpoints.go
@@ -62,7 +62,7 @@ type ServerlessPrivateEndpointsApi interface {
 	DeleteServerlessPrivateEndpointWithParams(ctx context.Context, args *DeleteServerlessPrivateEndpointApiParams) DeleteServerlessPrivateEndpointApiRequest
 
 	// Method available only for mocking purposes
-	DeleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (interface{}, *http.Response, error)
+	DeleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (any, *http.Response, error)
 
 	/*
 		GetServerlessPrivateEndpoint Return One Private Endpoint for One Serverless Instance
@@ -295,7 +295,7 @@ func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpointWi
 	}
 }
 
-func (r DeleteServerlessPrivateEndpointApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteServerlessPrivateEndpointApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteServerlessPrivateEndpointExecute(r)
 }
 
@@ -322,13 +322,13 @@ func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpoint(c
 
 // DeleteServerlessPrivateEndpointExecute executes the request
 //
-//	@return interface{}
-func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ServerlessPrivateEndpointsApiService.DeleteServerlessPrivateEndpoint")

--- a/admin/api_shared_tier_restore_jobs.go
+++ b/admin/api_shared_tier_restore_jobs.go
@@ -144,7 +144,7 @@ func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJob(ct
 func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJobExecute(r CreateSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *TenantRestore
 	)
@@ -271,7 +271,7 @@ func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJob(ctx c
 func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJobExecute(r GetSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *TenantRestore
 	)
@@ -389,7 +389,7 @@ func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobs(ctx
 func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobsExecute(r ListSharedClusterBackupRestoreJobsApiRequest) (*PaginatedTenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedTenantRestore
 	)

--- a/admin/api_shared_tier_snapshots.go
+++ b/admin/api_shared_tier_snapshots.go
@@ -144,7 +144,7 @@ func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackup(ctx context.
 func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackupExecute(r DownloadSharedClusterBackupApiRequest) (*TenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *TenantRestore
 	)
@@ -271,7 +271,7 @@ func (a *SharedTierSnapshotsApiService) GetSharedClusterBackup(ctx context.Conte
 func (a *SharedTierSnapshotsApiService) GetSharedClusterBackupExecute(r GetSharedClusterBackupApiRequest) (*BackupTenantSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *BackupTenantSnapshot
 	)
@@ -389,7 +389,7 @@ func (a *SharedTierSnapshotsApiService) ListSharedClusterBackups(ctx context.Con
 func (a *SharedTierSnapshotsApiService) ListSharedClusterBackupsExecute(r ListSharedClusterBackupsApiRequest) (*PaginatedTenantSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedTenantSnapshot
 	)

--- a/admin/api_streams.go
+++ b/admin/api_streams.go
@@ -608,7 +608,7 @@ func (a *StreamsApiService) AcceptVPCPeeringConnection(ctx context.Context, grou
 func (a *StreamsApiService) AcceptVPCPeeringConnectionExecute(r AcceptVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -734,7 +734,7 @@ func (a *StreamsApiService) CreateStreamConnection(ctx context.Context, groupId 
 func (a *StreamsApiService) CreateStreamConnectionExecute(r CreateStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *StreamsConnection
 	)
@@ -855,7 +855,7 @@ func (a *StreamsApiService) CreateStreamInstance(ctx context.Context, groupId st
 func (a *StreamsApiService) CreateStreamInstanceExecute(r CreateStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *StreamsTenant
 	)
@@ -975,7 +975,7 @@ func (a *StreamsApiService) CreateStreamInstanceWithSampleConnections(ctx contex
 func (a *StreamsApiService) CreateStreamInstanceWithSampleConnectionsExecute(r CreateStreamInstanceWithSampleConnectionsApiRequest) (*StreamsTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *StreamsTenant
 	)
@@ -1100,7 +1100,7 @@ func (a *StreamsApiService) CreateStreamProcessor(ctx context.Context, groupId s
 func (a *StreamsApiService) CreateStreamProcessorExecute(r CreateStreamProcessorApiRequest) (*StreamsProcessor, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *StreamsProcessor
 	)
@@ -1227,7 +1227,7 @@ func (a *StreamsApiService) DeleteStreamConnection(ctx context.Context, groupId 
 func (a *StreamsApiService) DeleteStreamConnectionExecute(r DeleteStreamConnectionApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1345,7 +1345,7 @@ func (a *StreamsApiService) DeleteStreamInstance(ctx context.Context, groupId st
 func (a *StreamsApiService) DeleteStreamInstanceExecute(r DeleteStreamInstanceApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1465,7 +1465,7 @@ func (a *StreamsApiService) DeleteStreamProcessor(ctx context.Context, groupId s
 func (a *StreamsApiService) DeleteStreamProcessorExecute(r DeleteStreamProcessorApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -1568,7 +1568,7 @@ func (a *StreamsApiService) DeleteVPCPeeringConnection(ctx context.Context, grou
 func (a *StreamsApiService) DeleteVPCPeeringConnectionExecute(r DeleteVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -1703,7 +1703,7 @@ func (a *StreamsApiService) DownloadStreamTenantAuditLogs(ctx context.Context, g
 func (a *StreamsApiService) DownloadStreamTenantAuditLogsExecute(r DownloadStreamTenantAuditLogsApiRequest) (io.ReadCloser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue io.ReadCloser
 	)
@@ -1831,7 +1831,7 @@ func (a *StreamsApiService) GetStreamConnection(ctx context.Context, groupId str
 func (a *StreamsApiService) GetStreamConnectionExecute(r GetStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *StreamsConnection
 	)
@@ -1958,7 +1958,7 @@ func (a *StreamsApiService) GetStreamInstance(ctx context.Context, groupId strin
 func (a *StreamsApiService) GetStreamInstanceExecute(r GetStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *StreamsTenant
 	)
@@ -2083,7 +2083,7 @@ func (a *StreamsApiService) GetStreamProcessor(ctx context.Context, groupId stri
 func (a *StreamsApiService) GetStreamProcessorExecute(r GetStreamProcessorApiRequest) (*StreamsProcessorWithStats, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *StreamsProcessorWithStats
 	)
@@ -2212,7 +2212,7 @@ func (a *StreamsApiService) GetVPCPeeringConnections(ctx context.Context, groupI
 func (a *StreamsApiService) GetVPCPeeringConnectionsExecute(r GetVPCPeeringConnectionsApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -2345,7 +2345,7 @@ func (a *StreamsApiService) ListStreamConnections(ctx context.Context, groupId s
 func (a *StreamsApiService) ListStreamConnectionsExecute(r ListStreamConnectionsApiRequest) (*PaginatedApiStreamsConnection, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiStreamsConnection
 	)
@@ -2489,7 +2489,7 @@ func (a *StreamsApiService) ListStreamInstances(ctx context.Context, groupId str
 func (a *StreamsApiService) ListStreamInstancesExecute(r ListStreamInstancesApiRequest) (*PaginatedApiStreamsTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiStreamsTenant
 	)
@@ -2646,7 +2646,7 @@ func (a *StreamsApiService) ListStreamProcessors(ctx context.Context, groupId st
 func (a *StreamsApiService) ListStreamProcessorsExecute(r ListStreamProcessorsApiRequest) (*PaginatedApiStreamsStreamProcessorWithStats, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiStreamsStreamProcessorWithStats
 	)
@@ -2784,7 +2784,7 @@ func (a *StreamsApiService) RejectVPCPeeringConnection(ctx context.Context, grou
 func (a *StreamsApiService) RejectVPCPeeringConnectionExecute(r RejectVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -2906,7 +2906,7 @@ func (a *StreamsApiService) StartStreamProcessor(ctx context.Context, groupId st
 func (a *StreamsApiService) StartStreamProcessorExecute(r StartStreamProcessorApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -3029,7 +3029,7 @@ func (a *StreamsApiService) StopStreamProcessor(ctx context.Context, groupId str
 func (a *StreamsApiService) StopStreamProcessorExecute(r StopStreamProcessorApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -3156,7 +3156,7 @@ func (a *StreamsApiService) UpdateStreamConnection(ctx context.Context, groupId 
 func (a *StreamsApiService) UpdateStreamConnectionExecute(r UpdateStreamConnectionApiRequest) (*StreamsConnection, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *StreamsConnection
 	)
@@ -3283,7 +3283,7 @@ func (a *StreamsApiService) UpdateStreamInstance(ctx context.Context, groupId st
 func (a *StreamsApiService) UpdateStreamInstanceExecute(r UpdateStreamInstanceApiRequest) (*StreamsTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *StreamsTenant
 	)

--- a/admin/api_streams.go
+++ b/admin/api_streams.go
@@ -35,7 +35,7 @@ type StreamsApi interface {
 	AcceptVPCPeeringConnectionWithParams(ctx context.Context, args *AcceptVPCPeeringConnectionApiParams) AcceptVPCPeeringConnectionApiRequest
 
 	// Method available only for mocking purposes
-	AcceptVPCPeeringConnectionExecute(r AcceptVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error)
+	AcceptVPCPeeringConnectionExecute(r AcceptVPCPeeringConnectionApiRequest) (any, *http.Response, error)
 
 	/*
 		CreateStreamConnection Create One Connection
@@ -96,7 +96,7 @@ type StreamsApi interface {
 		@param body Details to create one streams instance in the specified project.
 		@return CreateStreamInstanceWithSampleConnectionsApiRequest
 	*/
-	CreateStreamInstanceWithSampleConnections(ctx context.Context, groupId string, body *interface{}) CreateStreamInstanceWithSampleConnectionsApiRequest
+	CreateStreamInstanceWithSampleConnections(ctx context.Context, groupId string, body *any) CreateStreamInstanceWithSampleConnectionsApiRequest
 	/*
 		CreateStreamInstanceWithSampleConnections Create One Stream Instance With Sample Connections
 
@@ -158,7 +158,7 @@ type StreamsApi interface {
 	DeleteStreamConnectionWithParams(ctx context.Context, args *DeleteStreamConnectionApiParams) DeleteStreamConnectionApiRequest
 
 	// Method available only for mocking purposes
-	DeleteStreamConnectionExecute(r DeleteStreamConnectionApiRequest) (interface{}, *http.Response, error)
+	DeleteStreamConnectionExecute(r DeleteStreamConnectionApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteStreamInstance Delete One Stream Instance
@@ -182,7 +182,7 @@ type StreamsApi interface {
 	DeleteStreamInstanceWithParams(ctx context.Context, args *DeleteStreamInstanceApiParams) DeleteStreamInstanceApiRequest
 
 	// Method available only for mocking purposes
-	DeleteStreamInstanceExecute(r DeleteStreamInstanceApiRequest) (interface{}, *http.Response, error)
+	DeleteStreamInstanceExecute(r DeleteStreamInstanceApiRequest) (any, *http.Response, error)
 
 	/*
 		DeleteStreamProcessor Delete One Stream Processor
@@ -231,7 +231,7 @@ type StreamsApi interface {
 	DeleteVPCPeeringConnectionWithParams(ctx context.Context, args *DeleteVPCPeeringConnectionApiParams) DeleteVPCPeeringConnectionApiRequest
 
 	// Method available only for mocking purposes
-	DeleteVPCPeeringConnectionExecute(r DeleteVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error)
+	DeleteVPCPeeringConnectionExecute(r DeleteVPCPeeringConnectionApiRequest) (any, *http.Response, error)
 
 	/*
 		DownloadStreamTenantAuditLogs Download Audit Logs for One Atlas Stream Processing Instance
@@ -447,7 +447,7 @@ type StreamsApi interface {
 	RejectVPCPeeringConnectionWithParams(ctx context.Context, args *RejectVPCPeeringConnectionApiParams) RejectVPCPeeringConnectionApiRequest
 
 	// Method available only for mocking purposes
-	RejectVPCPeeringConnectionExecute(r RejectVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error)
+	RejectVPCPeeringConnectionExecute(r RejectVPCPeeringConnectionApiRequest) (any, *http.Response, error)
 
 	/*
 		StartStreamProcessor Start One Stream Processor
@@ -472,7 +472,7 @@ type StreamsApi interface {
 	StartStreamProcessorWithParams(ctx context.Context, args *StartStreamProcessorApiParams) StartStreamProcessorApiRequest
 
 	// Method available only for mocking purposes
-	StartStreamProcessorExecute(r StartStreamProcessorApiRequest) (interface{}, *http.Response, error)
+	StartStreamProcessorExecute(r StartStreamProcessorApiRequest) (any, *http.Response, error)
 
 	/*
 		StopStreamProcessor Stop One Stream Processor
@@ -497,7 +497,7 @@ type StreamsApi interface {
 	StopStreamProcessorWithParams(ctx context.Context, args *StopStreamProcessorApiParams) StopStreamProcessorApiRequest
 
 	// Method available only for mocking purposes
-	StopStreamProcessorExecute(r StopStreamProcessorApiRequest) (interface{}, *http.Response, error)
+	StopStreamProcessorExecute(r StopStreamProcessorApiRequest) (any, *http.Response, error)
 
 	/*
 		UpdateStreamConnection Update One Stream Connection
@@ -578,7 +578,7 @@ func (a *StreamsApiService) AcceptVPCPeeringConnectionWithParams(ctx context.Con
 	}
 }
 
-func (r AcceptVPCPeeringConnectionApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r AcceptVPCPeeringConnectionApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.AcceptVPCPeeringConnectionExecute(r)
 }
 
@@ -604,13 +604,13 @@ func (a *StreamsApiService) AcceptVPCPeeringConnection(ctx context.Context, grou
 
 // AcceptVPCPeeringConnectionExecute executes the request
 //
-//	@return interface{}
-func (a *StreamsApiService) AcceptVPCPeeringConnectionExecute(r AcceptVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *StreamsApiService) AcceptVPCPeeringConnectionExecute(r AcceptVPCPeeringConnectionApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StreamsApiService.AcceptVPCPeeringConnection")
@@ -930,12 +930,12 @@ type CreateStreamInstanceWithSampleConnectionsApiRequest struct {
 	ctx        context.Context
 	ApiService StreamsApi
 	groupId    string
-	body       *interface{}
+	body       *any
 }
 
 type CreateStreamInstanceWithSampleConnectionsApiParams struct {
 	GroupId string
-	Body    *interface{}
+	Body    *any
 }
 
 func (a *StreamsApiService) CreateStreamInstanceWithSampleConnectionsWithParams(ctx context.Context, args *CreateStreamInstanceWithSampleConnectionsApiParams) CreateStreamInstanceWithSampleConnectionsApiRequest {
@@ -960,7 +960,7 @@ Creates one stream instance in the specified project with sample connections. To
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@return CreateStreamInstanceWithSampleConnectionsApiRequest
 */
-func (a *StreamsApiService) CreateStreamInstanceWithSampleConnections(ctx context.Context, groupId string, body *interface{}) CreateStreamInstanceWithSampleConnectionsApiRequest {
+func (a *StreamsApiService) CreateStreamInstanceWithSampleConnections(ctx context.Context, groupId string, body *any) CreateStreamInstanceWithSampleConnectionsApiRequest {
 	return CreateStreamInstanceWithSampleConnectionsApiRequest{
 		ApiService: a,
 		ctx:        ctx,
@@ -1196,7 +1196,7 @@ func (a *StreamsApiService) DeleteStreamConnectionWithParams(ctx context.Context
 	}
 }
 
-func (r DeleteStreamConnectionApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteStreamConnectionApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteStreamConnectionExecute(r)
 }
 
@@ -1223,13 +1223,13 @@ func (a *StreamsApiService) DeleteStreamConnection(ctx context.Context, groupId 
 
 // DeleteStreamConnectionExecute executes the request
 //
-//	@return interface{}
-func (a *StreamsApiService) DeleteStreamConnectionExecute(r DeleteStreamConnectionApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *StreamsApiService) DeleteStreamConnectionExecute(r DeleteStreamConnectionApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StreamsApiService.DeleteStreamConnection")
@@ -1316,7 +1316,7 @@ func (a *StreamsApiService) DeleteStreamInstanceWithParams(ctx context.Context, 
 	}
 }
 
-func (r DeleteStreamInstanceApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteStreamInstanceApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteStreamInstanceExecute(r)
 }
 
@@ -1341,13 +1341,13 @@ func (a *StreamsApiService) DeleteStreamInstance(ctx context.Context, groupId st
 
 // DeleteStreamInstanceExecute executes the request
 //
-//	@return interface{}
-func (a *StreamsApiService) DeleteStreamInstanceExecute(r DeleteStreamInstanceApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *StreamsApiService) DeleteStreamInstanceExecute(r DeleteStreamInstanceApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StreamsApiService.DeleteStreamInstance")
@@ -1539,7 +1539,7 @@ func (a *StreamsApiService) DeleteVPCPeeringConnectionWithParams(ctx context.Con
 	}
 }
 
-func (r DeleteVPCPeeringConnectionApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteVPCPeeringConnectionApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteVPCPeeringConnectionExecute(r)
 }
 
@@ -1564,13 +1564,13 @@ func (a *StreamsApiService) DeleteVPCPeeringConnection(ctx context.Context, grou
 
 // DeleteVPCPeeringConnectionExecute executes the request
 //
-//	@return interface{}
-func (a *StreamsApiService) DeleteVPCPeeringConnectionExecute(r DeleteVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *StreamsApiService) DeleteVPCPeeringConnectionExecute(r DeleteVPCPeeringConnectionApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StreamsApiService.DeleteVPCPeeringConnection")
@@ -2755,7 +2755,7 @@ func (a *StreamsApiService) RejectVPCPeeringConnectionWithParams(ctx context.Con
 	}
 }
 
-func (r RejectVPCPeeringConnectionApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r RejectVPCPeeringConnectionApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.RejectVPCPeeringConnectionExecute(r)
 }
 
@@ -2780,13 +2780,13 @@ func (a *StreamsApiService) RejectVPCPeeringConnection(ctx context.Context, grou
 
 // RejectVPCPeeringConnectionExecute executes the request
 //
-//	@return interface{}
-func (a *StreamsApiService) RejectVPCPeeringConnectionExecute(r RejectVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *StreamsApiService) RejectVPCPeeringConnectionExecute(r RejectVPCPeeringConnectionApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StreamsApiService.RejectVPCPeeringConnection")
@@ -2875,7 +2875,7 @@ func (a *StreamsApiService) StartStreamProcessorWithParams(ctx context.Context, 
 	}
 }
 
-func (r StartStreamProcessorApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r StartStreamProcessorApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.StartStreamProcessorExecute(r)
 }
 
@@ -2902,13 +2902,13 @@ func (a *StreamsApiService) StartStreamProcessor(ctx context.Context, groupId st
 
 // StartStreamProcessorExecute executes the request
 //
-//	@return interface{}
-func (a *StreamsApiService) StartStreamProcessorExecute(r StartStreamProcessorApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *StreamsApiService) StartStreamProcessorExecute(r StartStreamProcessorApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StreamsApiService.StartStreamProcessor")
@@ -2998,7 +2998,7 @@ func (a *StreamsApiService) StopStreamProcessorWithParams(ctx context.Context, a
 	}
 }
 
-func (r StopStreamProcessorApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r StopStreamProcessorApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.StopStreamProcessorExecute(r)
 }
 
@@ -3025,13 +3025,13 @@ func (a *StreamsApiService) StopStreamProcessor(ctx context.Context, groupId str
 
 // StopStreamProcessorExecute executes the request
 //
-//	@return interface{}
-func (a *StreamsApiService) StopStreamProcessorExecute(r StopStreamProcessorApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *StreamsApiService) StopStreamProcessorExecute(r StopStreamProcessorApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StreamsApiService.StopStreamProcessor")

--- a/admin/api_teams.go
+++ b/admin/api_teams.go
@@ -379,7 +379,7 @@ func (a *TeamsApiService) AddAllTeamsToProject(ctx context.Context, groupId stri
 func (a *TeamsApiService) AddAllTeamsToProjectExecute(r AddAllTeamsToProjectApiRequest) (*PaginatedTeamRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedTeamRole
 	)
@@ -504,7 +504,7 @@ func (a *TeamsApiService) AddTeamUser(ctx context.Context, orgId string, teamId 
 func (a *TeamsApiService) AddTeamUserExecute(r AddTeamUserApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiAppUser
 	)
@@ -625,7 +625,7 @@ func (a *TeamsApiService) CreateTeam(ctx context.Context, orgId string, team *Te
 func (a *TeamsApiService) CreateTeamExecute(r CreateTeamApiRequest) (*Team, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *Team
 	)
@@ -746,7 +746,7 @@ func (a *TeamsApiService) DeleteTeam(ctx context.Context, orgId string, teamId s
 func (a *TeamsApiService) DeleteTeamExecute(r DeleteTeamApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -863,7 +863,7 @@ func (a *TeamsApiService) GetTeamById(ctx context.Context, orgId string, teamId 
 func (a *TeamsApiService) GetTeamByIdExecute(r GetTeamByIdApiRequest) (*TeamResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *TeamResponse
 	)
@@ -980,7 +980,7 @@ func (a *TeamsApiService) GetTeamByName(ctx context.Context, orgId string, teamN
 func (a *TeamsApiService) GetTeamByNameExecute(r GetTeamByNameApiRequest) (*TeamResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *TeamResponse
 	)
@@ -1119,7 +1119,7 @@ func (a *TeamsApiService) ListOrganizationTeams(ctx context.Context, orgId strin
 func (a *TeamsApiService) ListOrganizationTeamsExecute(r ListOrganizationTeamsApiRequest) (*PaginatedTeam, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedTeam
 	)
@@ -1278,7 +1278,7 @@ func (a *TeamsApiService) ListProjectTeams(ctx context.Context, groupId string) 
 func (a *TeamsApiService) ListProjectTeamsExecute(r ListProjectTeamsApiRequest) (*PaginatedTeamRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedTeamRole
 	)
@@ -1433,7 +1433,7 @@ func (a *TeamsApiService) ListTeamUsers(ctx context.Context, orgId string, teamI
 func (a *TeamsApiService) ListTeamUsersExecute(r ListTeamUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedApiAppUser
 	)
@@ -1562,7 +1562,7 @@ func (a *TeamsApiService) RemoveProjectTeam(ctx context.Context, groupId string,
 func (a *TeamsApiService) RemoveProjectTeamExecute(r RemoveProjectTeamApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -1667,7 +1667,7 @@ func (a *TeamsApiService) RemoveTeamUser(ctx context.Context, orgId string, team
 func (a *TeamsApiService) RemoveTeamUserExecute(r RemoveTeamUserApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
+		localVarPostBody   any
 		formFiles          []formFile
 	)
 
@@ -1774,7 +1774,7 @@ func (a *TeamsApiService) RenameTeam(ctx context.Context, orgId string, teamId s
 func (a *TeamsApiService) RenameTeamExecute(r RenameTeamApiRequest) (*TeamResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *TeamResponse
 	)
@@ -1900,7 +1900,7 @@ func (a *TeamsApiService) UpdateTeamRoles(ctx context.Context, groupId string, t
 func (a *TeamsApiService) UpdateTeamRolesExecute(r UpdateTeamRolesApiRequest) (*PaginatedTeamRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedTeamRole
 	)

--- a/admin/api_teams.go
+++ b/admin/api_teams.go
@@ -107,7 +107,7 @@ type TeamsApi interface {
 	DeleteTeamWithParams(ctx context.Context, args *DeleteTeamApiParams) DeleteTeamApiRequest
 
 	// Method available only for mocking purposes
-	DeleteTeamExecute(r DeleteTeamApiRequest) (interface{}, *http.Response, error)
+	DeleteTeamExecute(r DeleteTeamApiRequest) (any, *http.Response, error)
 
 	/*
 		GetTeamById Return One Team using its ID
@@ -717,7 +717,7 @@ func (a *TeamsApiService) DeleteTeamWithParams(ctx context.Context, args *Delete
 	}
 }
 
-func (r DeleteTeamApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteTeamApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteTeamExecute(r)
 }
 
@@ -742,13 +742,13 @@ func (a *TeamsApiService) DeleteTeam(ctx context.Context, orgId string, teamId s
 
 // DeleteTeamExecute executes the request
 //
-//	@return interface{}
-func (a *TeamsApiService) DeleteTeamExecute(r DeleteTeamApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *TeamsApiService) DeleteTeamExecute(r DeleteTeamApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TeamsApiService.DeleteTeam")

--- a/admin/api_third_party_integrations.go
+++ b/admin/api_third_party_integrations.go
@@ -59,7 +59,7 @@ type ThirdPartyIntegrationsApi interface {
 	DeleteThirdPartyIntegrationWithParams(ctx context.Context, args *DeleteThirdPartyIntegrationApiParams) DeleteThirdPartyIntegrationApiRequest
 
 	// Method available only for mocking purposes
-	DeleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (interface{}, *http.Response, error)
+	DeleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (any, *http.Response, error)
 
 	/*
 		GetThirdPartyIntegration Return One Third-Party Service Integration
@@ -332,7 +332,7 @@ func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegrationWithParams
 	}
 }
 
-func (r DeleteThirdPartyIntegrationApiRequest) Execute() (interface{}, *http.Response, error) {
+func (r DeleteThirdPartyIntegrationApiRequest) Execute() (any, *http.Response, error) {
 	return r.ApiService.DeleteThirdPartyIntegrationExecute(r)
 }
 
@@ -357,13 +357,13 @@ func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegration(ctx conte
 
 // DeleteThirdPartyIntegrationExecute executes the request
 //
-//	@return interface{}
-func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (interface{}, *http.Response, error) {
+//	@return any
+func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (any, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    any
 		formFiles           []formFile
-		localVarReturnValue interface{}
+		localVarReturnValue any
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ThirdPartyIntegrationsApiService.DeleteThirdPartyIntegration")

--- a/admin/api_third_party_integrations.go
+++ b/admin/api_third_party_integrations.go
@@ -218,7 +218,7 @@ func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegration(ctx conte
 func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegrationExecute(r CreateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedIntegration
 	)
@@ -361,7 +361,7 @@ func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegration(ctx conte
 func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (interface{}, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue interface{}
 	)
@@ -478,7 +478,7 @@ func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegration(ctx context.
 func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegrationExecute(r GetThirdPartyIntegrationApiRequest) (*ThirdPartyIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *ThirdPartyIntegration
 	)
@@ -617,7 +617,7 @@ func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrations(ctx contex
 func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrationsExecute(r ListThirdPartyIntegrationsApiRequest) (*PaginatedIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedIntegration
 	)
@@ -785,7 +785,7 @@ func (a *ThirdPartyIntegrationsApiService) UpdateThirdPartyIntegration(ctx conte
 func (a *ThirdPartyIntegrationsApiService) UpdateThirdPartyIntegrationExecute(r UpdateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedIntegration
 	)

--- a/admin/api_x509_authentication.go
+++ b/admin/api_x509_authentication.go
@@ -152,7 +152,7 @@ func (a *X509AuthenticationApiService) CreateDatabaseUserCertificate(ctx context
 func (a *X509AuthenticationApiService) CreateDatabaseUserCertificateExecute(r CreateDatabaseUserCertificateApiRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue string
 	)
@@ -271,7 +271,7 @@ func (a *X509AuthenticationApiService) DisableCustomerManagedX509(ctx context.Co
 func (a *X509AuthenticationApiService) DisableCustomerManagedX509Execute(r DisableCustomerManagedX509ApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *UserSecurity
 	)
@@ -414,7 +414,7 @@ func (a *X509AuthenticationApiService) ListDatabaseUserCertificates(ctx context.
 func (a *X509AuthenticationApiService) ListDatabaseUserCertificatesExecute(r ListDatabaseUserCertificatesApiRequest) (*PaginatedUserCert, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
+		localVarPostBody    any
 		formFiles           []formFile
 		localVarReturnValue *PaginatedUserCert
 	)

--- a/admin/client.go
+++ b/admin/client.go
@@ -227,7 +227,7 @@ func contains(haystack []string, needle string) bool {
 	return false
 }
 
-func parameterValueToString(obj interface{}, key string) string {
+func parameterValueToString(obj any, key string) string {
 	if reflect.TypeOf(obj).Kind() != reflect.Ptr {
 		return fmt.Sprintf("%v", obj)
 	}
@@ -244,7 +244,7 @@ func parameterValueToString(obj interface{}, key string) string {
 
 // parameterAddToHeaderOrQuery adds the provided object to the request header or url query
 // supporting deep object syntax
-func parameterAddToHeaderOrQuery(headerOrQueryParams interface{}, keyPrefix string, obj interface{}, collectionType string) {
+func parameterAddToHeaderOrQuery(headerOrQueryParams any, keyPrefix string, obj any, collectionType string) {
 	var v = reflect.ValueOf(obj)
 	var value = ""
 	if v == reflect.ValueOf(nil) {
@@ -368,7 +368,7 @@ type formFile struct {
 func (c *APIClient) prepareRequest(
 	ctx context.Context,
 	path string, method string,
-	postBody interface{},
+	postBody any,
 	headerParams map[string]string,
 	queryParams url.Values,
 	formParams url.Values,
@@ -536,7 +536,7 @@ func (c *APIClient) makeApiError(res *http.Response, httpMethod, httpPath string
 	return newErr
 }
 
-func (c *APIClient) decode(v interface{}, b io.ReadCloser, contentType string) (err error) {
+func (c *APIClient) decode(v any, b io.ReadCloser, contentType string) (err error) {
 	switch r := v.(type) {
 	case *string:
 		buf, err := io.ReadAll(b)
@@ -565,7 +565,7 @@ func (c *APIClient) decode(v interface{}, b io.ReadCloser, contentType string) (
 			return xml.Unmarshal(buf, v)
 		}
 		if jsonCheck.MatchString(contentType) {
-			if actualObj, ok := v.(interface{ GetActualInstance() interface{} }); ok { // oneOf, anyOf schemas
+			if actualObj, ok := v.(interface{ GetActualInstance() any }); ok { // oneOf, anyOf schemas
 				if unmarshalObj, ok := actualObj.(interface{ UnmarshalJSON([]byte) error }); ok { // make sure it has UnmarshalJSON defined
 					if err = unmarshalObj.UnmarshalJSON(buf); err != nil {
 						return err
@@ -603,12 +603,12 @@ func addFile(w *multipart.Writer, fieldName, path string) error {
 }
 
 // Prevent trying to import "fmt"
-func reportError(format string, a ...interface{}) error {
+func reportError(format string, a ...any) error {
 	return fmt.Errorf(format, a...)
 }
 
-// Set request body from an interface{}
-func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err error) {
+// Set request body from an any
+func setBody(body any, contentType string) (bodyBuf *bytes.Buffer, err error) {
 	bodyBuf = &bytes.Buffer{}
 
 	if reader, ok := body.(io.Reader); ok {
@@ -639,7 +639,7 @@ func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err e
 }
 
 // detectContentType method is used to figure out `Request.Body` content type for request header
-func detectContentType(body interface{}) string {
+func detectContentType(body any) string {
 	contentType := "text/plain; charset=utf-8"
 	kind := reflect.TypeOf(body).Kind()
 

--- a/admin/model_api_atlas_fts_analyzers.go
+++ b/admin/model_api_atlas_fts_analyzers.go
@@ -5,11 +5,11 @@ package admin
 // ApiAtlasFTSAnalyzers Settings that describe one Atlas Search custom analyzer.
 type ApiAtlasFTSAnalyzers struct {
 	// Filters that examine text one character at a time and perform filtering operations.
-	CharFilters *[]interface{} `json:"charFilters,omitempty"`
+	CharFilters *[]any `json:"charFilters,omitempty"`
 	// Human-readable name that identifies the custom analyzer. Names must be unique within an index, and must not start with any of the following strings: - `lucene.` - `builtin.` - `mongodb.`
 	Name string `json:"name"`
 	// Filter that performs operations such as:  - Stemming, which reduces related words, such as \"talking\", \"talked\", and \"talks\" to their root word \"talk\".  - Redaction, the removal of sensitive information from public documents.
-	TokenFilters *[]interface{}                `json:"tokenFilters,omitempty"`
+	TokenFilters *[]any                        `json:"tokenFilters,omitempty"`
 	Tokenizer    ApiAtlasFTSAnalyzersTokenizer `json:"tokenizer"`
 }
 
@@ -33,9 +33,9 @@ func NewApiAtlasFTSAnalyzersWithDefaults() *ApiAtlasFTSAnalyzers {
 }
 
 // GetCharFilters returns the CharFilters field value if set, zero value otherwise
-func (o *ApiAtlasFTSAnalyzers) GetCharFilters() []interface{} {
+func (o *ApiAtlasFTSAnalyzers) GetCharFilters() []any {
 	if o == nil || IsNil(o.CharFilters) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.CharFilters
@@ -43,7 +43,7 @@ func (o *ApiAtlasFTSAnalyzers) GetCharFilters() []interface{} {
 
 // GetCharFiltersOk returns a tuple with the CharFilters field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ApiAtlasFTSAnalyzers) GetCharFiltersOk() (*[]interface{}, bool) {
+func (o *ApiAtlasFTSAnalyzers) GetCharFiltersOk() (*[]any, bool) {
 	if o == nil || IsNil(o.CharFilters) {
 		return nil, false
 	}
@@ -60,8 +60,8 @@ func (o *ApiAtlasFTSAnalyzers) HasCharFilters() bool {
 	return false
 }
 
-// SetCharFilters gets a reference to the given []interface{} and assigns it to the CharFilters field.
-func (o *ApiAtlasFTSAnalyzers) SetCharFilters(v []interface{}) {
+// SetCharFilters gets a reference to the given []any and assigns it to the CharFilters field.
+func (o *ApiAtlasFTSAnalyzers) SetCharFilters(v []any) {
 	o.CharFilters = &v
 }
 
@@ -90,9 +90,9 @@ func (o *ApiAtlasFTSAnalyzers) SetName(v string) {
 }
 
 // GetTokenFilters returns the TokenFilters field value if set, zero value otherwise
-func (o *ApiAtlasFTSAnalyzers) GetTokenFilters() []interface{} {
+func (o *ApiAtlasFTSAnalyzers) GetTokenFilters() []any {
 	if o == nil || IsNil(o.TokenFilters) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.TokenFilters
@@ -100,7 +100,7 @@ func (o *ApiAtlasFTSAnalyzers) GetTokenFilters() []interface{} {
 
 // GetTokenFiltersOk returns a tuple with the TokenFilters field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ApiAtlasFTSAnalyzers) GetTokenFiltersOk() (*[]interface{}, bool) {
+func (o *ApiAtlasFTSAnalyzers) GetTokenFiltersOk() (*[]any, bool) {
 	if o == nil || IsNil(o.TokenFilters) {
 		return nil, false
 	}
@@ -117,8 +117,8 @@ func (o *ApiAtlasFTSAnalyzers) HasTokenFilters() bool {
 	return false
 }
 
-// SetTokenFilters gets a reference to the given []interface{} and assigns it to the TokenFilters field.
-func (o *ApiAtlasFTSAnalyzers) SetTokenFilters(v []interface{}) {
+// SetTokenFilters gets a reference to the given []any and assigns it to the TokenFilters field.
+func (o *ApiAtlasFTSAnalyzers) SetTokenFilters(v []any) {
 	o.TokenFilters = &v
 }
 

--- a/admin/model_api_atlas_fts_mappings.go
+++ b/admin/model_api_atlas_fts_mappings.go
@@ -7,7 +7,7 @@ type ApiAtlasFTSMappings struct {
 	// Flag that indicates whether the index uses dynamic or static mappings. Required if **mappings.fields** is omitted.
 	Dynamic *bool `json:"dynamic,omitempty"`
 	// One or more field specifications for the Atlas Search index. Required if **mappings.dynamic** is omitted or set to **false**.
-	Fields interface{} `json:"fields,omitempty"`
+	Fields any `json:"fields,omitempty"`
 }
 
 // NewApiAtlasFTSMappings instantiates a new ApiAtlasFTSMappings object
@@ -65,9 +65,9 @@ func (o *ApiAtlasFTSMappings) SetDynamic(v bool) {
 }
 
 // GetFields returns the Fields field value if set, zero value otherwise
-func (o *ApiAtlasFTSMappings) GetFields() interface{} {
+func (o *ApiAtlasFTSMappings) GetFields() any {
 	if o == nil || IsNil(o.Fields) {
-		var ret interface{}
+		var ret any
 		return ret
 	}
 	return o.Fields
@@ -75,9 +75,9 @@ func (o *ApiAtlasFTSMappings) GetFields() interface{} {
 
 // GetFieldsOk returns a tuple with the Fields field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ApiAtlasFTSMappings) GetFieldsOk() (interface{}, bool) {
+func (o *ApiAtlasFTSMappings) GetFieldsOk() (any, bool) {
 	if o == nil || IsNil(o.Fields) {
-		var ret interface{}
+		var ret any
 		return ret, false
 	}
 
@@ -93,7 +93,7 @@ func (o *ApiAtlasFTSMappings) HasFields() bool {
 	return false
 }
 
-// SetFields gets a reference to the given interface{} and assigns it to the Fields field.
-func (o *ApiAtlasFTSMappings) SetFields(v interface{}) {
+// SetFields gets a reference to the given any and assigns it to the Fields field.
+func (o *ApiAtlasFTSMappings) SetFields(v any) {
 	o.Fields = v
 }

--- a/admin/model_api_error.go
+++ b/admin/model_api_error.go
@@ -12,7 +12,7 @@ type ApiError struct {
 	// Application error code returned with this error.
 	ErrorCode *string `json:"errorCode,omitempty"`
 	// Parameters used to give more information about the error.
-	Parameters *[]interface{} `json:"parameters,omitempty"`
+	Parameters *[]any `json:"parameters,omitempty"`
 	// Application error message returned with this error.
 	Reason *string `json:"reason,omitempty"`
 }
@@ -167,9 +167,9 @@ func (o *ApiError) SetErrorCode(v string) {
 }
 
 // GetParameters returns the Parameters field value if set, zero value otherwise
-func (o *ApiError) GetParameters() []interface{} {
+func (o *ApiError) GetParameters() []any {
 	if o == nil || IsNil(o.Parameters) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.Parameters
@@ -177,7 +177,7 @@ func (o *ApiError) GetParameters() []interface{} {
 
 // GetParametersOk returns a tuple with the Parameters field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ApiError) GetParametersOk() (*[]interface{}, bool) {
+func (o *ApiError) GetParametersOk() (*[]any, bool) {
 	if o == nil || IsNil(o.Parameters) {
 		return nil, false
 	}
@@ -194,8 +194,8 @@ func (o *ApiError) HasParameters() bool {
 	return false
 }
 
-// SetParameters gets a reference to the given []interface{} and assigns it to the Parameters field.
-func (o *ApiError) SetParameters(v []interface{}) {
+// SetParameters gets a reference to the given []any and assigns it to the Parameters field.
+func (o *ApiError) SetParameters(v []any) {
 	o.Parameters = &v
 }
 

--- a/admin/model_atlas_search_analyzer.go
+++ b/admin/model_atlas_search_analyzer.go
@@ -5,20 +5,20 @@ package admin
 // AtlasSearchAnalyzer struct for AtlasSearchAnalyzer
 type AtlasSearchAnalyzer struct {
 	// Filters that examine text one character at a time and perform filtering operations.
-	CharFilters *[]interface{} `json:"charFilters,omitempty"`
+	CharFilters *[]any `json:"charFilters,omitempty"`
 	// Name that identifies the custom analyzer. Names must be unique within an index, and must not start with any of the following strings: - `lucene.` - `builtin.` - `mongodb.`
 	Name string `json:"name"`
 	// Filter that performs operations such as:  - Stemming, which reduces related words, such as \"talking\", \"talked\", and \"talks\" to their root word \"talk\".  - Redaction, which is the removal of sensitive information from public documents.
-	TokenFilters *[]interface{} `json:"tokenFilters,omitempty"`
+	TokenFilters *[]any `json:"tokenFilters,omitempty"`
 	// Tokenizer that you want to use to create tokens. Tokens determine how Atlas Search splits up text into discrete chunks for indexing.
-	Tokenizer interface{} `json:"tokenizer"`
+	Tokenizer any `json:"tokenizer"`
 }
 
 // NewAtlasSearchAnalyzer instantiates a new AtlasSearchAnalyzer object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewAtlasSearchAnalyzer(name string, tokenizer interface{}) *AtlasSearchAnalyzer {
+func NewAtlasSearchAnalyzer(name string, tokenizer any) *AtlasSearchAnalyzer {
 	this := AtlasSearchAnalyzer{}
 	this.Name = name
 	this.Tokenizer = tokenizer
@@ -34,9 +34,9 @@ func NewAtlasSearchAnalyzerWithDefaults() *AtlasSearchAnalyzer {
 }
 
 // GetCharFilters returns the CharFilters field value if set, zero value otherwise
-func (o *AtlasSearchAnalyzer) GetCharFilters() []interface{} {
+func (o *AtlasSearchAnalyzer) GetCharFilters() []any {
 	if o == nil || IsNil(o.CharFilters) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.CharFilters
@@ -44,7 +44,7 @@ func (o *AtlasSearchAnalyzer) GetCharFilters() []interface{} {
 
 // GetCharFiltersOk returns a tuple with the CharFilters field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AtlasSearchAnalyzer) GetCharFiltersOk() (*[]interface{}, bool) {
+func (o *AtlasSearchAnalyzer) GetCharFiltersOk() (*[]any, bool) {
 	if o == nil || IsNil(o.CharFilters) {
 		return nil, false
 	}
@@ -61,8 +61,8 @@ func (o *AtlasSearchAnalyzer) HasCharFilters() bool {
 	return false
 }
 
-// SetCharFilters gets a reference to the given []interface{} and assigns it to the CharFilters field.
-func (o *AtlasSearchAnalyzer) SetCharFilters(v []interface{}) {
+// SetCharFilters gets a reference to the given []any and assigns it to the CharFilters field.
+func (o *AtlasSearchAnalyzer) SetCharFilters(v []any) {
 	o.CharFilters = &v
 }
 
@@ -91,9 +91,9 @@ func (o *AtlasSearchAnalyzer) SetName(v string) {
 }
 
 // GetTokenFilters returns the TokenFilters field value if set, zero value otherwise
-func (o *AtlasSearchAnalyzer) GetTokenFilters() []interface{} {
+func (o *AtlasSearchAnalyzer) GetTokenFilters() []any {
 	if o == nil || IsNil(o.TokenFilters) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.TokenFilters
@@ -101,7 +101,7 @@ func (o *AtlasSearchAnalyzer) GetTokenFilters() []interface{} {
 
 // GetTokenFiltersOk returns a tuple with the TokenFilters field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AtlasSearchAnalyzer) GetTokenFiltersOk() (*[]interface{}, bool) {
+func (o *AtlasSearchAnalyzer) GetTokenFiltersOk() (*[]any, bool) {
 	if o == nil || IsNil(o.TokenFilters) {
 		return nil, false
 	}
@@ -118,15 +118,15 @@ func (o *AtlasSearchAnalyzer) HasTokenFilters() bool {
 	return false
 }
 
-// SetTokenFilters gets a reference to the given []interface{} and assigns it to the TokenFilters field.
-func (o *AtlasSearchAnalyzer) SetTokenFilters(v []interface{}) {
+// SetTokenFilters gets a reference to the given []any and assigns it to the TokenFilters field.
+func (o *AtlasSearchAnalyzer) SetTokenFilters(v []any) {
 	o.TokenFilters = &v
 }
 
 // GetTokenizer returns the Tokenizer field value
-func (o *AtlasSearchAnalyzer) GetTokenizer() interface{} {
+func (o *AtlasSearchAnalyzer) GetTokenizer() any {
 	if o == nil {
-		var ret interface{}
+		var ret any
 		return ret
 	}
 
@@ -135,15 +135,15 @@ func (o *AtlasSearchAnalyzer) GetTokenizer() interface{} {
 
 // GetTokenizerOk returns a tuple with the Tokenizer field value
 // and a boolean to check if the value has been set.
-func (o *AtlasSearchAnalyzer) GetTokenizerOk() (interface{}, bool) {
+func (o *AtlasSearchAnalyzer) GetTokenizerOk() (any, bool) {
 	if o == nil {
-		var ret interface{}
+		var ret any
 		return ret, false
 	}
 	return o.Tokenizer, true
 }
 
 // SetTokenizer sets field value
-func (o *AtlasSearchAnalyzer) SetTokenizer(v interface{}) {
+func (o *AtlasSearchAnalyzer) SetTokenizer(v any) {
 	o.Tokenizer = v
 }

--- a/admin/model_base_search_index_create_request_definition.go
+++ b/admin/model_base_search_index_create_request_definition.go
@@ -12,11 +12,11 @@ type BaseSearchIndexCreateRequestDefinition struct {
 	// Method applied to identify words when searching this index.
 	SearchAnalyzer *string `json:"searchAnalyzer,omitempty"`
 	// Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn't store (false) the fields on Atlas Search.  Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see Stored Source Fields.
-	StoredSource interface{} `json:"storedSource,omitempty"`
+	StoredSource any `json:"storedSource,omitempty"`
 	// Rule sets that map words to their synonyms in this index.
 	Synonyms *[]SearchSynonymMappingDefinition `json:"synonyms,omitempty"`
 	// Settings that configure the fields, one per object, to index. You must define at least one \"vector\" type field. You can optionally define \"filter\" type fields also.
-	Fields *[]interface{} `json:"fields,omitempty"`
+	Fields *[]any `json:"fields,omitempty"`
 }
 
 // NewBaseSearchIndexCreateRequestDefinition instantiates a new BaseSearchIndexCreateRequestDefinition object
@@ -177,9 +177,9 @@ func (o *BaseSearchIndexCreateRequestDefinition) SetSearchAnalyzer(v string) {
 }
 
 // GetStoredSource returns the StoredSource field value if set, zero value otherwise
-func (o *BaseSearchIndexCreateRequestDefinition) GetStoredSource() interface{} {
+func (o *BaseSearchIndexCreateRequestDefinition) GetStoredSource() any {
 	if o == nil || IsNil(o.StoredSource) {
-		var ret interface{}
+		var ret any
 		return ret
 	}
 	return o.StoredSource
@@ -187,9 +187,9 @@ func (o *BaseSearchIndexCreateRequestDefinition) GetStoredSource() interface{} {
 
 // GetStoredSourceOk returns a tuple with the StoredSource field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *BaseSearchIndexCreateRequestDefinition) GetStoredSourceOk() (interface{}, bool) {
+func (o *BaseSearchIndexCreateRequestDefinition) GetStoredSourceOk() (any, bool) {
 	if o == nil || IsNil(o.StoredSource) {
-		var ret interface{}
+		var ret any
 		return ret, false
 	}
 
@@ -205,8 +205,8 @@ func (o *BaseSearchIndexCreateRequestDefinition) HasStoredSource() bool {
 	return false
 }
 
-// SetStoredSource gets a reference to the given interface{} and assigns it to the StoredSource field.
-func (o *BaseSearchIndexCreateRequestDefinition) SetStoredSource(v interface{}) {
+// SetStoredSource gets a reference to the given any and assigns it to the StoredSource field.
+func (o *BaseSearchIndexCreateRequestDefinition) SetStoredSource(v any) {
 	o.StoredSource = v
 }
 
@@ -244,9 +244,9 @@ func (o *BaseSearchIndexCreateRequestDefinition) SetSynonyms(v []SearchSynonymMa
 }
 
 // GetFields returns the Fields field value if set, zero value otherwise
-func (o *BaseSearchIndexCreateRequestDefinition) GetFields() []interface{} {
+func (o *BaseSearchIndexCreateRequestDefinition) GetFields() []any {
 	if o == nil || IsNil(o.Fields) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.Fields
@@ -254,7 +254,7 @@ func (o *BaseSearchIndexCreateRequestDefinition) GetFields() []interface{} {
 
 // GetFieldsOk returns a tuple with the Fields field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *BaseSearchIndexCreateRequestDefinition) GetFieldsOk() (*[]interface{}, bool) {
+func (o *BaseSearchIndexCreateRequestDefinition) GetFieldsOk() (*[]any, bool) {
 	if o == nil || IsNil(o.Fields) {
 		return nil, false
 	}
@@ -271,7 +271,7 @@ func (o *BaseSearchIndexCreateRequestDefinition) HasFields() bool {
 	return false
 }
 
-// SetFields gets a reference to the given []interface{} and assigns it to the Fields field.
-func (o *BaseSearchIndexCreateRequestDefinition) SetFields(v []interface{}) {
+// SetFields gets a reference to the given []any and assigns it to the Fields field.
+func (o *BaseSearchIndexCreateRequestDefinition) SetFields(v []any) {
 	o.Fields = &v
 }

--- a/admin/model_base_search_index_response_latest_definition.go
+++ b/admin/model_base_search_index_response_latest_definition.go
@@ -12,11 +12,11 @@ type BaseSearchIndexResponseLatestDefinition struct {
 	// Method applied to identify words when searching this index.
 	SearchAnalyzer *string `json:"searchAnalyzer,omitempty"`
 	// Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn't store (false) the fields on Atlas Search.  Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see Stored Source Fields.
-	StoredSource interface{} `json:"storedSource,omitempty"`
+	StoredSource any `json:"storedSource,omitempty"`
 	// Rule sets that map words to their synonyms in this index.
 	Synonyms *[]SearchSynonymMappingDefinition `json:"synonyms,omitempty"`
 	// Settings that configure the fields, one per object, to index. You must define at least one \"vector\" type field. You can optionally define \"filter\" type fields also.
-	Fields *[]interface{} `json:"fields,omitempty"`
+	Fields *[]any `json:"fields,omitempty"`
 }
 
 // NewBaseSearchIndexResponseLatestDefinition instantiates a new BaseSearchIndexResponseLatestDefinition object
@@ -177,9 +177,9 @@ func (o *BaseSearchIndexResponseLatestDefinition) SetSearchAnalyzer(v string) {
 }
 
 // GetStoredSource returns the StoredSource field value if set, zero value otherwise
-func (o *BaseSearchIndexResponseLatestDefinition) GetStoredSource() interface{} {
+func (o *BaseSearchIndexResponseLatestDefinition) GetStoredSource() any {
 	if o == nil || IsNil(o.StoredSource) {
-		var ret interface{}
+		var ret any
 		return ret
 	}
 	return o.StoredSource
@@ -187,9 +187,9 @@ func (o *BaseSearchIndexResponseLatestDefinition) GetStoredSource() interface{} 
 
 // GetStoredSourceOk returns a tuple with the StoredSource field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *BaseSearchIndexResponseLatestDefinition) GetStoredSourceOk() (interface{}, bool) {
+func (o *BaseSearchIndexResponseLatestDefinition) GetStoredSourceOk() (any, bool) {
 	if o == nil || IsNil(o.StoredSource) {
-		var ret interface{}
+		var ret any
 		return ret, false
 	}
 
@@ -205,8 +205,8 @@ func (o *BaseSearchIndexResponseLatestDefinition) HasStoredSource() bool {
 	return false
 }
 
-// SetStoredSource gets a reference to the given interface{} and assigns it to the StoredSource field.
-func (o *BaseSearchIndexResponseLatestDefinition) SetStoredSource(v interface{}) {
+// SetStoredSource gets a reference to the given any and assigns it to the StoredSource field.
+func (o *BaseSearchIndexResponseLatestDefinition) SetStoredSource(v any) {
 	o.StoredSource = v
 }
 
@@ -244,9 +244,9 @@ func (o *BaseSearchIndexResponseLatestDefinition) SetSynonyms(v []SearchSynonymM
 }
 
 // GetFields returns the Fields field value if set, zero value otherwise
-func (o *BaseSearchIndexResponseLatestDefinition) GetFields() []interface{} {
+func (o *BaseSearchIndexResponseLatestDefinition) GetFields() []any {
 	if o == nil || IsNil(o.Fields) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.Fields
@@ -254,7 +254,7 @@ func (o *BaseSearchIndexResponseLatestDefinition) GetFields() []interface{} {
 
 // GetFieldsOk returns a tuple with the Fields field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *BaseSearchIndexResponseLatestDefinition) GetFieldsOk() (*[]interface{}, bool) {
+func (o *BaseSearchIndexResponseLatestDefinition) GetFieldsOk() (*[]any, bool) {
 	if o == nil || IsNil(o.Fields) {
 		return nil, false
 	}
@@ -271,7 +271,7 @@ func (o *BaseSearchIndexResponseLatestDefinition) HasFields() bool {
 	return false
 }
 
-// SetFields gets a reference to the given []interface{} and assigns it to the Fields field.
-func (o *BaseSearchIndexResponseLatestDefinition) SetFields(v []interface{}) {
+// SetFields gets a reference to the given []any and assigns it to the Fields field.
+func (o *BaseSearchIndexResponseLatestDefinition) SetFields(v []any) {
 	o.Fields = &v
 }

--- a/admin/model_cluster_search_index.go
+++ b/admin/model_cluster_search_index.go
@@ -26,11 +26,11 @@ type ClusterSearchIndex struct {
 	// Method applied to identify words when searching this index.
 	SearchAnalyzer *string `json:"searchAnalyzer,omitempty"`
 	// Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn't store (false) the fields on Atlas Search.  Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see documentation.
-	StoredSource interface{} `json:"storedSource,omitempty"`
+	StoredSource any `json:"storedSource,omitempty"`
 	// Rule sets that map words to their synonyms in this index.
 	Synonyms *[]SearchSynonymMappingDefinition `json:"synonyms,omitempty"`
 	// Settings that configure the fields, one per object, to index. You must define at least one \"vector\" type field. You can optionally define \"filter\" type fields also.
-	Fields *[]interface{} `json:"fields,omitempty"`
+	Fields *[]any `json:"fields,omitempty"`
 }
 
 // NewClusterSearchIndex instantiates a new ClusterSearchIndex object
@@ -365,9 +365,9 @@ func (o *ClusterSearchIndex) SetSearchAnalyzer(v string) {
 }
 
 // GetStoredSource returns the StoredSource field value if set, zero value otherwise
-func (o *ClusterSearchIndex) GetStoredSource() interface{} {
+func (o *ClusterSearchIndex) GetStoredSource() any {
 	if o == nil || IsNil(o.StoredSource) {
-		var ret interface{}
+		var ret any
 		return ret
 	}
 	return o.StoredSource
@@ -375,9 +375,9 @@ func (o *ClusterSearchIndex) GetStoredSource() interface{} {
 
 // GetStoredSourceOk returns a tuple with the StoredSource field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ClusterSearchIndex) GetStoredSourceOk() (interface{}, bool) {
+func (o *ClusterSearchIndex) GetStoredSourceOk() (any, bool) {
 	if o == nil || IsNil(o.StoredSource) {
-		var ret interface{}
+		var ret any
 		return ret, false
 	}
 
@@ -393,8 +393,8 @@ func (o *ClusterSearchIndex) HasStoredSource() bool {
 	return false
 }
 
-// SetStoredSource gets a reference to the given interface{} and assigns it to the StoredSource field.
-func (o *ClusterSearchIndex) SetStoredSource(v interface{}) {
+// SetStoredSource gets a reference to the given any and assigns it to the StoredSource field.
+func (o *ClusterSearchIndex) SetStoredSource(v any) {
 	o.StoredSource = v
 }
 
@@ -432,9 +432,9 @@ func (o *ClusterSearchIndex) SetSynonyms(v []SearchSynonymMappingDefinition) {
 }
 
 // GetFields returns the Fields field value if set, zero value otherwise
-func (o *ClusterSearchIndex) GetFields() []interface{} {
+func (o *ClusterSearchIndex) GetFields() []any {
 	if o == nil || IsNil(o.Fields) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.Fields
@@ -442,7 +442,7 @@ func (o *ClusterSearchIndex) GetFields() []interface{} {
 
 // GetFieldsOk returns a tuple with the Fields field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ClusterSearchIndex) GetFieldsOk() (*[]interface{}, bool) {
+func (o *ClusterSearchIndex) GetFieldsOk() (*[]any, bool) {
 	if o == nil || IsNil(o.Fields) {
 		return nil, false
 	}
@@ -459,7 +459,7 @@ func (o *ClusterSearchIndex) HasFields() bool {
 	return false
 }
 
-// SetFields gets a reference to the given []interface{} and assigns it to the Fields field.
-func (o *ClusterSearchIndex) SetFields(v []interface{}) {
+// SetFields gets a reference to the given []any and assigns it to the Fields field.
+func (o *ClusterSearchIndex) SetFields(v []any) {
 	o.Fields = &v
 }

--- a/admin/model_index_options.go
+++ b/admin/model_index_options.go
@@ -29,15 +29,15 @@ type IndexOptions struct {
 	// Human-readable label that identifies this index. This option applies to all index types.
 	Name *string `json:"name,omitempty"`
 	// Rules that limit the documents that the index references to a filter expression. All MongoDB index types accept a **partialFilterExpression** option. **partialFilterExpression** can include following expressions:  - equality (`\"parameter\" : \"value\"` or using the `$eq` operator) - `\"$exists\": true` , maximum: `$gt`, `$gte`, `$lt`, `$lte` comparisons - `$type` - `$and` (top-level only)  This option applies to all index types.
-	PartialFilterExpression interface{} `json:"partialFilterExpression,omitempty"`
+	PartialFilterExpression any `json:"partialFilterExpression,omitempty"`
 	// Flag that indicates whether the index references documents that only have the specified parameter. These indexes use less space but behave differently in some situations like when sorting. The following index types default to sparse and ignore this option: `2dsphere`, `2d`, `geoHaystack`, `text`.  Compound indexes that includes one or more indexes with `2dsphere` keys alongside other key types, only the `2dsphere` index parameters determine which documents the index references. If you run MongoDB 3.2 or later, use partial indexes. This option applies to all index types.
 	Sparse *bool `json:"sparse,omitempty"`
 	// Storage engine set for the specific index. This value can be set only at creation. This option uses the following format: `\"storageEngine\" : { \"<storage-engine-name>\" : \"<options>\" }` MongoDB validates storage engine configuration options when creating indexes. To support replica sets with members with different storage engines, MongoDB logs these options to the oplog during replication. This option applies to all index types.
-	StorageEngine interface{} `json:"storageEngine,omitempty"`
+	StorageEngine any `json:"storageEngine,omitempty"`
 	// Version applied to this text index. MongoDB 3.2 and later use version `3`. Use this option to override the default version number. This option applies to the **text** index type only.
 	TextIndexVersion *int `json:"textIndexVersion,omitempty"`
 	// Relative importance to place upon provided index parameters. This object expresses this as key/value pairs of index parameter and weight to apply to that parameter. You can specify weights for some or all the indexed parameters. The weight must be an integer between 1 and 99,999. MongoDB 5.0 and later can apply **weights** to **text** indexes only.
-	Weights interface{} `json:"weights,omitempty"`
+	Weights any `json:"weights,omitempty"`
 }
 
 // NewIndexOptions instantiates a new IndexOptions object
@@ -494,9 +494,9 @@ func (o *IndexOptions) SetName(v string) {
 }
 
 // GetPartialFilterExpression returns the PartialFilterExpression field value if set, zero value otherwise
-func (o *IndexOptions) GetPartialFilterExpression() interface{} {
+func (o *IndexOptions) GetPartialFilterExpression() any {
 	if o == nil || IsNil(o.PartialFilterExpression) {
-		var ret interface{}
+		var ret any
 		return ret
 	}
 	return o.PartialFilterExpression
@@ -504,9 +504,9 @@ func (o *IndexOptions) GetPartialFilterExpression() interface{} {
 
 // GetPartialFilterExpressionOk returns a tuple with the PartialFilterExpression field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *IndexOptions) GetPartialFilterExpressionOk() (interface{}, bool) {
+func (o *IndexOptions) GetPartialFilterExpressionOk() (any, bool) {
 	if o == nil || IsNil(o.PartialFilterExpression) {
-		var ret interface{}
+		var ret any
 		return ret, false
 	}
 
@@ -522,8 +522,8 @@ func (o *IndexOptions) HasPartialFilterExpression() bool {
 	return false
 }
 
-// SetPartialFilterExpression gets a reference to the given interface{} and assigns it to the PartialFilterExpression field.
-func (o *IndexOptions) SetPartialFilterExpression(v interface{}) {
+// SetPartialFilterExpression gets a reference to the given any and assigns it to the PartialFilterExpression field.
+func (o *IndexOptions) SetPartialFilterExpression(v any) {
 	o.PartialFilterExpression = v
 }
 
@@ -561,9 +561,9 @@ func (o *IndexOptions) SetSparse(v bool) {
 }
 
 // GetStorageEngine returns the StorageEngine field value if set, zero value otherwise
-func (o *IndexOptions) GetStorageEngine() interface{} {
+func (o *IndexOptions) GetStorageEngine() any {
 	if o == nil || IsNil(o.StorageEngine) {
-		var ret interface{}
+		var ret any
 		return ret
 	}
 	return o.StorageEngine
@@ -571,9 +571,9 @@ func (o *IndexOptions) GetStorageEngine() interface{} {
 
 // GetStorageEngineOk returns a tuple with the StorageEngine field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *IndexOptions) GetStorageEngineOk() (interface{}, bool) {
+func (o *IndexOptions) GetStorageEngineOk() (any, bool) {
 	if o == nil || IsNil(o.StorageEngine) {
-		var ret interface{}
+		var ret any
 		return ret, false
 	}
 
@@ -589,8 +589,8 @@ func (o *IndexOptions) HasStorageEngine() bool {
 	return false
 }
 
-// SetStorageEngine gets a reference to the given interface{} and assigns it to the StorageEngine field.
-func (o *IndexOptions) SetStorageEngine(v interface{}) {
+// SetStorageEngine gets a reference to the given any and assigns it to the StorageEngine field.
+func (o *IndexOptions) SetStorageEngine(v any) {
 	o.StorageEngine = v
 }
 
@@ -628,9 +628,9 @@ func (o *IndexOptions) SetTextIndexVersion(v int) {
 }
 
 // GetWeights returns the Weights field value if set, zero value otherwise
-func (o *IndexOptions) GetWeights() interface{} {
+func (o *IndexOptions) GetWeights() any {
 	if o == nil || IsNil(o.Weights) {
-		var ret interface{}
+		var ret any
 		return ret
 	}
 	return o.Weights
@@ -638,9 +638,9 @@ func (o *IndexOptions) GetWeights() interface{} {
 
 // GetWeightsOk returns a tuple with the Weights field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *IndexOptions) GetWeightsOk() (interface{}, bool) {
+func (o *IndexOptions) GetWeightsOk() (any, bool) {
 	if o == nil || IsNil(o.Weights) {
-		var ret interface{}
+		var ret any
 		return ret, false
 	}
 
@@ -656,7 +656,7 @@ func (o *IndexOptions) HasWeights() bool {
 	return false
 }
 
-// SetWeights gets a reference to the given interface{} and assigns it to the Weights field.
-func (o *IndexOptions) SetWeights(v interface{}) {
+// SetWeights gets a reference to the given any and assigns it to the Weights field.
+func (o *IndexOptions) SetWeights(v any) {
 	o.Weights = v
 }

--- a/admin/model_performance_advisor_operation.go
+++ b/admin/model_performance_advisor_operation.go
@@ -6,7 +6,7 @@ package admin
 type PerformanceAdvisorOperation struct {
 	// List that contains the search criteria that the query uses. To use the values in key-value pairs in these predicates requires **Project Data Access Read Only** permissions or greater. Otherwise, MongoDB Cloud redacts these values.
 	// Read only field.
-	Predicates *[]interface{}             `json:"predicates,omitempty"`
+	Predicates *[]any                     `json:"predicates,omitempty"`
 	Stats      *PerformanceAdvisorOpStats `json:"stats,omitempty"`
 }
 
@@ -28,9 +28,9 @@ func NewPerformanceAdvisorOperationWithDefaults() *PerformanceAdvisorOperation {
 }
 
 // GetPredicates returns the Predicates field value if set, zero value otherwise
-func (o *PerformanceAdvisorOperation) GetPredicates() []interface{} {
+func (o *PerformanceAdvisorOperation) GetPredicates() []any {
 	if o == nil || IsNil(o.Predicates) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.Predicates
@@ -38,7 +38,7 @@ func (o *PerformanceAdvisorOperation) GetPredicates() []interface{} {
 
 // GetPredicatesOk returns a tuple with the Predicates field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PerformanceAdvisorOperation) GetPredicatesOk() (*[]interface{}, bool) {
+func (o *PerformanceAdvisorOperation) GetPredicatesOk() (*[]any, bool) {
 	if o == nil || IsNil(o.Predicates) {
 		return nil, false
 	}
@@ -55,8 +55,8 @@ func (o *PerformanceAdvisorOperation) HasPredicates() bool {
 	return false
 }
 
-// SetPredicates gets a reference to the given []interface{} and assigns it to the Predicates field.
-func (o *PerformanceAdvisorOperation) SetPredicates(v []interface{}) {
+// SetPredicates gets a reference to the given []any and assigns it to the Predicates field.
+func (o *PerformanceAdvisorOperation) SetPredicates(v []any) {
 	o.Predicates = &v
 }
 

--- a/admin/model_search_index_update_request_definition.go
+++ b/admin/model_search_index_update_request_definition.go
@@ -12,11 +12,11 @@ type SearchIndexUpdateRequestDefinition struct {
 	// Method applied to identify words when searching this index.
 	SearchAnalyzer *string `json:"searchAnalyzer,omitempty"`
 	// Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn't store (false) the fields on Atlas Search.  Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see Stored Source Fields.
-	StoredSource interface{} `json:"storedSource,omitempty"`
+	StoredSource any `json:"storedSource,omitempty"`
 	// Rule sets that map words to their synonyms in this index.
 	Synonyms *[]SearchSynonymMappingDefinition `json:"synonyms,omitempty"`
 	// Settings that configure the fields, one per object, to index. You must define at least one \"vector\" type field. You can optionally define \"filter\" type fields also.
-	Fields *[]interface{} `json:"fields,omitempty"`
+	Fields *[]any `json:"fields,omitempty"`
 }
 
 // NewSearchIndexUpdateRequestDefinition instantiates a new SearchIndexUpdateRequestDefinition object
@@ -177,9 +177,9 @@ func (o *SearchIndexUpdateRequestDefinition) SetSearchAnalyzer(v string) {
 }
 
 // GetStoredSource returns the StoredSource field value if set, zero value otherwise
-func (o *SearchIndexUpdateRequestDefinition) GetStoredSource() interface{} {
+func (o *SearchIndexUpdateRequestDefinition) GetStoredSource() any {
 	if o == nil || IsNil(o.StoredSource) {
-		var ret interface{}
+		var ret any
 		return ret
 	}
 	return o.StoredSource
@@ -187,9 +187,9 @@ func (o *SearchIndexUpdateRequestDefinition) GetStoredSource() interface{} {
 
 // GetStoredSourceOk returns a tuple with the StoredSource field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *SearchIndexUpdateRequestDefinition) GetStoredSourceOk() (interface{}, bool) {
+func (o *SearchIndexUpdateRequestDefinition) GetStoredSourceOk() (any, bool) {
 	if o == nil || IsNil(o.StoredSource) {
-		var ret interface{}
+		var ret any
 		return ret, false
 	}
 
@@ -205,8 +205,8 @@ func (o *SearchIndexUpdateRequestDefinition) HasStoredSource() bool {
 	return false
 }
 
-// SetStoredSource gets a reference to the given interface{} and assigns it to the StoredSource field.
-func (o *SearchIndexUpdateRequestDefinition) SetStoredSource(v interface{}) {
+// SetStoredSource gets a reference to the given any and assigns it to the StoredSource field.
+func (o *SearchIndexUpdateRequestDefinition) SetStoredSource(v any) {
 	o.StoredSource = v
 }
 
@@ -244,9 +244,9 @@ func (o *SearchIndexUpdateRequestDefinition) SetSynonyms(v []SearchSynonymMappin
 }
 
 // GetFields returns the Fields field value if set, zero value otherwise
-func (o *SearchIndexUpdateRequestDefinition) GetFields() []interface{} {
+func (o *SearchIndexUpdateRequestDefinition) GetFields() []any {
 	if o == nil || IsNil(o.Fields) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.Fields
@@ -254,7 +254,7 @@ func (o *SearchIndexUpdateRequestDefinition) GetFields() []interface{} {
 
 // GetFieldsOk returns a tuple with the Fields field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *SearchIndexUpdateRequestDefinition) GetFieldsOk() (*[]interface{}, bool) {
+func (o *SearchIndexUpdateRequestDefinition) GetFieldsOk() (*[]any, bool) {
 	if o == nil || IsNil(o.Fields) {
 		return nil, false
 	}
@@ -271,7 +271,7 @@ func (o *SearchIndexUpdateRequestDefinition) HasFields() bool {
 	return false
 }
 
-// SetFields gets a reference to the given []interface{} and assigns it to the Fields field.
-func (o *SearchIndexUpdateRequestDefinition) SetFields(v []interface{}) {
+// SetFields gets a reference to the given []any and assigns it to the Fields field.
+func (o *SearchIndexUpdateRequestDefinition) SetFields(v []any) {
 	o.Fields = &v
 }

--- a/admin/model_search_mappings.go
+++ b/admin/model_search_mappings.go
@@ -7,7 +7,7 @@ type SearchMappings struct {
 	// Flag that indicates whether the index uses dynamic or static mappings. Required if **mappings.fields** is omitted.
 	Dynamic *bool `json:"dynamic,omitempty"`
 	// One or more field specifications for the Atlas Search index. Required if **mappings.dynamic** is omitted or set to **false**.
-	Fields interface{} `json:"fields,omitempty"`
+	Fields any `json:"fields,omitempty"`
 }
 
 // NewSearchMappings instantiates a new SearchMappings object
@@ -61,9 +61,9 @@ func (o *SearchMappings) SetDynamic(v bool) {
 }
 
 // GetFields returns the Fields field value if set, zero value otherwise
-func (o *SearchMappings) GetFields() interface{} {
+func (o *SearchMappings) GetFields() any {
 	if o == nil || IsNil(o.Fields) {
-		var ret interface{}
+		var ret any
 		return ret
 	}
 	return o.Fields
@@ -71,9 +71,9 @@ func (o *SearchMappings) GetFields() interface{} {
 
 // GetFieldsOk returns a tuple with the Fields field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *SearchMappings) GetFieldsOk() (interface{}, bool) {
+func (o *SearchMappings) GetFieldsOk() (any, bool) {
 	if o == nil || IsNil(o.Fields) {
-		var ret interface{}
+		var ret any
 		return ret, false
 	}
 
@@ -89,7 +89,7 @@ func (o *SearchMappings) HasFields() bool {
 	return false
 }
 
-// SetFields gets a reference to the given interface{} and assigns it to the Fields field.
-func (o *SearchMappings) SetFields(v interface{}) {
+// SetFields gets a reference to the given any and assigns it to the Fields field.
+func (o *SearchMappings) SetFields(v any) {
 	o.Fields = v
 }

--- a/admin/model_shard_keys.go
+++ b/admin/model_shard_keys.go
@@ -6,7 +6,7 @@ package admin
 type ShardKeys struct {
 	// List of fields to use for the shard key.
 	// Write only field.
-	Key *[]interface{} `json:"key,omitempty"`
+	Key *[]any `json:"key,omitempty"`
 }
 
 // NewShardKeys instantiates a new ShardKeys object
@@ -27,9 +27,9 @@ func NewShardKeysWithDefaults() *ShardKeys {
 }
 
 // GetKey returns the Key field value if set, zero value otherwise
-func (o *ShardKeys) GetKey() []interface{} {
+func (o *ShardKeys) GetKey() []any {
 	if o == nil || IsNil(o.Key) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.Key
@@ -37,7 +37,7 @@ func (o *ShardKeys) GetKey() []interface{} {
 
 // GetKeyOk returns a tuple with the Key field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ShardKeys) GetKeyOk() (*[]interface{}, bool) {
+func (o *ShardKeys) GetKeyOk() (*[]any, bool) {
 	if o == nil || IsNil(o.Key) {
 		return nil, false
 	}
@@ -54,7 +54,7 @@ func (o *ShardKeys) HasKey() bool {
 	return false
 }
 
-// SetKey gets a reference to the given []interface{} and assigns it to the Key field.
-func (o *ShardKeys) SetKey(v []interface{}) {
+// SetKey gets a reference to the given []any and assigns it to the Key field.
+func (o *ShardKeys) SetKey(v []any) {
 	o.Key = &v
 }

--- a/admin/model_streams_processor.go
+++ b/admin/model_streams_processor.go
@@ -14,7 +14,7 @@ type StreamsProcessor struct {
 	Name    *string         `json:"name,omitempty"`
 	Options *StreamsOptions `json:"options,omitempty"`
 	// Stream aggregation pipeline you want to apply to your streaming data.
-	Pipeline *[]interface{} `json:"pipeline,omitempty"`
+	Pipeline *[]any `json:"pipeline,omitempty"`
 }
 
 // NewStreamsProcessor instantiates a new StreamsProcessor object
@@ -167,9 +167,9 @@ func (o *StreamsProcessor) SetOptions(v StreamsOptions) {
 }
 
 // GetPipeline returns the Pipeline field value if set, zero value otherwise
-func (o *StreamsProcessor) GetPipeline() []interface{} {
+func (o *StreamsProcessor) GetPipeline() []any {
 	if o == nil || IsNil(o.Pipeline) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.Pipeline
@@ -177,7 +177,7 @@ func (o *StreamsProcessor) GetPipeline() []interface{} {
 
 // GetPipelineOk returns a tuple with the Pipeline field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *StreamsProcessor) GetPipelineOk() (*[]interface{}, bool) {
+func (o *StreamsProcessor) GetPipelineOk() (*[]any, bool) {
 	if o == nil || IsNil(o.Pipeline) {
 		return nil, false
 	}
@@ -194,7 +194,7 @@ func (o *StreamsProcessor) HasPipeline() bool {
 	return false
 }
 
-// SetPipeline gets a reference to the given []interface{} and assigns it to the Pipeline field.
-func (o *StreamsProcessor) SetPipeline(v []interface{}) {
+// SetPipeline gets a reference to the given []any and assigns it to the Pipeline field.
+func (o *StreamsProcessor) SetPipeline(v []any) {
 	o.Pipeline = &v
 }

--- a/admin/model_streams_processor_with_stats.go
+++ b/admin/model_streams_processor_with_stats.go
@@ -16,20 +16,20 @@ type StreamsProcessorWithStats struct {
 	Options *StreamsOptions `json:"options,omitempty"`
 	// Stream aggregation pipeline you want to apply to your streaming data.
 	// Read only field.
-	Pipeline []interface{} `json:"pipeline"`
+	Pipeline []any `json:"pipeline"`
 	// The state of the stream processor. Commonly occurring states are 'CREATED', 'STARTED', 'STOPPED' and 'FAILED'.
 	// Read only field.
 	State string `json:"state"`
 	// The stats associated with the stream processor.
 	// Read only field.
-	Stats interface{} `json:"stats,omitempty"`
+	Stats any `json:"stats,omitempty"`
 }
 
 // NewStreamsProcessorWithStats instantiates a new StreamsProcessorWithStats object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewStreamsProcessorWithStats(id string, name string, pipeline []interface{}, state string) *StreamsProcessorWithStats {
+func NewStreamsProcessorWithStats(id string, name string, pipeline []any, state string) *StreamsProcessorWithStats {
 	this := StreamsProcessorWithStats{}
 	this.Id = id
 	this.Name = name
@@ -161,9 +161,9 @@ func (o *StreamsProcessorWithStats) SetOptions(v StreamsOptions) {
 }
 
 // GetPipeline returns the Pipeline field value
-func (o *StreamsProcessorWithStats) GetPipeline() []interface{} {
+func (o *StreamsProcessorWithStats) GetPipeline() []any {
 	if o == nil {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 
@@ -172,7 +172,7 @@ func (o *StreamsProcessorWithStats) GetPipeline() []interface{} {
 
 // GetPipelineOk returns a tuple with the Pipeline field value
 // and a boolean to check if the value has been set.
-func (o *StreamsProcessorWithStats) GetPipelineOk() (*[]interface{}, bool) {
+func (o *StreamsProcessorWithStats) GetPipelineOk() (*[]any, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -180,7 +180,7 @@ func (o *StreamsProcessorWithStats) GetPipelineOk() (*[]interface{}, bool) {
 }
 
 // SetPipeline sets field value
-func (o *StreamsProcessorWithStats) SetPipeline(v []interface{}) {
+func (o *StreamsProcessorWithStats) SetPipeline(v []any) {
 	o.Pipeline = v
 }
 
@@ -209,9 +209,9 @@ func (o *StreamsProcessorWithStats) SetState(v string) {
 }
 
 // GetStats returns the Stats field value if set, zero value otherwise
-func (o *StreamsProcessorWithStats) GetStats() interface{} {
+func (o *StreamsProcessorWithStats) GetStats() any {
 	if o == nil || IsNil(o.Stats) {
-		var ret interface{}
+		var ret any
 		return ret
 	}
 	return o.Stats
@@ -219,9 +219,9 @@ func (o *StreamsProcessorWithStats) GetStats() interface{} {
 
 // GetStatsOk returns a tuple with the Stats field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *StreamsProcessorWithStats) GetStatsOk() (interface{}, bool) {
+func (o *StreamsProcessorWithStats) GetStatsOk() (any, bool) {
 	if o == nil || IsNil(o.Stats) {
-		var ret interface{}
+		var ret any
 		return ret, false
 	}
 
@@ -237,7 +237,7 @@ func (o *StreamsProcessorWithStats) HasStats() bool {
 	return false
 }
 
-// SetStats gets a reference to the given interface{} and assigns it to the Stats field.
-func (o *StreamsProcessorWithStats) SetStats(v interface{}) {
+// SetStats gets a reference to the given any and assigns it to the Stats field.
+func (o *StreamsProcessorWithStats) SetStats(v any) {
 	o.Stats = v
 }

--- a/admin/model_vector_search_index_definition.go
+++ b/admin/model_vector_search_index_definition.go
@@ -5,7 +5,7 @@ package admin
 // VectorSearchIndexDefinition The vector search index definition set by the user.
 type VectorSearchIndexDefinition struct {
 	// Settings that configure the fields, one per object, to index. You must define at least one \"vector\" type field. You can optionally define \"filter\" type fields also.
-	Fields *[]interface{} `json:"fields,omitempty"`
+	Fields *[]any `json:"fields,omitempty"`
 }
 
 // NewVectorSearchIndexDefinition instantiates a new VectorSearchIndexDefinition object
@@ -26,9 +26,9 @@ func NewVectorSearchIndexDefinitionWithDefaults() *VectorSearchIndexDefinition {
 }
 
 // GetFields returns the Fields field value if set, zero value otherwise
-func (o *VectorSearchIndexDefinition) GetFields() []interface{} {
+func (o *VectorSearchIndexDefinition) GetFields() []any {
 	if o == nil || IsNil(o.Fields) {
-		var ret []interface{}
+		var ret []any
 		return ret
 	}
 	return *o.Fields
@@ -36,7 +36,7 @@ func (o *VectorSearchIndexDefinition) GetFields() []interface{} {
 
 // GetFieldsOk returns a tuple with the Fields field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *VectorSearchIndexDefinition) GetFieldsOk() (*[]interface{}, bool) {
+func (o *VectorSearchIndexDefinition) GetFieldsOk() (*[]any, bool) {
 	if o == nil || IsNil(o.Fields) {
 		return nil, false
 	}
@@ -53,7 +53,7 @@ func (o *VectorSearchIndexDefinition) HasFields() bool {
 	return false
 }
 
-// SetFields gets a reference to the given []interface{} and assigns it to the Fields field.
-func (o *VectorSearchIndexDefinition) SetFields(v []interface{}) {
+// SetFields gets a reference to the given []any and assigns it to the Fields field.
+func (o *VectorSearchIndexDefinition) SetFields(v []any) {
 	o.Fields = &v
 }

--- a/admin/utils.go
+++ b/admin/utils.go
@@ -32,11 +32,11 @@ func PtrString(v string) *string { return &v }
 func PtrTime(v time.Time) *time.Time { return &v }
 
 type modelWithMap interface {
-	ToMap() (map[string]interface{}, error)
+	ToMap() (map[string]any, error)
 }
 
 // IsNil checks if an input is nil
-func IsNil(i interface{}) bool {
+func IsNil(i any) bool {
 	if i == nil {
 		return true
 	}

--- a/docs/docs/ApiAtlasFTSAnalyzers.md
+++ b/docs/docs/ApiAtlasFTSAnalyzers.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**CharFilters** | Pointer to **[]interface{}** | Filters that examine text one character at a time and perform filtering operations. | [optional] 
+**CharFilters** | Pointer to [**[]any**](any.md) | Filters that examine text one character at a time and perform filtering operations. | [optional] 
 **Name** | **string** | Human-readable name that identifies the custom analyzer. Names must be unique within an index, and must not start with any of the following strings: - &#x60;lucene.&#x60; - &#x60;builtin.&#x60; - &#x60;mongodb.&#x60; | 
-**TokenFilters** | Pointer to **[]interface{}** | Filter that performs operations such as:  - Stemming, which reduces related words, such as \&quot;talking\&quot;, \&quot;talked\&quot;, and \&quot;talks\&quot; to their root word \&quot;talk\&quot;.  - Redaction, the removal of sensitive information from public documents. | [optional] 
+**TokenFilters** | Pointer to [**[]any**](any.md) | Filter that performs operations such as:  - Stemming, which reduces related words, such as \&quot;talking\&quot;, \&quot;talked\&quot;, and \&quot;talks\&quot; to their root word \&quot;talk\&quot;.  - Redaction, the removal of sensitive information from public documents. | [optional] 
 **Tokenizer** | [**ApiAtlasFTSAnalyzersTokenizer**](ApiAtlasFTSAnalyzersTokenizer.md) |  | 
 
 ## Methods
@@ -30,20 +30,20 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetCharFilters
 
-`func (o *ApiAtlasFTSAnalyzers) GetCharFilters() []interface{}`
+`func (o *ApiAtlasFTSAnalyzers) GetCharFilters() []any`
 
 GetCharFilters returns the CharFilters field if non-nil, zero value otherwise.
 
 ### GetCharFiltersOk
 
-`func (o *ApiAtlasFTSAnalyzers) GetCharFiltersOk() (*[]interface{}, bool)`
+`func (o *ApiAtlasFTSAnalyzers) GetCharFiltersOk() (*[]any, bool)`
 
 GetCharFiltersOk returns a tuple with the CharFilters field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetCharFilters
 
-`func (o *ApiAtlasFTSAnalyzers) SetCharFilters(v []interface{})`
+`func (o *ApiAtlasFTSAnalyzers) SetCharFilters(v []any)`
 
 SetCharFilters sets CharFilters field to given value.
 
@@ -73,20 +73,20 @@ SetName sets Name field to given value.
 
 ### GetTokenFilters
 
-`func (o *ApiAtlasFTSAnalyzers) GetTokenFilters() []interface{}`
+`func (o *ApiAtlasFTSAnalyzers) GetTokenFilters() []any`
 
 GetTokenFilters returns the TokenFilters field if non-nil, zero value otherwise.
 
 ### GetTokenFiltersOk
 
-`func (o *ApiAtlasFTSAnalyzers) GetTokenFiltersOk() (*[]interface{}, bool)`
+`func (o *ApiAtlasFTSAnalyzers) GetTokenFiltersOk() (*[]any, bool)`
 
 GetTokenFiltersOk returns a tuple with the TokenFilters field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetTokenFilters
 
-`func (o *ApiAtlasFTSAnalyzers) SetTokenFilters(v []interface{})`
+`func (o *ApiAtlasFTSAnalyzers) SetTokenFilters(v []any)`
 
 SetTokenFilters sets TokenFilters field to given value.
 

--- a/docs/docs/ApiAtlasFTSMappings.md
+++ b/docs/docs/ApiAtlasFTSMappings.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Dynamic** | Pointer to **bool** | Flag that indicates whether the index uses dynamic or static mappings. Required if **mappings.fields** is omitted. | [optional] [default to false]
-**Fields** | Pointer to **interface{}** | One or more field specifications for the Atlas Search index. Required if **mappings.dynamic** is omitted or set to **false**. | [optional] 
+**Fields** | Pointer to [**any**](interface{}.md) | One or more field specifications for the Atlas Search index. Required if **mappings.dynamic** is omitted or set to **false**. | [optional] 
 
 ## Methods
 
@@ -52,20 +52,20 @@ SetDynamic sets Dynamic field to given value.
 HasDynamic returns a boolean if a field has been set.
 ### GetFields
 
-`func (o *ApiAtlasFTSMappings) GetFields() interface{}`
+`func (o *ApiAtlasFTSMappings) GetFields() any`
 
 GetFields returns the Fields field if non-nil, zero value otherwise.
 
 ### GetFieldsOk
 
-`func (o *ApiAtlasFTSMappings) GetFieldsOk() (*interface{}, bool)`
+`func (o *ApiAtlasFTSMappings) GetFieldsOk() (*any, bool)`
 
 GetFieldsOk returns a tuple with the Fields field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetFields
 
-`func (o *ApiAtlasFTSMappings) SetFields(v interface{})`
+`func (o *ApiAtlasFTSMappings) SetFields(v any)`
 
 SetFields sets Fields field to given value.
 

--- a/docs/docs/ApiError.md
+++ b/docs/docs/ApiError.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Detail** | Pointer to **string** | Describes the specific conditions or reasons that cause each type of error. | [optional] 
 **Error** | Pointer to **int** | HTTP status code returned with this error. | [optional] 
 **ErrorCode** | Pointer to **string** | Application error code returned with this error. | [optional] 
-**Parameters** | Pointer to **[]interface{}** | Parameters used to give more information about the error. | [optional] 
+**Parameters** | Pointer to [**[]any**](any.md) | Parameters used to give more information about the error. | [optional] 
 **Reason** | Pointer to **string** | Application error message returned with this error. | [optional] 
 
 ## Methods
@@ -128,20 +128,20 @@ SetErrorCode sets ErrorCode field to given value.
 HasErrorCode returns a boolean if a field has been set.
 ### GetParameters
 
-`func (o *ApiError) GetParameters() []interface{}`
+`func (o *ApiError) GetParameters() []any`
 
 GetParameters returns the Parameters field if non-nil, zero value otherwise.
 
 ### GetParametersOk
 
-`func (o *ApiError) GetParametersOk() (*[]interface{}, bool)`
+`func (o *ApiError) GetParametersOk() (*[]any, bool)`
 
 GetParametersOk returns a tuple with the Parameters field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetParameters
 
-`func (o *ApiError) SetParameters(v []interface{})`
+`func (o *ApiError) SetParameters(v []any)`
 
 SetParameters sets Parameters field to given value.
 

--- a/docs/docs/AtlasSearchAnalyzer.md
+++ b/docs/docs/AtlasSearchAnalyzer.md
@@ -4,16 +4,16 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**CharFilters** | Pointer to **[]interface{}** | Filters that examine text one character at a time and perform filtering operations. | [optional] 
+**CharFilters** | Pointer to [**[]any**](any.md) | Filters that examine text one character at a time and perform filtering operations. | [optional] 
 **Name** | **string** | Name that identifies the custom analyzer. Names must be unique within an index, and must not start with any of the following strings: - &#x60;lucene.&#x60; - &#x60;builtin.&#x60; - &#x60;mongodb.&#x60; | 
-**TokenFilters** | Pointer to **[]interface{}** | Filter that performs operations such as:  - Stemming, which reduces related words, such as \&quot;talking\&quot;, \&quot;talked\&quot;, and \&quot;talks\&quot; to their root word \&quot;talk\&quot;.  - Redaction, which is the removal of sensitive information from public documents. | [optional] 
-**Tokenizer** | **interface{}** | Tokenizer that you want to use to create tokens. Tokens determine how Atlas Search splits up text into discrete chunks for indexing. | 
+**TokenFilters** | Pointer to [**[]any**](any.md) | Filter that performs operations such as:  - Stemming, which reduces related words, such as \&quot;talking\&quot;, \&quot;talked\&quot;, and \&quot;talks\&quot; to their root word \&quot;talk\&quot;.  - Redaction, which is the removal of sensitive information from public documents. | [optional] 
+**Tokenizer** | [**any**](interface{}.md) | Tokenizer that you want to use to create tokens. Tokens determine how Atlas Search splits up text into discrete chunks for indexing. | 
 
 ## Methods
 
 ### NewAtlasSearchAnalyzer
 
-`func NewAtlasSearchAnalyzer(name string, tokenizer interface{}, ) *AtlasSearchAnalyzer`
+`func NewAtlasSearchAnalyzer(name string, tokenizer any, ) *AtlasSearchAnalyzer`
 
 NewAtlasSearchAnalyzer instantiates a new AtlasSearchAnalyzer object
 This constructor will assign default values to properties that have it defined,
@@ -30,20 +30,20 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetCharFilters
 
-`func (o *AtlasSearchAnalyzer) GetCharFilters() []interface{}`
+`func (o *AtlasSearchAnalyzer) GetCharFilters() []any`
 
 GetCharFilters returns the CharFilters field if non-nil, zero value otherwise.
 
 ### GetCharFiltersOk
 
-`func (o *AtlasSearchAnalyzer) GetCharFiltersOk() (*[]interface{}, bool)`
+`func (o *AtlasSearchAnalyzer) GetCharFiltersOk() (*[]any, bool)`
 
 GetCharFiltersOk returns a tuple with the CharFilters field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetCharFilters
 
-`func (o *AtlasSearchAnalyzer) SetCharFilters(v []interface{})`
+`func (o *AtlasSearchAnalyzer) SetCharFilters(v []any)`
 
 SetCharFilters sets CharFilters field to given value.
 
@@ -73,20 +73,20 @@ SetName sets Name field to given value.
 
 ### GetTokenFilters
 
-`func (o *AtlasSearchAnalyzer) GetTokenFilters() []interface{}`
+`func (o *AtlasSearchAnalyzer) GetTokenFilters() []any`
 
 GetTokenFilters returns the TokenFilters field if non-nil, zero value otherwise.
 
 ### GetTokenFiltersOk
 
-`func (o *AtlasSearchAnalyzer) GetTokenFiltersOk() (*[]interface{}, bool)`
+`func (o *AtlasSearchAnalyzer) GetTokenFiltersOk() (*[]any, bool)`
 
 GetTokenFiltersOk returns a tuple with the TokenFilters field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetTokenFilters
 
-`func (o *AtlasSearchAnalyzer) SetTokenFilters(v []interface{})`
+`func (o *AtlasSearchAnalyzer) SetTokenFilters(v []any)`
 
 SetTokenFilters sets TokenFilters field to given value.
 
@@ -97,20 +97,20 @@ SetTokenFilters sets TokenFilters field to given value.
 HasTokenFilters returns a boolean if a field has been set.
 ### GetTokenizer
 
-`func (o *AtlasSearchAnalyzer) GetTokenizer() interface{}`
+`func (o *AtlasSearchAnalyzer) GetTokenizer() any`
 
 GetTokenizer returns the Tokenizer field if non-nil, zero value otherwise.
 
 ### GetTokenizerOk
 
-`func (o *AtlasSearchAnalyzer) GetTokenizerOk() (*interface{}, bool)`
+`func (o *AtlasSearchAnalyzer) GetTokenizerOk() (*any, bool)`
 
 GetTokenizerOk returns a tuple with the Tokenizer field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetTokenizer
 
-`func (o *AtlasSearchAnalyzer) SetTokenizer(v interface{})`
+`func (o *AtlasSearchAnalyzer) SetTokenizer(v any)`
 
 SetTokenizer sets Tokenizer field to given value.
 

--- a/docs/docs/AtlasSearchApi.md
+++ b/docs/docs/AtlasSearchApi.md
@@ -282,7 +282,7 @@ Name | Type | Description  | Notes
 
 ## DeleteAtlasSearchDeployment
 
-> interface{} DeleteAtlasSearchDeployment(ctx, groupId, clusterName).Execute()
+> any DeleteAtlasSearchDeployment(ctx, groupId, clusterName).Execute()
 
 Delete Search Nodes
 
@@ -322,7 +322,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteAtlasSearchDeployment`: interface{}
+    // response from `DeleteAtlasSearchDeployment`: any
     fmt.Fprintf(os.Stdout, "Response from `AtlasSearchApi.DeleteAtlasSearchDeployment`: %v (%v)\n", resp, r)
 }
 ```
@@ -348,7 +348,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -365,7 +365,7 @@ Name | Type | Description  | Notes
 
 ## DeleteAtlasSearchIndex
 
-> interface{} DeleteAtlasSearchIndex(ctx, groupId, clusterName, indexId).Execute()
+> any DeleteAtlasSearchIndex(ctx, groupId, clusterName, indexId).Execute()
 
 Remove One Atlas Search Index by Id
 
@@ -406,7 +406,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteAtlasSearchIndex`: interface{}
+    // response from `DeleteAtlasSearchIndex`: any
     fmt.Fprintf(os.Stdout, "Response from `AtlasSearchApi.DeleteAtlasSearchIndex`: %v (%v)\n", resp, r)
 }
 ```
@@ -434,7 +434,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -451,7 +451,7 @@ Name | Type | Description  | Notes
 
 ## DeleteAtlasSearchIndexByName
 
-> interface{} DeleteAtlasSearchIndexByName(ctx, groupId, clusterName, collectionName, databaseName, indexName).Execute()
+> any DeleteAtlasSearchIndexByName(ctx, groupId, clusterName, collectionName, databaseName, indexName).Execute()
 
 Remove One Atlas Search Index by Name
 
@@ -494,7 +494,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteAtlasSearchIndexByName`: interface{}
+    // response from `DeleteAtlasSearchIndexByName`: any
     fmt.Fprintf(os.Stdout, "Response from `AtlasSearchApi.DeleteAtlasSearchIndexByName`: %v (%v)\n", resp, r)
 }
 ```
@@ -526,7 +526,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -543,7 +543,7 @@ Name | Type | Description  | Notes
 
 ## DeleteAtlasSearchIndexDeprecated
 
-> interface{} DeleteAtlasSearchIndexDeprecated(ctx, groupId, clusterName, indexId).Execute()
+> any DeleteAtlasSearchIndexDeprecated(ctx, groupId, clusterName, indexId).Execute()
 
 Remove One Atlas Search Index
 
@@ -584,7 +584,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteAtlasSearchIndexDeprecated`: interface{}
+    // response from `DeleteAtlasSearchIndexDeprecated`: any
     fmt.Fprintf(os.Stdout, "Response from `AtlasSearchApi.DeleteAtlasSearchIndexDeprecated`: %v (%v)\n", resp, r)
 }
 ```
@@ -612,7 +612,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/BaseSearchIndexCreateRequestDefinition.md
+++ b/docs/docs/BaseSearchIndexCreateRequestDefinition.md
@@ -8,9 +8,9 @@ Name | Type | Description | Notes
 **Analyzers** | Pointer to [**[]AtlasSearchAnalyzer**](AtlasSearchAnalyzer.md) | List of user-defined methods to convert database field text into searchable words. | [optional] 
 **Mappings** | Pointer to [**SearchMappings**](SearchMappings.md) |  | [optional] 
 **SearchAnalyzer** | Pointer to **string** | Method applied to identify words when searching this index. | [optional] [default to "lucene.standard"]
-**StoredSource** | Pointer to **interface{}** | Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn&#39;t store (false) the fields on Atlas Search.  Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see Stored Source Fields. | [optional] 
+**StoredSource** | Pointer to [**any**](interface{}.md) | Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn&#39;t store (false) the fields on Atlas Search.  Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see Stored Source Fields. | [optional] 
 **Synonyms** | Pointer to [**[]SearchSynonymMappingDefinition**](SearchSynonymMappingDefinition.md) | Rule sets that map words to their synonyms in this index. | [optional] 
-**Fields** | Pointer to **[]interface{}** | Settings that configure the fields, one per object, to index. You must define at least one \&quot;vector\&quot; type field. You can optionally define \&quot;filter\&quot; type fields also. | [optional] 
+**Fields** | Pointer to [**[]any**](any.md) | Settings that configure the fields, one per object, to index. You must define at least one \&quot;vector\&quot; type field. You can optionally define \&quot;filter\&quot; type fields also. | [optional] 
 
 ## Methods
 
@@ -129,20 +129,20 @@ SetSearchAnalyzer sets SearchAnalyzer field to given value.
 HasSearchAnalyzer returns a boolean if a field has been set.
 ### GetStoredSource
 
-`func (o *BaseSearchIndexCreateRequestDefinition) GetStoredSource() interface{}`
+`func (o *BaseSearchIndexCreateRequestDefinition) GetStoredSource() any`
 
 GetStoredSource returns the StoredSource field if non-nil, zero value otherwise.
 
 ### GetStoredSourceOk
 
-`func (o *BaseSearchIndexCreateRequestDefinition) GetStoredSourceOk() (*interface{}, bool)`
+`func (o *BaseSearchIndexCreateRequestDefinition) GetStoredSourceOk() (*any, bool)`
 
 GetStoredSourceOk returns a tuple with the StoredSource field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetStoredSource
 
-`func (o *BaseSearchIndexCreateRequestDefinition) SetStoredSource(v interface{})`
+`func (o *BaseSearchIndexCreateRequestDefinition) SetStoredSource(v any)`
 
 SetStoredSource sets StoredSource field to given value.
 
@@ -177,20 +177,20 @@ SetSynonyms sets Synonyms field to given value.
 HasSynonyms returns a boolean if a field has been set.
 ### GetFields
 
-`func (o *BaseSearchIndexCreateRequestDefinition) GetFields() []interface{}`
+`func (o *BaseSearchIndexCreateRequestDefinition) GetFields() []any`
 
 GetFields returns the Fields field if non-nil, zero value otherwise.
 
 ### GetFieldsOk
 
-`func (o *BaseSearchIndexCreateRequestDefinition) GetFieldsOk() (*[]interface{}, bool)`
+`func (o *BaseSearchIndexCreateRequestDefinition) GetFieldsOk() (*[]any, bool)`
 
 GetFieldsOk returns a tuple with the Fields field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetFields
 
-`func (o *BaseSearchIndexCreateRequestDefinition) SetFields(v []interface{})`
+`func (o *BaseSearchIndexCreateRequestDefinition) SetFields(v []any)`
 
 SetFields sets Fields field to given value.
 

--- a/docs/docs/BaseSearchIndexResponseLatestDefinition.md
+++ b/docs/docs/BaseSearchIndexResponseLatestDefinition.md
@@ -8,9 +8,9 @@ Name | Type | Description | Notes
 **Analyzers** | Pointer to [**[]AtlasSearchAnalyzer**](AtlasSearchAnalyzer.md) | List of user-defined methods to convert database field text into searchable words. | [optional] 
 **Mappings** | Pointer to [**SearchMappings**](SearchMappings.md) |  | [optional] 
 **SearchAnalyzer** | Pointer to **string** | Method applied to identify words when searching this index. | [optional] [default to "lucene.standard"]
-**StoredSource** | Pointer to **interface{}** | Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn&#39;t store (false) the fields on Atlas Search.  Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see Stored Source Fields. | [optional] 
+**StoredSource** | Pointer to [**any**](interface{}.md) | Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn&#39;t store (false) the fields on Atlas Search.  Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see Stored Source Fields. | [optional] 
 **Synonyms** | Pointer to [**[]SearchSynonymMappingDefinition**](SearchSynonymMappingDefinition.md) | Rule sets that map words to their synonyms in this index. | [optional] 
-**Fields** | Pointer to **[]interface{}** | Settings that configure the fields, one per object, to index. You must define at least one \&quot;vector\&quot; type field. You can optionally define \&quot;filter\&quot; type fields also. | [optional] 
+**Fields** | Pointer to [**[]any**](any.md) | Settings that configure the fields, one per object, to index. You must define at least one \&quot;vector\&quot; type field. You can optionally define \&quot;filter\&quot; type fields also. | [optional] 
 
 ## Methods
 
@@ -129,20 +129,20 @@ SetSearchAnalyzer sets SearchAnalyzer field to given value.
 HasSearchAnalyzer returns a boolean if a field has been set.
 ### GetStoredSource
 
-`func (o *BaseSearchIndexResponseLatestDefinition) GetStoredSource() interface{}`
+`func (o *BaseSearchIndexResponseLatestDefinition) GetStoredSource() any`
 
 GetStoredSource returns the StoredSource field if non-nil, zero value otherwise.
 
 ### GetStoredSourceOk
 
-`func (o *BaseSearchIndexResponseLatestDefinition) GetStoredSourceOk() (*interface{}, bool)`
+`func (o *BaseSearchIndexResponseLatestDefinition) GetStoredSourceOk() (*any, bool)`
 
 GetStoredSourceOk returns a tuple with the StoredSource field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetStoredSource
 
-`func (o *BaseSearchIndexResponseLatestDefinition) SetStoredSource(v interface{})`
+`func (o *BaseSearchIndexResponseLatestDefinition) SetStoredSource(v any)`
 
 SetStoredSource sets StoredSource field to given value.
 
@@ -177,20 +177,20 @@ SetSynonyms sets Synonyms field to given value.
 HasSynonyms returns a boolean if a field has been set.
 ### GetFields
 
-`func (o *BaseSearchIndexResponseLatestDefinition) GetFields() []interface{}`
+`func (o *BaseSearchIndexResponseLatestDefinition) GetFields() []any`
 
 GetFields returns the Fields field if non-nil, zero value otherwise.
 
 ### GetFieldsOk
 
-`func (o *BaseSearchIndexResponseLatestDefinition) GetFieldsOk() (*[]interface{}, bool)`
+`func (o *BaseSearchIndexResponseLatestDefinition) GetFieldsOk() (*[]any, bool)`
 
 GetFieldsOk returns a tuple with the Fields field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetFields
 
-`func (o *BaseSearchIndexResponseLatestDefinition) SetFields(v []interface{})`
+`func (o *BaseSearchIndexResponseLatestDefinition) SetFields(v []any)`
 
 SetFields sets Fields field to given value.
 

--- a/docs/docs/CloudBackupsApi.md
+++ b/docs/docs/CloudBackupsApi.md
@@ -38,7 +38,7 @@ Method | HTTP request | Description
 
 ## CancelBackupRestoreJob
 
-> interface{} CancelBackupRestoreJob(ctx, groupId, clusterName, restoreJobId).Execute()
+> any CancelBackupRestoreJob(ctx, groupId, clusterName, restoreJobId).Execute()
 
 Cancel One Restore Job of One Cluster
 
@@ -79,7 +79,7 @@ func main() {
         }
         return
     }
-    // response from `CancelBackupRestoreJob`: interface{}
+    // response from `CancelBackupRestoreJob`: any
     fmt.Fprintf(os.Stdout, "Response from `CloudBackupsApi.CancelBackupRestoreJob`: %v (%v)\n", resp, r)
 }
 ```
@@ -107,7 +107,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -544,7 +544,7 @@ Name | Type | Description  | Notes
 
 ## DeleteExportBucket
 
-> interface{} DeleteExportBucket(ctx, groupId, exportBucketId).Execute()
+> any DeleteExportBucket(ctx, groupId, exportBucketId).Execute()
 
 Revoke Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports
 
@@ -584,7 +584,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteExportBucket`: interface{}
+    // response from `DeleteExportBucket`: any
     fmt.Fprintf(os.Stdout, "Response from `CloudBackupsApi.DeleteExportBucket`: %v (%v)\n", resp, r)
 }
 ```
@@ -610,7 +610,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -627,7 +627,7 @@ Name | Type | Description  | Notes
 
 ## DeleteReplicaSetBackup
 
-> interface{} DeleteReplicaSetBackup(ctx, groupId, clusterName, snapshotId).Execute()
+> any DeleteReplicaSetBackup(ctx, groupId, clusterName, snapshotId).Execute()
 
 Remove One Replica Set Cloud Backup
 
@@ -668,7 +668,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteReplicaSetBackup`: interface{}
+    // response from `DeleteReplicaSetBackup`: any
     fmt.Fprintf(os.Stdout, "Response from `CloudBackupsApi.DeleteReplicaSetBackup`: %v (%v)\n", resp, r)
 }
 ```
@@ -696,7 +696,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -713,7 +713,7 @@ Name | Type | Description  | Notes
 
 ## DeleteShardedClusterBackup
 
-> interface{} DeleteShardedClusterBackup(ctx, groupId, clusterName, snapshotId).Execute()
+> any DeleteShardedClusterBackup(ctx, groupId, clusterName, snapshotId).Execute()
 
 Remove One Sharded Cluster Cloud Backup
 
@@ -754,7 +754,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteShardedClusterBackup`: interface{}
+    // response from `DeleteShardedClusterBackup`: any
     fmt.Fprintf(os.Stdout, "Response from `CloudBackupsApi.DeleteShardedClusterBackup`: %v (%v)\n", resp, r)
 }
 ```
@@ -782,7 +782,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/CloudMigrationServiceApi.md
+++ b/docs/docs/CloudMigrationServiceApi.md
@@ -262,7 +262,7 @@ Name | Type | Description  | Notes
 
 ## DeleteLinkToken
 
-> interface{} DeleteLinkToken(ctx, orgId).Execute()
+> any DeleteLinkToken(ctx, orgId).Execute()
 
 Remove One Link-Token
 
@@ -301,7 +301,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteLinkToken`: interface{}
+    // response from `DeleteLinkToken`: any
     fmt.Fprintf(os.Stdout, "Response from `CloudMigrationServiceApi.DeleteLinkToken`: %v (%v)\n", resp, r)
 }
 ```
@@ -325,7 +325,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/ClusterSearchIndex.md
+++ b/docs/docs/ClusterSearchIndex.md
@@ -14,9 +14,9 @@ Name | Type | Description | Notes
 **Analyzers** | Pointer to [**[]ApiAtlasFTSAnalyzers**](ApiAtlasFTSAnalyzers.md) | List of user-defined methods to convert database field text into searchable words. | [optional] 
 **Mappings** | Pointer to [**ApiAtlasFTSMappings**](ApiAtlasFTSMappings.md) |  | [optional] 
 **SearchAnalyzer** | Pointer to **string** | Method applied to identify words when searching this index. | [optional] [default to "lucene.standard"]
-**StoredSource** | Pointer to **interface{}** | Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn&#39;t store (false) the fields on Atlas Search.  Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see documentation. | [optional] 
+**StoredSource** | Pointer to [**any**](interface{}.md) | Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn&#39;t store (false) the fields on Atlas Search.  Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see documentation. | [optional] 
 **Synonyms** | Pointer to [**[]SearchSynonymMappingDefinition**](SearchSynonymMappingDefinition.md) | Rule sets that map words to their synonyms in this index. | [optional] 
-**Fields** | Pointer to **[]interface{}** | Settings that configure the fields, one per object, to index. You must define at least one \&quot;vector\&quot; type field. You can optionally define \&quot;filter\&quot; type fields also. | [optional] 
+**Fields** | Pointer to [**[]any**](any.md) | Settings that configure the fields, one per object, to index. You must define at least one \&quot;vector\&quot; type field. You can optionally define \&quot;filter\&quot; type fields also. | [optional] 
 
 ## Methods
 
@@ -264,20 +264,20 @@ SetSearchAnalyzer sets SearchAnalyzer field to given value.
 HasSearchAnalyzer returns a boolean if a field has been set.
 ### GetStoredSource
 
-`func (o *ClusterSearchIndex) GetStoredSource() interface{}`
+`func (o *ClusterSearchIndex) GetStoredSource() any`
 
 GetStoredSource returns the StoredSource field if non-nil, zero value otherwise.
 
 ### GetStoredSourceOk
 
-`func (o *ClusterSearchIndex) GetStoredSourceOk() (*interface{}, bool)`
+`func (o *ClusterSearchIndex) GetStoredSourceOk() (*any, bool)`
 
 GetStoredSourceOk returns a tuple with the StoredSource field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetStoredSource
 
-`func (o *ClusterSearchIndex) SetStoredSource(v interface{})`
+`func (o *ClusterSearchIndex) SetStoredSource(v any)`
 
 SetStoredSource sets StoredSource field to given value.
 
@@ -312,20 +312,20 @@ SetSynonyms sets Synonyms field to given value.
 HasSynonyms returns a boolean if a field has been set.
 ### GetFields
 
-`func (o *ClusterSearchIndex) GetFields() []interface{}`
+`func (o *ClusterSearchIndex) GetFields() []any`
 
 GetFields returns the Fields field if non-nil, zero value otherwise.
 
 ### GetFieldsOk
 
-`func (o *ClusterSearchIndex) GetFieldsOk() (*[]interface{}, bool)`
+`func (o *ClusterSearchIndex) GetFieldsOk() (*[]any, bool)`
 
 GetFieldsOk returns a tuple with the Fields field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetFields
 
-`func (o *ClusterSearchIndex) SetFields(v []interface{})`
+`func (o *ClusterSearchIndex) SetFields(v []any)`
 
 SetFields sets Fields field to given value.
 

--- a/docs/docs/ClustersApi.md
+++ b/docs/docs/ClustersApi.md
@@ -525,7 +525,7 @@ Name | Type | Description  | Notes
 
 ## GrantMongoDBEmployeeAccess
 
-> interface{} GrantMongoDBEmployeeAccess(ctx, groupId, clusterName, employeeAccessGrant EmployeeAccessGrant).Execute()
+> any GrantMongoDBEmployeeAccess(ctx, groupId, clusterName, employeeAccessGrant EmployeeAccessGrant).Execute()
 
 Grant MongoDB employee cluster access for one cluster.
 
@@ -566,7 +566,7 @@ func main() {
         }
         return
     }
-    // response from `GrantMongoDBEmployeeAccess`: interface{}
+    // response from `GrantMongoDBEmployeeAccess`: any
     fmt.Fprintf(os.Stdout, "Response from `ClustersApi.GrantMongoDBEmployeeAccess`: %v (%v)\n", resp, r)
 }
 ```
@@ -593,7 +593,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -951,7 +951,7 @@ Name | Type | Description  | Notes
 
 ## PinFeatureCompatibilityVersion
 
-> interface{} PinFeatureCompatibilityVersion(ctx, groupId, clusterName, pinFCV PinFCV).Execute()
+> any PinFeatureCompatibilityVersion(ctx, groupId, clusterName, pinFCV PinFCV).Execute()
 
 Pin FCV for One Cluster from One Project
 
@@ -992,7 +992,7 @@ func main() {
         }
         return
     }
-    // response from `PinFeatureCompatibilityVersion`: interface{}
+    // response from `PinFeatureCompatibilityVersion`: any
     fmt.Fprintf(os.Stdout, "Response from `ClustersApi.PinFeatureCompatibilityVersion`: %v (%v)\n", resp, r)
 }
 ```
@@ -1019,7 +1019,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -1036,7 +1036,7 @@ Name | Type | Description  | Notes
 
 ## RevokeMongoDBEmployeeAccess
 
-> interface{} RevokeMongoDBEmployeeAccess(ctx, groupId, clusterName).Execute()
+> any RevokeMongoDBEmployeeAccess(ctx, groupId, clusterName).Execute()
 
 Revoke granted MongoDB employee cluster access for one cluster.
 
@@ -1076,7 +1076,7 @@ func main() {
         }
         return
     }
-    // response from `RevokeMongoDBEmployeeAccess`: interface{}
+    // response from `RevokeMongoDBEmployeeAccess`: any
     fmt.Fprintf(os.Stdout, "Response from `ClustersApi.RevokeMongoDBEmployeeAccess`: %v (%v)\n", resp, r)
 }
 ```
@@ -1102,7 +1102,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -1200,7 +1200,7 @@ Name | Type | Description  | Notes
 
 ## UnpinFeatureCompatibilityVersion
 
-> interface{} UnpinFeatureCompatibilityVersion(ctx, groupId, clusterName).Execute()
+> any UnpinFeatureCompatibilityVersion(ctx, groupId, clusterName).Execute()
 
 Unpins FCV for One Cluster from One Project
 
@@ -1240,7 +1240,7 @@ func main() {
         }
         return
     }
-    // response from `UnpinFeatureCompatibilityVersion`: interface{}
+    // response from `UnpinFeatureCompatibilityVersion`: any
     fmt.Fprintf(os.Stdout, "Response from `ClustersApi.UnpinFeatureCompatibilityVersion`: %v (%v)\n", resp, r)
 }
 ```
@@ -1266,7 +1266,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/CollectionLevelMetricsApi.md
+++ b/docs/docs/CollectionLevelMetricsApi.md
@@ -215,7 +215,7 @@ Name | Type | Description  | Notes
 
 ## GetCollStatsLatencyNamespaceMetrics
 
-> interface{} GetCollStatsLatencyNamespaceMetrics(ctx, groupId).Execute()
+> any GetCollStatsLatencyNamespaceMetrics(ctx, groupId).Execute()
 
 Return all metric names
 
@@ -254,7 +254,7 @@ func main() {
         }
         return
     }
-    // response from `GetCollStatsLatencyNamespaceMetrics`: interface{}
+    // response from `GetCollStatsLatencyNamespaceMetrics`: any
     fmt.Fprintf(os.Stdout, "Response from `CollectionLevelMetricsApi.GetCollStatsLatencyNamespaceMetrics`: %v (%v)\n", resp, r)
 }
 ```
@@ -278,7 +278,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/DataFederationApi.md
+++ b/docs/docs/DataFederationApi.md
@@ -277,7 +277,7 @@ Name | Type | Description  | Notes
 
 ## DeleteDataFederationPrivateEndpoint
 
-> interface{} DeleteDataFederationPrivateEndpoint(ctx, groupId, endpointId).Execute()
+> any DeleteDataFederationPrivateEndpoint(ctx, groupId, endpointId).Execute()
 
 Remove One Federated Database Instance and Online Archive Private Endpoint from One Project
 
@@ -317,7 +317,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteDataFederationPrivateEndpoint`: interface{}
+    // response from `DeleteDataFederationPrivateEndpoint`: any
     fmt.Fprintf(os.Stdout, "Response from `DataFederationApi.DeleteDataFederationPrivateEndpoint`: %v (%v)\n", resp, r)
 }
 ```
@@ -343,7 +343,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -360,7 +360,7 @@ Name | Type | Description  | Notes
 
 ## DeleteFederatedDatabase
 
-> interface{} DeleteFederatedDatabase(ctx, groupId, tenantName).Execute()
+> any DeleteFederatedDatabase(ctx, groupId, tenantName).Execute()
 
 Remove One Federated Database Instance from One Project
 
@@ -400,7 +400,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteFederatedDatabase`: interface{}
+    // response from `DeleteFederatedDatabase`: any
     fmt.Fprintf(os.Stdout, "Response from `DataFederationApi.DeleteFederatedDatabase`: %v (%v)\n", resp, r)
 }
 ```
@@ -426,7 +426,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -443,7 +443,7 @@ Name | Type | Description  | Notes
 
 ## DeleteOneDataFederationInstanceQueryLimit
 
-> interface{} DeleteOneDataFederationInstanceQueryLimit(ctx, groupId, tenantName, limitName).Execute()
+> any DeleteOneDataFederationInstanceQueryLimit(ctx, groupId, tenantName, limitName).Execute()
 
 Delete One Query Limit For One Federated Database Instance
 
@@ -484,7 +484,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteOneDataFederationInstanceQueryLimit`: interface{}
+    // response from `DeleteOneDataFederationInstanceQueryLimit`: any
     fmt.Fprintf(os.Stdout, "Response from `DataFederationApi.DeleteOneDataFederationInstanceQueryLimit`: %v (%v)\n", resp, r)
 }
 ```
@@ -512,7 +512,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/DataLakePipelinesApi.md
+++ b/docs/docs/DataLakePipelinesApi.md
@@ -104,7 +104,7 @@ Name | Type | Description  | Notes
 
 ## DeletePipeline
 
-> interface{} DeletePipeline(ctx, groupId, pipelineName).Execute()
+> any DeletePipeline(ctx, groupId, pipelineName).Execute()
 
 Remove One Data Lake Pipeline
 
@@ -144,7 +144,7 @@ func main() {
         }
         return
     }
-    // response from `DeletePipeline`: interface{}
+    // response from `DeletePipeline`: any
     fmt.Fprintf(os.Stdout, "Response from `DataLakePipelinesApi.DeletePipeline`: %v (%v)\n", resp, r)
 }
 ```
@@ -170,7 +170,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -187,7 +187,7 @@ Name | Type | Description  | Notes
 
 ## DeletePipelineRunDataset
 
-> interface{} DeletePipelineRunDataset(ctx, groupId, pipelineName, pipelineRunId).Execute()
+> any DeletePipelineRunDataset(ctx, groupId, pipelineName, pipelineRunId).Execute()
 
 Delete Pipeline Run Dataset
 
@@ -228,7 +228,7 @@ func main() {
         }
         return
     }
-    // response from `DeletePipelineRunDataset`: interface{}
+    // response from `DeletePipelineRunDataset`: any
     fmt.Fprintf(os.Stdout, "Response from `DataLakePipelinesApi.DeletePipelineRunDataset`: %v (%v)\n", resp, r)
 }
 ```
@@ -256,7 +256,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/DatabaseUsersApi.md
+++ b/docs/docs/DatabaseUsersApi.md
@@ -96,7 +96,7 @@ Name | Type | Description  | Notes
 
 ## DeleteDatabaseUser
 
-> interface{} DeleteDatabaseUser(ctx, groupId, databaseName, username).Execute()
+> any DeleteDatabaseUser(ctx, groupId, databaseName, username).Execute()
 
 Remove One Database User from One Project
 
@@ -137,7 +137,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteDatabaseUser`: interface{}
+    // response from `DeleteDatabaseUser`: any
     fmt.Fprintf(os.Stdout, "Response from `DatabaseUsersApi.DeleteDatabaseUser`: %v (%v)\n", resp, r)
 }
 ```
@@ -165,7 +165,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/EncryptionAtRestUsingCustomerKeyManagementApi.md
+++ b/docs/docs/EncryptionAtRestUsingCustomerKeyManagementApi.md
@@ -355,7 +355,7 @@ Name | Type | Description  | Notes
 
 ## RequestEncryptionAtRestPrivateEndpointDeletion
 
-> interface{} RequestEncryptionAtRestPrivateEndpointDeletion(ctx, groupId, cloudProvider, endpointId).Execute()
+> any RequestEncryptionAtRestPrivateEndpointDeletion(ctx, groupId, cloudProvider, endpointId).Execute()
 
 Delete Private Endpoint for Encryption at Rest Using Customer Key Management
 
@@ -396,7 +396,7 @@ func main() {
         }
         return
     }
-    // response from `RequestEncryptionAtRestPrivateEndpointDeletion`: interface{}
+    // response from `RequestEncryptionAtRestPrivateEndpointDeletion`: any
     fmt.Fprintf(os.Stdout, "Response from `EncryptionAtRestUsingCustomerKeyManagementApi.RequestEncryptionAtRestPrivateEndpointDeletion`: %v (%v)\n", resp, r)
 }
 ```
@@ -424,7 +424,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/FederatedAuthenticationApi.md
+++ b/docs/docs/FederatedAuthenticationApi.md
@@ -1107,7 +1107,7 @@ Name | Type | Description  | Notes
 
 ## RemoveConnectedOrgConfig
 
-> interface{} RemoveConnectedOrgConfig(ctx, federationSettingsId, orgId).Execute()
+> any RemoveConnectedOrgConfig(ctx, federationSettingsId, orgId).Execute()
 
 Remove One Org Config Connected to One Federation
 
@@ -1147,7 +1147,7 @@ func main() {
         }
         return
     }
-    // response from `RemoveConnectedOrgConfig`: interface{}
+    // response from `RemoveConnectedOrgConfig`: any
     fmt.Fprintf(os.Stdout, "Response from `FederatedAuthenticationApi.RemoveConnectedOrgConfig`: %v (%v)\n", resp, r)
 }
 ```
@@ -1173,7 +1173,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/IndexOptions.md
+++ b/docs/docs/IndexOptions.md
@@ -16,11 +16,11 @@ Name | Type | Description | Notes
 **Max** | Pointer to **int** | Upper inclusive boundary to limit the longitude and latitude values. This option applies to the 2d index type only. | [optional] [default to 180]
 **Min** | Pointer to **int** | Lower inclusive boundary to limit the longitude and latitude values. This option applies to the 2d index type only. | [optional] [default to -180]
 **Name** | Pointer to **string** | Human-readable label that identifies this index. This option applies to all index types. | [optional] 
-**PartialFilterExpression** | Pointer to **interface{}** | Rules that limit the documents that the index references to a filter expression. All MongoDB index types accept a **partialFilterExpression** option. **partialFilterExpression** can include following expressions:  - equality (&#x60;\&quot;parameter\&quot; : \&quot;value\&quot;&#x60; or using the &#x60;$eq&#x60; operator) - &#x60;\&quot;$exists\&quot;: true&#x60; , maximum: &#x60;$gt&#x60;, &#x60;$gte&#x60;, &#x60;$lt&#x60;, &#x60;$lte&#x60; comparisons - &#x60;$type&#x60; - &#x60;$and&#x60; (top-level only)  This option applies to all index types. | [optional] 
+**PartialFilterExpression** | Pointer to [**any**](interface{}.md) | Rules that limit the documents that the index references to a filter expression. All MongoDB index types accept a **partialFilterExpression** option. **partialFilterExpression** can include following expressions:  - equality (&#x60;\&quot;parameter\&quot; : \&quot;value\&quot;&#x60; or using the &#x60;$eq&#x60; operator) - &#x60;\&quot;$exists\&quot;: true&#x60; , maximum: &#x60;$gt&#x60;, &#x60;$gte&#x60;, &#x60;$lt&#x60;, &#x60;$lte&#x60; comparisons - &#x60;$type&#x60; - &#x60;$and&#x60; (top-level only)  This option applies to all index types. | [optional] 
 **Sparse** | Pointer to **bool** | Flag that indicates whether the index references documents that only have the specified parameter. These indexes use less space but behave differently in some situations like when sorting. The following index types default to sparse and ignore this option: &#x60;2dsphere&#x60;, &#x60;2d&#x60;, &#x60;geoHaystack&#x60;, &#x60;text&#x60;.  Compound indexes that includes one or more indexes with &#x60;2dsphere&#x60; keys alongside other key types, only the &#x60;2dsphere&#x60; index parameters determine which documents the index references. If you run MongoDB 3.2 or later, use partial indexes. This option applies to all index types. | [optional] [default to false]
-**StorageEngine** | Pointer to **interface{}** | Storage engine set for the specific index. This value can be set only at creation. This option uses the following format: &#x60;\&quot;storageEngine\&quot; : { \&quot;&lt;storage-engine-name&gt;\&quot; : \&quot;&lt;options&gt;\&quot; }&#x60; MongoDB validates storage engine configuration options when creating indexes. To support replica sets with members with different storage engines, MongoDB logs these options to the oplog during replication. This option applies to all index types. | [optional] 
+**StorageEngine** | Pointer to [**any**](interface{}.md) | Storage engine set for the specific index. This value can be set only at creation. This option uses the following format: &#x60;\&quot;storageEngine\&quot; : { \&quot;&lt;storage-engine-name&gt;\&quot; : \&quot;&lt;options&gt;\&quot; }&#x60; MongoDB validates storage engine configuration options when creating indexes. To support replica sets with members with different storage engines, MongoDB logs these options to the oplog during replication. This option applies to all index types. | [optional] 
 **TextIndexVersion** | Pointer to **int** | Version applied to this text index. MongoDB 3.2 and later use version &#x60;3&#x60;. Use this option to override the default version number. This option applies to the **text** index type only. | [optional] [default to 3]
-**Weights** | Pointer to **interface{}** | Relative importance to place upon provided index parameters. This object expresses this as key/value pairs of index parameter and weight to apply to that parameter. You can specify weights for some or all the indexed parameters. The weight must be an integer between 1 and 99,999. MongoDB 5.0 and later can apply **weights** to **text** indexes only. | [optional] 
+**Weights** | Pointer to [**any**](interface{}.md) | Relative importance to place upon provided index parameters. This object expresses this as key/value pairs of index parameter and weight to apply to that parameter. You can specify weights for some or all the indexed parameters. The weight must be an integer between 1 and 99,999. MongoDB 5.0 and later can apply **weights** to **text** indexes only. | [optional] 
 
 ## Methods
 
@@ -331,20 +331,20 @@ SetName sets Name field to given value.
 HasName returns a boolean if a field has been set.
 ### GetPartialFilterExpression
 
-`func (o *IndexOptions) GetPartialFilterExpression() interface{}`
+`func (o *IndexOptions) GetPartialFilterExpression() any`
 
 GetPartialFilterExpression returns the PartialFilterExpression field if non-nil, zero value otherwise.
 
 ### GetPartialFilterExpressionOk
 
-`func (o *IndexOptions) GetPartialFilterExpressionOk() (*interface{}, bool)`
+`func (o *IndexOptions) GetPartialFilterExpressionOk() (*any, bool)`
 
 GetPartialFilterExpressionOk returns a tuple with the PartialFilterExpression field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPartialFilterExpression
 
-`func (o *IndexOptions) SetPartialFilterExpression(v interface{})`
+`func (o *IndexOptions) SetPartialFilterExpression(v any)`
 
 SetPartialFilterExpression sets PartialFilterExpression field to given value.
 
@@ -379,20 +379,20 @@ SetSparse sets Sparse field to given value.
 HasSparse returns a boolean if a field has been set.
 ### GetStorageEngine
 
-`func (o *IndexOptions) GetStorageEngine() interface{}`
+`func (o *IndexOptions) GetStorageEngine() any`
 
 GetStorageEngine returns the StorageEngine field if non-nil, zero value otherwise.
 
 ### GetStorageEngineOk
 
-`func (o *IndexOptions) GetStorageEngineOk() (*interface{}, bool)`
+`func (o *IndexOptions) GetStorageEngineOk() (*any, bool)`
 
 GetStorageEngineOk returns a tuple with the StorageEngine field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetStorageEngine
 
-`func (o *IndexOptions) SetStorageEngine(v interface{})`
+`func (o *IndexOptions) SetStorageEngine(v any)`
 
 SetStorageEngine sets StorageEngine field to given value.
 
@@ -427,20 +427,20 @@ SetTextIndexVersion sets TextIndexVersion field to given value.
 HasTextIndexVersion returns a boolean if a field has been set.
 ### GetWeights
 
-`func (o *IndexOptions) GetWeights() interface{}`
+`func (o *IndexOptions) GetWeights() any`
 
 GetWeights returns the Weights field if non-nil, zero value otherwise.
 
 ### GetWeightsOk
 
-`func (o *IndexOptions) GetWeightsOk() (*interface{}, bool)`
+`func (o *IndexOptions) GetWeightsOk() (*any, bool)`
 
 GetWeightsOk returns a tuple with the Weights field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetWeights
 
-`func (o *IndexOptions) SetWeights(v interface{})`
+`func (o *IndexOptions) SetWeights(v any)`
 
 SetWeights sets Weights field to given value.
 

--- a/docs/docs/LegacyBackupApi.md
+++ b/docs/docs/LegacyBackupApi.md
@@ -105,7 +105,7 @@ Name | Type | Description  | Notes
 
 ## DeleteLegacySnapshot
 
-> interface{} DeleteLegacySnapshot(ctx, groupId, clusterName, snapshotId).Execute()
+> any DeleteLegacySnapshot(ctx, groupId, clusterName, snapshotId).Execute()
 
 Remove One Legacy Backup Snapshot
 
@@ -146,7 +146,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteLegacySnapshot`: interface{}
+    // response from `DeleteLegacySnapshot`: any
     fmt.Fprintf(os.Stdout, "Response from `LegacyBackupApi.DeleteLegacySnapshot`: %v (%v)\n", resp, r)
 }
 ```
@@ -174,7 +174,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/MaintenanceWindowsApi.md
+++ b/docs/docs/MaintenanceWindowsApi.md
@@ -328,7 +328,7 @@ Name | Type | Description  | Notes
 
 ## UpdateMaintenanceWindow
 
-> interface{} UpdateMaintenanceWindow(ctx, groupId, groupMaintenanceWindow GroupMaintenanceWindow).Execute()
+> any UpdateMaintenanceWindow(ctx, groupId, groupMaintenanceWindow GroupMaintenanceWindow).Execute()
 
 Update Maintenance Window for One Project
 
@@ -368,7 +368,7 @@ func main() {
         }
         return
     }
-    // response from `UpdateMaintenanceWindow`: interface{}
+    // response from `UpdateMaintenanceWindow`: any
     fmt.Fprintf(os.Stdout, "Response from `MaintenanceWindowsApi.UpdateMaintenanceWindow`: %v (%v)\n", resp, r)
 }
 ```
@@ -393,7 +393,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/NetworkPeeringApi.md
+++ b/docs/docs/NetworkPeeringApi.md
@@ -186,7 +186,7 @@ Name | Type | Description  | Notes
 
 ## DeletePeeringConnection
 
-> interface{} DeletePeeringConnection(ctx, groupId, peerId).Execute()
+> any DeletePeeringConnection(ctx, groupId, peerId).Execute()
 
 Remove One Existing Network Peering Connection
 
@@ -226,7 +226,7 @@ func main() {
         }
         return
     }
-    // response from `DeletePeeringConnection`: interface{}
+    // response from `DeletePeeringConnection`: any
     fmt.Fprintf(os.Stdout, "Response from `NetworkPeeringApi.DeletePeeringConnection`: %v (%v)\n", resp, r)
 }
 ```
@@ -252,7 +252,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -269,7 +269,7 @@ Name | Type | Description  | Notes
 
 ## DeletePeeringContainer
 
-> interface{} DeletePeeringContainer(ctx, groupId, containerId).Execute()
+> any DeletePeeringContainer(ctx, groupId, containerId).Execute()
 
 Remove One Network Peering Container
 
@@ -309,7 +309,7 @@ func main() {
         }
         return
     }
-    // response from `DeletePeeringContainer`: interface{}
+    // response from `DeletePeeringContainer`: any
     fmt.Fprintf(os.Stdout, "Response from `NetworkPeeringApi.DeletePeeringContainer`: %v (%v)\n", resp, r)
 }
 ```
@@ -335,7 +335,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/OnlineArchiveApi.md
+++ b/docs/docs/OnlineArchiveApi.md
@@ -100,7 +100,7 @@ Name | Type | Description  | Notes
 
 ## DeleteOnlineArchive
 
-> interface{} DeleteOnlineArchive(ctx, groupId, archiveId, clusterName).Execute()
+> any DeleteOnlineArchive(ctx, groupId, archiveId, clusterName).Execute()
 
 Remove One Online Archive
 
@@ -141,7 +141,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteOnlineArchive`: interface{}
+    // response from `DeleteOnlineArchive`: any
     fmt.Fprintf(os.Stdout, "Response from `OnlineArchiveApi.DeleteOnlineArchive`: %v (%v)\n", resp, r)
 }
 ```
@@ -169,7 +169,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/OrganizationsApi.md
+++ b/docs/docs/OrganizationsApi.md
@@ -184,7 +184,7 @@ Name | Type | Description  | Notes
 
 ## DeleteOrganization
 
-> interface{} DeleteOrganization(ctx, orgId).Execute()
+> any DeleteOrganization(ctx, orgId).Execute()
 
 Remove One Organization
 
@@ -223,7 +223,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteOrganization`: interface{}
+    // response from `DeleteOrganization`: any
     fmt.Fprintf(os.Stdout, "Response from `OrganizationsApi.DeleteOrganization`: %v (%v)\n", resp, r)
 }
 ```
@@ -247,7 +247,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -264,7 +264,7 @@ Name | Type | Description  | Notes
 
 ## DeleteOrganizationInvitation
 
-> interface{} DeleteOrganizationInvitation(ctx, orgId, invitationId).Execute()
+> any DeleteOrganizationInvitation(ctx, orgId, invitationId).Execute()
 
 Cancel One Organization Invitation
 
@@ -304,7 +304,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteOrganizationInvitation`: interface{}
+    // response from `DeleteOrganizationInvitation`: any
     fmt.Fprintf(os.Stdout, "Response from `OrganizationsApi.DeleteOrganizationInvitation`: %v (%v)\n", resp, r)
 }
 ```
@@ -330,7 +330,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -928,7 +928,7 @@ Name | Type | Description  | Notes
 
 ## RemoveOrganizationUser
 
-> interface{} RemoveOrganizationUser(ctx, orgId, userId).Execute()
+> any RemoveOrganizationUser(ctx, orgId, userId).Execute()
 
 Remove One MongoDB Cloud User From One Organization
 
@@ -968,7 +968,7 @@ func main() {
         }
         return
     }
-    // response from `RemoveOrganizationUser`: interface{}
+    // response from `RemoveOrganizationUser`: any
     fmt.Fprintf(os.Stdout, "Response from `OrganizationsApi.RemoveOrganizationUser`: %v (%v)\n", resp, r)
 }
 ```
@@ -994,7 +994,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/PerformanceAdvisorApi.md
+++ b/docs/docs/PerformanceAdvisorApi.md
@@ -611,7 +611,7 @@ Name | Type | Description  | Notes
 
 ## SetServerlessAutoIndexing
 
-> interface{} SetServerlessAutoIndexing(ctx, groupId, clusterName).Enable(enable).Execute()
+> any SetServerlessAutoIndexing(ctx, groupId, clusterName).Enable(enable).Execute()
 
 Set Serverless Auto Indexing
 
@@ -652,7 +652,7 @@ func main() {
         }
         return
     }
-    // response from `SetServerlessAutoIndexing`: interface{}
+    // response from `SetServerlessAutoIndexing`: any
     fmt.Fprintf(os.Stdout, "Response from `PerformanceAdvisorApi.SetServerlessAutoIndexing`: %v (%v)\n", resp, r)
 }
 ```
@@ -679,7 +679,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/PerformanceAdvisorOperation.md
+++ b/docs/docs/PerformanceAdvisorOperation.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Predicates** | Pointer to **[]interface{}** | List that contains the search criteria that the query uses. To use the values in key-value pairs in these predicates requires **Project Data Access Read Only** permissions or greater. Otherwise, MongoDB Cloud redacts these values. | [optional] [readonly] 
+**Predicates** | Pointer to [**[]any**](any.md) | List that contains the search criteria that the query uses. To use the values in key-value pairs in these predicates requires **Project Data Access Read Only** permissions or greater. Otherwise, MongoDB Cloud redacts these values. | [optional] [readonly] 
 **Stats** | Pointer to [**PerformanceAdvisorOpStats**](PerformanceAdvisorOpStats.md) |  | [optional] 
 
 ## Methods
@@ -28,20 +28,20 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetPredicates
 
-`func (o *PerformanceAdvisorOperation) GetPredicates() []interface{}`
+`func (o *PerformanceAdvisorOperation) GetPredicates() []any`
 
 GetPredicates returns the Predicates field if non-nil, zero value otherwise.
 
 ### GetPredicatesOk
 
-`func (o *PerformanceAdvisorOperation) GetPredicatesOk() (*[]interface{}, bool)`
+`func (o *PerformanceAdvisorOperation) GetPredicatesOk() (*[]any, bool)`
 
 GetPredicatesOk returns a tuple with the Predicates field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPredicates
 
-`func (o *PerformanceAdvisorOperation) SetPredicates(v []interface{})`
+`func (o *PerformanceAdvisorOperation) SetPredicates(v []any)`
 
 SetPredicates sets Predicates field to given value.
 

--- a/docs/docs/PrivateEndpointServicesApi.md
+++ b/docs/docs/PrivateEndpointServicesApi.md
@@ -188,7 +188,7 @@ Name | Type | Description  | Notes
 
 ## DeletePrivateEndpoint
 
-> interface{} DeletePrivateEndpoint(ctx, groupId, cloudProvider, endpointId, endpointServiceId).Execute()
+> any DeletePrivateEndpoint(ctx, groupId, cloudProvider, endpointId, endpointServiceId).Execute()
 
 Remove One Private Endpoint for One Provider
 
@@ -230,7 +230,7 @@ func main() {
         }
         return
     }
-    // response from `DeletePrivateEndpoint`: interface{}
+    // response from `DeletePrivateEndpoint`: any
     fmt.Fprintf(os.Stdout, "Response from `PrivateEndpointServicesApi.DeletePrivateEndpoint`: %v (%v)\n", resp, r)
 }
 ```
@@ -260,7 +260,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -277,7 +277,7 @@ Name | Type | Description  | Notes
 
 ## DeletePrivateEndpointService
 
-> interface{} DeletePrivateEndpointService(ctx, groupId, cloudProvider, endpointServiceId).Execute()
+> any DeletePrivateEndpointService(ctx, groupId, cloudProvider, endpointServiceId).Execute()
 
 Remove One Private Endpoint Service for One Provider
 
@@ -318,7 +318,7 @@ func main() {
         }
         return
     }
-    // response from `DeletePrivateEndpointService`: interface{}
+    // response from `DeletePrivateEndpointService`: any
     fmt.Fprintf(os.Stdout, "Response from `PrivateEndpointServicesApi.DeletePrivateEndpointService`: %v (%v)\n", resp, r)
 }
 ```
@@ -346,7 +346,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/ProgrammaticAPIKeysApi.md
+++ b/docs/docs/ProgrammaticAPIKeysApi.md
@@ -23,7 +23,7 @@ Method | HTTP request | Description
 
 ## AddProjectApiKey
 
-> interface{} AddProjectApiKey(ctx, groupId, apiUserId, userAccessRoleAssignment []UserAccessRoleAssignment).Execute()
+> any AddProjectApiKey(ctx, groupId, apiUserId, userAccessRoleAssignment []UserAccessRoleAssignment).Execute()
 
 Assign One Organization API Key to One Project
 
@@ -64,7 +64,7 @@ func main() {
         }
         return
     }
-    // response from `AddProjectApiKey`: interface{}
+    // response from `AddProjectApiKey`: any
     fmt.Fprintf(os.Stdout, "Response from `ProgrammaticAPIKeysApi.AddProjectApiKey`: %v (%v)\n", resp, r)
 }
 ```
@@ -91,7 +91,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -363,7 +363,7 @@ Name | Type | Description  | Notes
 
 ## DeleteApiKey
 
-> interface{} DeleteApiKey(ctx, orgId, apiUserId).Execute()
+> any DeleteApiKey(ctx, orgId, apiUserId).Execute()
 
 Remove One Organization API Key
 
@@ -403,7 +403,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteApiKey`: interface{}
+    // response from `DeleteApiKey`: any
     fmt.Fprintf(os.Stdout, "Response from `ProgrammaticAPIKeysApi.DeleteApiKey`: %v (%v)\n", resp, r)
 }
 ```
@@ -429,7 +429,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -446,7 +446,7 @@ Name | Type | Description  | Notes
 
 ## DeleteApiKeyAccessListEntry
 
-> interface{} DeleteApiKeyAccessListEntry(ctx, orgId, apiUserId, ipAddress).Execute()
+> any DeleteApiKeyAccessListEntry(ctx, orgId, apiUserId, ipAddress).Execute()
 
 Remove One Access List Entry for One Organization API Key
 
@@ -487,7 +487,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteApiKeyAccessListEntry`: interface{}
+    // response from `DeleteApiKeyAccessListEntry`: any
     fmt.Fprintf(os.Stdout, "Response from `ProgrammaticAPIKeysApi.DeleteApiKeyAccessListEntry`: %v (%v)\n", resp, r)
 }
 ```
@@ -515,7 +515,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -962,7 +962,7 @@ Name | Type | Description  | Notes
 
 ## RemoveProjectApiKey
 
-> interface{} RemoveProjectApiKey(ctx, groupId, apiUserId).Execute()
+> any RemoveProjectApiKey(ctx, groupId, apiUserId).Execute()
 
 Unassign One Organization API Key from One Project
 
@@ -1002,7 +1002,7 @@ func main() {
         }
         return
     }
-    // response from `RemoveProjectApiKey`: interface{}
+    // response from `RemoveProjectApiKey`: any
     fmt.Fprintf(os.Stdout, "Response from `ProgrammaticAPIKeysApi.RemoveProjectApiKey`: %v (%v)\n", resp, r)
 }
 ```
@@ -1028,7 +1028,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/ProjectIPAccessListApi.md
+++ b/docs/docs/ProjectIPAccessListApi.md
@@ -102,7 +102,7 @@ Name | Type | Description  | Notes
 
 ## DeleteProjectIpAccessList
 
-> interface{} DeleteProjectIpAccessList(ctx, groupId, entryValue).Execute()
+> any DeleteProjectIpAccessList(ctx, groupId, entryValue).Execute()
 
 Remove One Entry from One Project IP Access List
 
@@ -142,7 +142,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteProjectIpAccessList`: interface{}
+    // response from `DeleteProjectIpAccessList`: any
     fmt.Fprintf(os.Stdout, "Response from `ProjectIPAccessListApi.DeleteProjectIpAccessList`: %v (%v)\n", resp, r)
 }
 ```
@@ -168,7 +168,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/ProjectsApi.md
+++ b/docs/docs/ProjectsApi.md
@@ -276,7 +276,7 @@ Name | Type | Description  | Notes
 
 ## DeleteProject
 
-> interface{} DeleteProject(ctx, groupId).Execute()
+> any DeleteProject(ctx, groupId).Execute()
 
 Remove One Project
 
@@ -315,7 +315,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteProject`: interface{}
+    // response from `DeleteProject`: any
     fmt.Fprintf(os.Stdout, "Response from `ProjectsApi.DeleteProject`: %v (%v)\n", resp, r)
 }
 ```
@@ -339,7 +339,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -356,7 +356,7 @@ Name | Type | Description  | Notes
 
 ## DeleteProjectInvitation
 
-> interface{} DeleteProjectInvitation(ctx, groupId, invitationId).Execute()
+> any DeleteProjectInvitation(ctx, groupId, invitationId).Execute()
 
 Cancel One Project Invitation
 
@@ -396,7 +396,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteProjectInvitation`: interface{}
+    // response from `DeleteProjectInvitation`: any
     fmt.Fprintf(os.Stdout, "Response from `ProjectsApi.DeleteProjectInvitation`: %v (%v)\n", resp, r)
 }
 ```
@@ -422,7 +422,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -439,7 +439,7 @@ Name | Type | Description  | Notes
 
 ## DeleteProjectLimit
 
-> interface{} DeleteProjectLimit(ctx, limitName, groupId).Execute()
+> any DeleteProjectLimit(ctx, limitName, groupId).Execute()
 
 Remove One Project Limit
 
@@ -479,7 +479,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteProjectLimit`: interface{}
+    // response from `DeleteProjectLimit`: any
     fmt.Fprintf(os.Stdout, "Response from `ProjectsApi.DeleteProjectLimit`: %v (%v)\n", resp, r)
 }
 ```
@@ -505,7 +505,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/ResourcePoliciesApi.md
+++ b/docs/docs/ResourcePoliciesApi.md
@@ -105,7 +105,7 @@ Name | Type | Description  | Notes
 
 ## DeleteAtlasResourcePolicy
 
-> interface{} DeleteAtlasResourcePolicy(ctx, orgId, resourcePolicyId).Execute()
+> any DeleteAtlasResourcePolicy(ctx, orgId, resourcePolicyId).Execute()
 
 Delete one Atlas Resource Policy
 
@@ -145,7 +145,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteAtlasResourcePolicy`: interface{}
+    // response from `DeleteAtlasResourcePolicy`: any
     fmt.Fprintf(os.Stdout, "Response from `ResourcePoliciesApi.DeleteAtlasResourcePolicy`: %v (%v)\n", resp, r)
 }
 ```
@@ -171,7 +171,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/SearchIndexUpdateRequestDefinition.md
+++ b/docs/docs/SearchIndexUpdateRequestDefinition.md
@@ -8,9 +8,9 @@ Name | Type | Description | Notes
 **Analyzers** | Pointer to [**[]AtlasSearchAnalyzer**](AtlasSearchAnalyzer.md) | List of user-defined methods to convert database field text into searchable words. | [optional] 
 **Mappings** | Pointer to [**SearchMappings**](SearchMappings.md) |  | [optional] 
 **SearchAnalyzer** | Pointer to **string** | Method applied to identify words when searching this index. | [optional] [default to "lucene.standard"]
-**StoredSource** | Pointer to **interface{}** | Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn&#39;t store (false) the fields on Atlas Search.  Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see Stored Source Fields. | [optional] 
+**StoredSource** | Pointer to [**any**](interface{}.md) | Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn&#39;t store (false) the fields on Atlas Search.  Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see Stored Source Fields. | [optional] 
 **Synonyms** | Pointer to [**[]SearchSynonymMappingDefinition**](SearchSynonymMappingDefinition.md) | Rule sets that map words to their synonyms in this index. | [optional] 
-**Fields** | Pointer to **[]interface{}** | Settings that configure the fields, one per object, to index. You must define at least one \&quot;vector\&quot; type field. You can optionally define \&quot;filter\&quot; type fields also. | [optional] 
+**Fields** | Pointer to [**[]any**](any.md) | Settings that configure the fields, one per object, to index. You must define at least one \&quot;vector\&quot; type field. You can optionally define \&quot;filter\&quot; type fields also. | [optional] 
 
 ## Methods
 
@@ -129,20 +129,20 @@ SetSearchAnalyzer sets SearchAnalyzer field to given value.
 HasSearchAnalyzer returns a boolean if a field has been set.
 ### GetStoredSource
 
-`func (o *SearchIndexUpdateRequestDefinition) GetStoredSource() interface{}`
+`func (o *SearchIndexUpdateRequestDefinition) GetStoredSource() any`
 
 GetStoredSource returns the StoredSource field if non-nil, zero value otherwise.
 
 ### GetStoredSourceOk
 
-`func (o *SearchIndexUpdateRequestDefinition) GetStoredSourceOk() (*interface{}, bool)`
+`func (o *SearchIndexUpdateRequestDefinition) GetStoredSourceOk() (*any, bool)`
 
 GetStoredSourceOk returns a tuple with the StoredSource field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetStoredSource
 
-`func (o *SearchIndexUpdateRequestDefinition) SetStoredSource(v interface{})`
+`func (o *SearchIndexUpdateRequestDefinition) SetStoredSource(v any)`
 
 SetStoredSource sets StoredSource field to given value.
 
@@ -177,20 +177,20 @@ SetSynonyms sets Synonyms field to given value.
 HasSynonyms returns a boolean if a field has been set.
 ### GetFields
 
-`func (o *SearchIndexUpdateRequestDefinition) GetFields() []interface{}`
+`func (o *SearchIndexUpdateRequestDefinition) GetFields() []any`
 
 GetFields returns the Fields field if non-nil, zero value otherwise.
 
 ### GetFieldsOk
 
-`func (o *SearchIndexUpdateRequestDefinition) GetFieldsOk() (*[]interface{}, bool)`
+`func (o *SearchIndexUpdateRequestDefinition) GetFieldsOk() (*[]any, bool)`
 
 GetFieldsOk returns a tuple with the Fields field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetFields
 
-`func (o *SearchIndexUpdateRequestDefinition) SetFields(v []interface{})`
+`func (o *SearchIndexUpdateRequestDefinition) SetFields(v []any)`
 
 SetFields sets Fields field to given value.
 

--- a/docs/docs/SearchMappings.md
+++ b/docs/docs/SearchMappings.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Dynamic** | Pointer to **bool** | Flag that indicates whether the index uses dynamic or static mappings. Required if **mappings.fields** is omitted. | [optional] 
-**Fields** | Pointer to **interface{}** | One or more field specifications for the Atlas Search index. Required if **mappings.dynamic** is omitted or set to **false**. | [optional] 
+**Fields** | Pointer to [**any**](interface{}.md) | One or more field specifications for the Atlas Search index. Required if **mappings.dynamic** is omitted or set to **false**. | [optional] 
 
 ## Methods
 
@@ -52,20 +52,20 @@ SetDynamic sets Dynamic field to given value.
 HasDynamic returns a boolean if a field has been set.
 ### GetFields
 
-`func (o *SearchMappings) GetFields() interface{}`
+`func (o *SearchMappings) GetFields() any`
 
 GetFields returns the Fields field if non-nil, zero value otherwise.
 
 ### GetFieldsOk
 
-`func (o *SearchMappings) GetFieldsOk() (*interface{}, bool)`
+`func (o *SearchMappings) GetFieldsOk() (*any, bool)`
 
 GetFieldsOk returns a tuple with the Fields field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetFields
 
-`func (o *SearchMappings) SetFields(v interface{})`
+`func (o *SearchMappings) SetFields(v any)`
 
 SetFields sets Fields field to given value.
 

--- a/docs/docs/ServerlessInstancesApi.md
+++ b/docs/docs/ServerlessInstancesApi.md
@@ -96,7 +96,7 @@ Name | Type | Description  | Notes
 
 ## DeleteServerlessInstance
 
-> interface{} DeleteServerlessInstance(ctx, groupId, name).Execute()
+> any DeleteServerlessInstance(ctx, groupId, name).Execute()
 
 Remove One Serverless Instance from One Project
 
@@ -136,7 +136,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteServerlessInstance`: interface{}
+    // response from `DeleteServerlessInstance`: any
     fmt.Fprintf(os.Stdout, "Response from `ServerlessInstancesApi.DeleteServerlessInstance`: %v (%v)\n", resp, r)
 }
 ```
@@ -162,7 +162,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/ServerlessPrivateEndpointsApi.md
+++ b/docs/docs/ServerlessPrivateEndpointsApi.md
@@ -99,7 +99,7 @@ Name | Type | Description  | Notes
 
 ## DeleteServerlessPrivateEndpoint
 
-> interface{} DeleteServerlessPrivateEndpoint(ctx, groupId, instanceName, endpointId).Execute()
+> any DeleteServerlessPrivateEndpoint(ctx, groupId, instanceName, endpointId).Execute()
 
 Remove One Private Endpoint for One Serverless Instance
 
@@ -140,7 +140,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteServerlessPrivateEndpoint`: interface{}
+    // response from `DeleteServerlessPrivateEndpoint`: any
     fmt.Fprintf(os.Stdout, "Response from `ServerlessPrivateEndpointsApi.DeleteServerlessPrivateEndpoint`: %v (%v)\n", resp, r)
 }
 ```
@@ -168,7 +168,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/ShardKeys.md
+++ b/docs/docs/ShardKeys.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Key** | Pointer to **[]interface{}** | List of fields to use for the shard key. | [optional] 
+**Key** | Pointer to [**[]any**](any.md) | List of fields to use for the shard key. | [optional] 
 
 ## Methods
 
@@ -27,20 +27,20 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetKey
 
-`func (o *ShardKeys) GetKey() []interface{}`
+`func (o *ShardKeys) GetKey() []any`
 
 GetKey returns the Key field if non-nil, zero value otherwise.
 
 ### GetKeyOk
 
-`func (o *ShardKeys) GetKeyOk() (*[]interface{}, bool)`
+`func (o *ShardKeys) GetKeyOk() (*[]any, bool)`
 
 GetKeyOk returns a tuple with the Key field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetKey
 
-`func (o *ShardKeys) SetKey(v []interface{})`
+`func (o *ShardKeys) SetKey(v []any)`
 
 SetKey sets Key field to given value.
 

--- a/docs/docs/StreamsApi.md
+++ b/docs/docs/StreamsApi.md
@@ -31,7 +31,7 @@ Method | HTTP request | Description
 
 ## AcceptVPCPeeringConnection
 
-> interface{} AcceptVPCPeeringConnection(ctx, groupId, id, vPCPeeringActionChallenge VPCPeeringActionChallenge).Execute()
+> any AcceptVPCPeeringConnection(ctx, groupId, id, vPCPeeringActionChallenge VPCPeeringActionChallenge).Execute()
 
 Requests the acceptance of an incoming VPC Peering connection.
 
@@ -72,7 +72,7 @@ func main() {
         }
         return
     }
-    // response from `AcceptVPCPeeringConnection`: interface{}
+    // response from `AcceptVPCPeeringConnection`: any
     fmt.Fprintf(os.Stdout, "Response from `StreamsApi.AcceptVPCPeeringConnection`: %v (%v)\n", resp, r)
 }
 ```
@@ -99,7 +99,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -283,7 +283,7 @@ Name | Type | Description  | Notes
 
 ## CreateStreamInstanceWithSampleConnections
 
-> StreamsTenant CreateStreamInstanceWithSampleConnections(ctx, groupId, body interface{}).Execute()
+> StreamsTenant CreateStreamInstanceWithSampleConnections(ctx, groupId, body any).Execute()
 
 Create One Stream Instance With Sample Connections
 
@@ -312,7 +312,7 @@ func main() {
     }
 
     groupId := "32b6e34b3d91647abb20e7b8" // string | 
-    body := interface{}{ ... } // interface{} | 
+    body := any{ ... } // any | 
 
     resp, r, err := sdk.StreamsApi.CreateStreamInstanceWithSampleConnections(context.Background(), groupId, &body).Execute()
     if err != nil {
@@ -344,7 +344,7 @@ Other parameters are passed through a pointer to a apiCreateStreamInstanceWithSa
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **body** | **interface{}** | Details to create one streams instance in the specified project. | 
+ **body** | **any** | Details to create one streams instance in the specified project. | 
 
 ### Return type
 
@@ -450,7 +450,7 @@ Name | Type | Description  | Notes
 
 ## DeleteStreamConnection
 
-> interface{} DeleteStreamConnection(ctx, groupId, tenantName, connectionName).Execute()
+> any DeleteStreamConnection(ctx, groupId, tenantName, connectionName).Execute()
 
 Delete One Stream Connection
 
@@ -491,7 +491,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteStreamConnection`: interface{}
+    // response from `DeleteStreamConnection`: any
     fmt.Fprintf(os.Stdout, "Response from `StreamsApi.DeleteStreamConnection`: %v (%v)\n", resp, r)
 }
 ```
@@ -519,7 +519,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -536,7 +536,7 @@ Name | Type | Description  | Notes
 
 ## DeleteStreamInstance
 
-> interface{} DeleteStreamInstance(ctx, groupId, tenantName).Execute()
+> any DeleteStreamInstance(ctx, groupId, tenantName).Execute()
 
 Delete One Stream Instance
 
@@ -576,7 +576,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteStreamInstance`: interface{}
+    // response from `DeleteStreamInstance`: any
     fmt.Fprintf(os.Stdout, "Response from `StreamsApi.DeleteStreamInstance`: %v (%v)\n", resp, r)
 }
 ```
@@ -602,7 +602,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -703,7 +703,7 @@ Name | Type | Description  | Notes
 
 ## DeleteVPCPeeringConnection
 
-> interface{} DeleteVPCPeeringConnection(ctx, groupId, id).Execute()
+> any DeleteVPCPeeringConnection(ctx, groupId, id).Execute()
 
 Deletes an incoming VPC Peering connection.
 
@@ -743,7 +743,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteVPCPeeringConnection`: interface{}
+    // response from `DeleteVPCPeeringConnection`: any
     fmt.Fprintf(os.Stdout, "Response from `StreamsApi.DeleteVPCPeeringConnection`: %v (%v)\n", resp, r)
 }
 ```
@@ -769,7 +769,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -1472,7 +1472,7 @@ Name | Type | Description  | Notes
 
 ## RejectVPCPeeringConnection
 
-> interface{} RejectVPCPeeringConnection(ctx, groupId, id).Execute()
+> any RejectVPCPeeringConnection(ctx, groupId, id).Execute()
 
 Requests the rejection of an incoming VPC Peering connection.
 
@@ -1512,7 +1512,7 @@ func main() {
         }
         return
     }
-    // response from `RejectVPCPeeringConnection`: interface{}
+    // response from `RejectVPCPeeringConnection`: any
     fmt.Fprintf(os.Stdout, "Response from `StreamsApi.RejectVPCPeeringConnection`: %v (%v)\n", resp, r)
 }
 ```
@@ -1538,7 +1538,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -1555,7 +1555,7 @@ Name | Type | Description  | Notes
 
 ## StartStreamProcessor
 
-> interface{} StartStreamProcessor(ctx, groupId, tenantName, processorName).Execute()
+> any StartStreamProcessor(ctx, groupId, tenantName, processorName).Execute()
 
 Start One Stream Processor
 
@@ -1596,7 +1596,7 @@ func main() {
         }
         return
     }
-    // response from `StartStreamProcessor`: interface{}
+    // response from `StartStreamProcessor`: any
     fmt.Fprintf(os.Stdout, "Response from `StreamsApi.StartStreamProcessor`: %v (%v)\n", resp, r)
 }
 ```
@@ -1624,7 +1624,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)
@@ -1641,7 +1641,7 @@ Name | Type | Description  | Notes
 
 ## StopStreamProcessor
 
-> interface{} StopStreamProcessor(ctx, groupId, tenantName, processorName).Execute()
+> any StopStreamProcessor(ctx, groupId, tenantName, processorName).Execute()
 
 Stop One Stream Processor
 
@@ -1682,7 +1682,7 @@ func main() {
         }
         return
     }
-    // response from `StopStreamProcessor`: interface{}
+    // response from `StopStreamProcessor`: any
     fmt.Fprintf(os.Stdout, "Response from `StreamsApi.StopStreamProcessor`: %v (%v)\n", resp, r)
 }
 ```
@@ -1710,7 +1710,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/StreamsProcessor.md
+++ b/docs/docs/StreamsProcessor.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Links** | Pointer to [**[]Link**](Link.md) | List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. | [optional] [readonly] 
 **Name** | Pointer to **string** | Human-readable name of the stream processor. | [optional] 
 **Options** | Pointer to [**StreamsOptions**](StreamsOptions.md) |  | [optional] 
-**Pipeline** | Pointer to **[]interface{}** | Stream aggregation pipeline you want to apply to your streaming data. | [optional] 
+**Pipeline** | Pointer to [**[]any**](any.md) | Stream aggregation pipeline you want to apply to your streaming data. | [optional] 
 
 ## Methods
 
@@ -127,20 +127,20 @@ SetOptions sets Options field to given value.
 HasOptions returns a boolean if a field has been set.
 ### GetPipeline
 
-`func (o *StreamsProcessor) GetPipeline() []interface{}`
+`func (o *StreamsProcessor) GetPipeline() []any`
 
 GetPipeline returns the Pipeline field if non-nil, zero value otherwise.
 
 ### GetPipelineOk
 
-`func (o *StreamsProcessor) GetPipelineOk() (*[]interface{}, bool)`
+`func (o *StreamsProcessor) GetPipelineOk() (*[]any, bool)`
 
 GetPipelineOk returns a tuple with the Pipeline field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPipeline
 
-`func (o *StreamsProcessor) SetPipeline(v []interface{})`
+`func (o *StreamsProcessor) SetPipeline(v []any)`
 
 SetPipeline sets Pipeline field to given value.
 

--- a/docs/docs/StreamsProcessorWithStats.md
+++ b/docs/docs/StreamsProcessorWithStats.md
@@ -8,15 +8,15 @@ Name | Type | Description | Notes
 **Links** | Pointer to [**[]Link**](Link.md) | List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. | [optional] [readonly] 
 **Name** | **string** | Human-readable name of the stream processor. | [readonly] 
 **Options** | Pointer to [**StreamsOptions**](StreamsOptions.md) |  | [optional] 
-**Pipeline** | **[]interface{}** | Stream aggregation pipeline you want to apply to your streaming data. | [readonly] 
+**Pipeline** | [**[]any**](any.md) | Stream aggregation pipeline you want to apply to your streaming data. | [readonly] 
 **State** | **string** | The state of the stream processor. Commonly occurring states are &#39;CREATED&#39;, &#39;STARTED&#39;, &#39;STOPPED&#39; and &#39;FAILED&#39;. | [readonly] 
-**Stats** | Pointer to **interface{}** | The stats associated with the stream processor. | [optional] [readonly] 
+**Stats** | Pointer to [**any**](interface{}.md) | The stats associated with the stream processor. | [optional] [readonly] 
 
 ## Methods
 
 ### NewStreamsProcessorWithStats
 
-`func NewStreamsProcessorWithStats(id string, name string, pipeline []interface{}, state string, ) *StreamsProcessorWithStats`
+`func NewStreamsProcessorWithStats(id string, name string, pipeline []any, state string, ) *StreamsProcessorWithStats`
 
 NewStreamsProcessorWithStats instantiates a new StreamsProcessorWithStats object
 This constructor will assign default values to properties that have it defined,
@@ -119,20 +119,20 @@ SetOptions sets Options field to given value.
 HasOptions returns a boolean if a field has been set.
 ### GetPipeline
 
-`func (o *StreamsProcessorWithStats) GetPipeline() []interface{}`
+`func (o *StreamsProcessorWithStats) GetPipeline() []any`
 
 GetPipeline returns the Pipeline field if non-nil, zero value otherwise.
 
 ### GetPipelineOk
 
-`func (o *StreamsProcessorWithStats) GetPipelineOk() (*[]interface{}, bool)`
+`func (o *StreamsProcessorWithStats) GetPipelineOk() (*[]any, bool)`
 
 GetPipelineOk returns a tuple with the Pipeline field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPipeline
 
-`func (o *StreamsProcessorWithStats) SetPipeline(v []interface{})`
+`func (o *StreamsProcessorWithStats) SetPipeline(v []any)`
 
 SetPipeline sets Pipeline field to given value.
 
@@ -157,20 +157,20 @@ SetState sets State field to given value.
 
 ### GetStats
 
-`func (o *StreamsProcessorWithStats) GetStats() interface{}`
+`func (o *StreamsProcessorWithStats) GetStats() any`
 
 GetStats returns the Stats field if non-nil, zero value otherwise.
 
 ### GetStatsOk
 
-`func (o *StreamsProcessorWithStats) GetStatsOk() (*interface{}, bool)`
+`func (o *StreamsProcessorWithStats) GetStatsOk() (*any, bool)`
 
 GetStatsOk returns a tuple with the Stats field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetStats
 
-`func (o *StreamsProcessorWithStats) SetStats(v interface{})`
+`func (o *StreamsProcessorWithStats) SetStats(v any)`
 
 SetStats sets Stats field to given value.
 

--- a/docs/docs/TeamsApi.md
+++ b/docs/docs/TeamsApi.md
@@ -271,7 +271,7 @@ Name | Type | Description  | Notes
 
 ## DeleteTeam
 
-> interface{} DeleteTeam(ctx, orgId, teamId).Execute()
+> any DeleteTeam(ctx, orgId, teamId).Execute()
 
 Remove One Team from One Organization
 
@@ -311,7 +311,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteTeam`: interface{}
+    // response from `DeleteTeam`: any
     fmt.Fprintf(os.Stdout, "Response from `TeamsApi.DeleteTeam`: %v (%v)\n", resp, r)
 }
 ```
@@ -337,7 +337,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/ThirdPartyIntegrationsApi.md
+++ b/docs/docs/ThirdPartyIntegrationsApi.md
@@ -105,7 +105,7 @@ Name | Type | Description  | Notes
 
 ## DeleteThirdPartyIntegration
 
-> interface{} DeleteThirdPartyIntegration(ctx, integrationType, groupId).Execute()
+> any DeleteThirdPartyIntegration(ctx, integrationType, groupId).Execute()
 
 Remove One Third-Party Service Integration
 
@@ -145,7 +145,7 @@ func main() {
         }
         return
     }
-    // response from `DeleteThirdPartyIntegration`: interface{}
+    // response from `DeleteThirdPartyIntegration`: any
     fmt.Fprintf(os.Stdout, "Response from `ThirdPartyIntegrationsApi.DeleteThirdPartyIntegration`: %v (%v)\n", resp, r)
 }
 ```
@@ -171,7 +171,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**interface{}**
+**any**
 
 ### Authorization
 [DigestAuth](../README.md#Authentication)

--- a/docs/docs/VectorSearchIndexDefinition.md
+++ b/docs/docs/VectorSearchIndexDefinition.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Fields** | Pointer to **[]interface{}** | Settings that configure the fields, one per object, to index. You must define at least one \&quot;vector\&quot; type field. You can optionally define \&quot;filter\&quot; type fields also. | [optional] 
+**Fields** | Pointer to [**[]any**](any.md) | Settings that configure the fields, one per object, to index. You must define at least one \&quot;vector\&quot; type field. You can optionally define \&quot;filter\&quot; type fields also. | [optional] 
 
 ## Methods
 
@@ -27,20 +27,20 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetFields
 
-`func (o *VectorSearchIndexDefinition) GetFields() []interface{}`
+`func (o *VectorSearchIndexDefinition) GetFields() []any`
 
 GetFields returns the Fields field if non-nil, zero value otherwise.
 
 ### GetFieldsOk
 
-`func (o *VectorSearchIndexDefinition) GetFieldsOk() (*[]interface{}, bool)`
+`func (o *VectorSearchIndexDefinition) GetFieldsOk() (*[]any, bool)`
 
 GetFieldsOk returns a tuple with the Fields field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetFields
 
-`func (o *VectorSearchIndexDefinition) SetFields(v []interface{})`
+`func (o *VectorSearchIndexDefinition) SetFields(v []any)`
 
 SetFields sets Fields field to given value.
 

--- a/mockadmin/access_tracking_api.go
+++ b/mockadmin/access_tracking_api.go
@@ -52,7 +52,7 @@ type AccessTrackingApi_ListAccessLogsByClusterName_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *AccessTrackingApi_Expecter) ListAccessLogsByClusterName(ctx interface{}, groupId interface{}, clusterName interface{}) *AccessTrackingApi_ListAccessLogsByClusterName_Call {
+func (_e *AccessTrackingApi_Expecter) ListAccessLogsByClusterName(ctx any, groupId any, clusterName any) *AccessTrackingApi_ListAccessLogsByClusterName_Call {
 	return &AccessTrackingApi_ListAccessLogsByClusterName_Call{Call: _e.mock.On("ListAccessLogsByClusterName", ctx, groupId, clusterName)}
 }
 
@@ -119,7 +119,7 @@ type AccessTrackingApi_ListAccessLogsByClusterNameExecute_Call struct {
 
 // ListAccessLogsByClusterNameExecute is a helper method to define mock.On call
 //   - r admin.ListAccessLogsByClusterNameApiRequest
-func (_e *AccessTrackingApi_Expecter) ListAccessLogsByClusterNameExecute(r interface{}) *AccessTrackingApi_ListAccessLogsByClusterNameExecute_Call {
+func (_e *AccessTrackingApi_Expecter) ListAccessLogsByClusterNameExecute(r any) *AccessTrackingApi_ListAccessLogsByClusterNameExecute_Call {
 	return &AccessTrackingApi_ListAccessLogsByClusterNameExecute_Call{Call: _e.mock.On("ListAccessLogsByClusterNameExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type AccessTrackingApi_ListAccessLogsByClusterNameWithParams_Call struct {
 // ListAccessLogsByClusterNameWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListAccessLogsByClusterNameApiParams
-func (_e *AccessTrackingApi_Expecter) ListAccessLogsByClusterNameWithParams(ctx interface{}, args interface{}) *AccessTrackingApi_ListAccessLogsByClusterNameWithParams_Call {
+func (_e *AccessTrackingApi_Expecter) ListAccessLogsByClusterNameWithParams(ctx any, args any) *AccessTrackingApi_ListAccessLogsByClusterNameWithParams_Call {
 	return &AccessTrackingApi_ListAccessLogsByClusterNameWithParams_Call{Call: _e.mock.On("ListAccessLogsByClusterNameWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type AccessTrackingApi_ListAccessLogsByHostname_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - hostname string
-func (_e *AccessTrackingApi_Expecter) ListAccessLogsByHostname(ctx interface{}, groupId interface{}, hostname interface{}) *AccessTrackingApi_ListAccessLogsByHostname_Call {
+func (_e *AccessTrackingApi_Expecter) ListAccessLogsByHostname(ctx any, groupId any, hostname any) *AccessTrackingApi_ListAccessLogsByHostname_Call {
 	return &AccessTrackingApi_ListAccessLogsByHostname_Call{Call: _e.mock.On("ListAccessLogsByHostname", ctx, groupId, hostname)}
 }
 
@@ -281,7 +281,7 @@ type AccessTrackingApi_ListAccessLogsByHostnameExecute_Call struct {
 
 // ListAccessLogsByHostnameExecute is a helper method to define mock.On call
 //   - r admin.ListAccessLogsByHostnameApiRequest
-func (_e *AccessTrackingApi_Expecter) ListAccessLogsByHostnameExecute(r interface{}) *AccessTrackingApi_ListAccessLogsByHostnameExecute_Call {
+func (_e *AccessTrackingApi_Expecter) ListAccessLogsByHostnameExecute(r any) *AccessTrackingApi_ListAccessLogsByHostnameExecute_Call {
 	return &AccessTrackingApi_ListAccessLogsByHostnameExecute_Call{Call: _e.mock.On("ListAccessLogsByHostnameExecute", r)}
 }
 
@@ -328,7 +328,7 @@ type AccessTrackingApi_ListAccessLogsByHostnameWithParams_Call struct {
 // ListAccessLogsByHostnameWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListAccessLogsByHostnameApiParams
-func (_e *AccessTrackingApi_Expecter) ListAccessLogsByHostnameWithParams(ctx interface{}, args interface{}) *AccessTrackingApi_ListAccessLogsByHostnameWithParams_Call {
+func (_e *AccessTrackingApi_Expecter) ListAccessLogsByHostnameWithParams(ctx any, args any) *AccessTrackingApi_ListAccessLogsByHostnameWithParams_Call {
 	return &AccessTrackingApi_ListAccessLogsByHostnameWithParams_Call{Call: _e.mock.On("ListAccessLogsByHostnameWithParams", ctx, args)}
 }
 

--- a/mockadmin/alert_configurations_api.go
+++ b/mockadmin/alert_configurations_api.go
@@ -52,7 +52,7 @@ type AlertConfigurationsApi_CreateAlertConfiguration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - groupAlertsConfig *admin.GroupAlertsConfig
-func (_e *AlertConfigurationsApi_Expecter) CreateAlertConfiguration(ctx interface{}, groupId interface{}, groupAlertsConfig interface{}) *AlertConfigurationsApi_CreateAlertConfiguration_Call {
+func (_e *AlertConfigurationsApi_Expecter) CreateAlertConfiguration(ctx any, groupId any, groupAlertsConfig any) *AlertConfigurationsApi_CreateAlertConfiguration_Call {
 	return &AlertConfigurationsApi_CreateAlertConfiguration_Call{Call: _e.mock.On("CreateAlertConfiguration", ctx, groupId, groupAlertsConfig)}
 }
 
@@ -119,7 +119,7 @@ type AlertConfigurationsApi_CreateAlertConfigurationExecute_Call struct {
 
 // CreateAlertConfigurationExecute is a helper method to define mock.On call
 //   - r admin.CreateAlertConfigurationApiRequest
-func (_e *AlertConfigurationsApi_Expecter) CreateAlertConfigurationExecute(r interface{}) *AlertConfigurationsApi_CreateAlertConfigurationExecute_Call {
+func (_e *AlertConfigurationsApi_Expecter) CreateAlertConfigurationExecute(r any) *AlertConfigurationsApi_CreateAlertConfigurationExecute_Call {
 	return &AlertConfigurationsApi_CreateAlertConfigurationExecute_Call{Call: _e.mock.On("CreateAlertConfigurationExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type AlertConfigurationsApi_CreateAlertConfigurationWithParams_Call struct {
 // CreateAlertConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateAlertConfigurationApiParams
-func (_e *AlertConfigurationsApi_Expecter) CreateAlertConfigurationWithParams(ctx interface{}, args interface{}) *AlertConfigurationsApi_CreateAlertConfigurationWithParams_Call {
+func (_e *AlertConfigurationsApi_Expecter) CreateAlertConfigurationWithParams(ctx any, args any) *AlertConfigurationsApi_CreateAlertConfigurationWithParams_Call {
 	return &AlertConfigurationsApi_CreateAlertConfigurationWithParams_Call{Call: _e.mock.On("CreateAlertConfigurationWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type AlertConfigurationsApi_DeleteAlertConfiguration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - alertConfigId string
-func (_e *AlertConfigurationsApi_Expecter) DeleteAlertConfiguration(ctx interface{}, groupId interface{}, alertConfigId interface{}) *AlertConfigurationsApi_DeleteAlertConfiguration_Call {
+func (_e *AlertConfigurationsApi_Expecter) DeleteAlertConfiguration(ctx any, groupId any, alertConfigId any) *AlertConfigurationsApi_DeleteAlertConfiguration_Call {
 	return &AlertConfigurationsApi_DeleteAlertConfiguration_Call{Call: _e.mock.On("DeleteAlertConfiguration", ctx, groupId, alertConfigId)}
 }
 
@@ -272,7 +272,7 @@ type AlertConfigurationsApi_DeleteAlertConfigurationExecute_Call struct {
 
 // DeleteAlertConfigurationExecute is a helper method to define mock.On call
 //   - r admin.DeleteAlertConfigurationApiRequest
-func (_e *AlertConfigurationsApi_Expecter) DeleteAlertConfigurationExecute(r interface{}) *AlertConfigurationsApi_DeleteAlertConfigurationExecute_Call {
+func (_e *AlertConfigurationsApi_Expecter) DeleteAlertConfigurationExecute(r any) *AlertConfigurationsApi_DeleteAlertConfigurationExecute_Call {
 	return &AlertConfigurationsApi_DeleteAlertConfigurationExecute_Call{Call: _e.mock.On("DeleteAlertConfigurationExecute", r)}
 }
 
@@ -319,7 +319,7 @@ type AlertConfigurationsApi_DeleteAlertConfigurationWithParams_Call struct {
 // DeleteAlertConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteAlertConfigurationApiParams
-func (_e *AlertConfigurationsApi_Expecter) DeleteAlertConfigurationWithParams(ctx interface{}, args interface{}) *AlertConfigurationsApi_DeleteAlertConfigurationWithParams_Call {
+func (_e *AlertConfigurationsApi_Expecter) DeleteAlertConfigurationWithParams(ctx any, args any) *AlertConfigurationsApi_DeleteAlertConfigurationWithParams_Call {
 	return &AlertConfigurationsApi_DeleteAlertConfigurationWithParams_Call{Call: _e.mock.On("DeleteAlertConfigurationWithParams", ctx, args)}
 }
 
@@ -367,7 +367,7 @@ type AlertConfigurationsApi_GetAlertConfiguration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - alertConfigId string
-func (_e *AlertConfigurationsApi_Expecter) GetAlertConfiguration(ctx interface{}, groupId interface{}, alertConfigId interface{}) *AlertConfigurationsApi_GetAlertConfiguration_Call {
+func (_e *AlertConfigurationsApi_Expecter) GetAlertConfiguration(ctx any, groupId any, alertConfigId any) *AlertConfigurationsApi_GetAlertConfiguration_Call {
 	return &AlertConfigurationsApi_GetAlertConfiguration_Call{Call: _e.mock.On("GetAlertConfiguration", ctx, groupId, alertConfigId)}
 }
 
@@ -434,7 +434,7 @@ type AlertConfigurationsApi_GetAlertConfigurationExecute_Call struct {
 
 // GetAlertConfigurationExecute is a helper method to define mock.On call
 //   - r admin.GetAlertConfigurationApiRequest
-func (_e *AlertConfigurationsApi_Expecter) GetAlertConfigurationExecute(r interface{}) *AlertConfigurationsApi_GetAlertConfigurationExecute_Call {
+func (_e *AlertConfigurationsApi_Expecter) GetAlertConfigurationExecute(r any) *AlertConfigurationsApi_GetAlertConfigurationExecute_Call {
 	return &AlertConfigurationsApi_GetAlertConfigurationExecute_Call{Call: _e.mock.On("GetAlertConfigurationExecute", r)}
 }
 
@@ -481,7 +481,7 @@ type AlertConfigurationsApi_GetAlertConfigurationWithParams_Call struct {
 // GetAlertConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetAlertConfigurationApiParams
-func (_e *AlertConfigurationsApi_Expecter) GetAlertConfigurationWithParams(ctx interface{}, args interface{}) *AlertConfigurationsApi_GetAlertConfigurationWithParams_Call {
+func (_e *AlertConfigurationsApi_Expecter) GetAlertConfigurationWithParams(ctx any, args any) *AlertConfigurationsApi_GetAlertConfigurationWithParams_Call {
 	return &AlertConfigurationsApi_GetAlertConfigurationWithParams_Call{Call: _e.mock.On("GetAlertConfigurationWithParams", ctx, args)}
 }
 
@@ -527,7 +527,7 @@ type AlertConfigurationsApi_ListAlertConfigurationMatchersFieldNames_Call struct
 
 // ListAlertConfigurationMatchersFieldNames is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationMatchersFieldNames(ctx interface{}) *AlertConfigurationsApi_ListAlertConfigurationMatchersFieldNames_Call {
+func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationMatchersFieldNames(ctx any) *AlertConfigurationsApi_ListAlertConfigurationMatchersFieldNames_Call {
 	return &AlertConfigurationsApi_ListAlertConfigurationMatchersFieldNames_Call{Call: _e.mock.On("ListAlertConfigurationMatchersFieldNames", ctx)}
 }
 
@@ -594,7 +594,7 @@ type AlertConfigurationsApi_ListAlertConfigurationMatchersFieldNamesExecute_Call
 
 // ListAlertConfigurationMatchersFieldNamesExecute is a helper method to define mock.On call
 //   - r admin.ListAlertConfigurationMatchersFieldNamesApiRequest
-func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationMatchersFieldNamesExecute(r interface{}) *AlertConfigurationsApi_ListAlertConfigurationMatchersFieldNamesExecute_Call {
+func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationMatchersFieldNamesExecute(r any) *AlertConfigurationsApi_ListAlertConfigurationMatchersFieldNamesExecute_Call {
 	return &AlertConfigurationsApi_ListAlertConfigurationMatchersFieldNamesExecute_Call{Call: _e.mock.On("ListAlertConfigurationMatchersFieldNamesExecute", r)}
 }
 
@@ -641,7 +641,7 @@ type AlertConfigurationsApi_ListAlertConfigurationMatchersFieldNamesWithParams_C
 // ListAlertConfigurationMatchersFieldNamesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListAlertConfigurationMatchersFieldNamesApiParams
-func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationMatchersFieldNamesWithParams(ctx interface{}, args interface{}) *AlertConfigurationsApi_ListAlertConfigurationMatchersFieldNamesWithParams_Call {
+func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationMatchersFieldNamesWithParams(ctx any, args any) *AlertConfigurationsApi_ListAlertConfigurationMatchersFieldNamesWithParams_Call {
 	return &AlertConfigurationsApi_ListAlertConfigurationMatchersFieldNamesWithParams_Call{Call: _e.mock.On("ListAlertConfigurationMatchersFieldNamesWithParams", ctx, args)}
 }
 
@@ -688,7 +688,7 @@ type AlertConfigurationsApi_ListAlertConfigurations_Call struct {
 // ListAlertConfigurations is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurations(ctx interface{}, groupId interface{}) *AlertConfigurationsApi_ListAlertConfigurations_Call {
+func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurations(ctx any, groupId any) *AlertConfigurationsApi_ListAlertConfigurations_Call {
 	return &AlertConfigurationsApi_ListAlertConfigurations_Call{Call: _e.mock.On("ListAlertConfigurations", ctx, groupId)}
 }
 
@@ -736,7 +736,7 @@ type AlertConfigurationsApi_ListAlertConfigurationsByAlertId_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - alertId string
-func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationsByAlertId(ctx interface{}, groupId interface{}, alertId interface{}) *AlertConfigurationsApi_ListAlertConfigurationsByAlertId_Call {
+func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationsByAlertId(ctx any, groupId any, alertId any) *AlertConfigurationsApi_ListAlertConfigurationsByAlertId_Call {
 	return &AlertConfigurationsApi_ListAlertConfigurationsByAlertId_Call{Call: _e.mock.On("ListAlertConfigurationsByAlertId", ctx, groupId, alertId)}
 }
 
@@ -803,7 +803,7 @@ type AlertConfigurationsApi_ListAlertConfigurationsByAlertIdExecute_Call struct 
 
 // ListAlertConfigurationsByAlertIdExecute is a helper method to define mock.On call
 //   - r admin.ListAlertConfigurationsByAlertIdApiRequest
-func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationsByAlertIdExecute(r interface{}) *AlertConfigurationsApi_ListAlertConfigurationsByAlertIdExecute_Call {
+func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationsByAlertIdExecute(r any) *AlertConfigurationsApi_ListAlertConfigurationsByAlertIdExecute_Call {
 	return &AlertConfigurationsApi_ListAlertConfigurationsByAlertIdExecute_Call{Call: _e.mock.On("ListAlertConfigurationsByAlertIdExecute", r)}
 }
 
@@ -850,7 +850,7 @@ type AlertConfigurationsApi_ListAlertConfigurationsByAlertIdWithParams_Call stru
 // ListAlertConfigurationsByAlertIdWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListAlertConfigurationsByAlertIdApiParams
-func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationsByAlertIdWithParams(ctx interface{}, args interface{}) *AlertConfigurationsApi_ListAlertConfigurationsByAlertIdWithParams_Call {
+func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationsByAlertIdWithParams(ctx any, args any) *AlertConfigurationsApi_ListAlertConfigurationsByAlertIdWithParams_Call {
 	return &AlertConfigurationsApi_ListAlertConfigurationsByAlertIdWithParams_Call{Call: _e.mock.On("ListAlertConfigurationsByAlertIdWithParams", ctx, args)}
 }
 
@@ -917,7 +917,7 @@ type AlertConfigurationsApi_ListAlertConfigurationsExecute_Call struct {
 
 // ListAlertConfigurationsExecute is a helper method to define mock.On call
 //   - r admin.ListAlertConfigurationsApiRequest
-func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationsExecute(r interface{}) *AlertConfigurationsApi_ListAlertConfigurationsExecute_Call {
+func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationsExecute(r any) *AlertConfigurationsApi_ListAlertConfigurationsExecute_Call {
 	return &AlertConfigurationsApi_ListAlertConfigurationsExecute_Call{Call: _e.mock.On("ListAlertConfigurationsExecute", r)}
 }
 
@@ -964,7 +964,7 @@ type AlertConfigurationsApi_ListAlertConfigurationsWithParams_Call struct {
 // ListAlertConfigurationsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListAlertConfigurationsApiParams
-func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationsWithParams(ctx interface{}, args interface{}) *AlertConfigurationsApi_ListAlertConfigurationsWithParams_Call {
+func (_e *AlertConfigurationsApi_Expecter) ListAlertConfigurationsWithParams(ctx any, args any) *AlertConfigurationsApi_ListAlertConfigurationsWithParams_Call {
 	return &AlertConfigurationsApi_ListAlertConfigurationsWithParams_Call{Call: _e.mock.On("ListAlertConfigurationsWithParams", ctx, args)}
 }
 
@@ -1013,7 +1013,7 @@ type AlertConfigurationsApi_ToggleAlertConfiguration_Call struct {
 //   - groupId string
 //   - alertConfigId string
 //   - alertsToggle *admin.AlertsToggle
-func (_e *AlertConfigurationsApi_Expecter) ToggleAlertConfiguration(ctx interface{}, groupId interface{}, alertConfigId interface{}, alertsToggle interface{}) *AlertConfigurationsApi_ToggleAlertConfiguration_Call {
+func (_e *AlertConfigurationsApi_Expecter) ToggleAlertConfiguration(ctx any, groupId any, alertConfigId any, alertsToggle any) *AlertConfigurationsApi_ToggleAlertConfiguration_Call {
 	return &AlertConfigurationsApi_ToggleAlertConfiguration_Call{Call: _e.mock.On("ToggleAlertConfiguration", ctx, groupId, alertConfigId, alertsToggle)}
 }
 
@@ -1080,7 +1080,7 @@ type AlertConfigurationsApi_ToggleAlertConfigurationExecute_Call struct {
 
 // ToggleAlertConfigurationExecute is a helper method to define mock.On call
 //   - r admin.ToggleAlertConfigurationApiRequest
-func (_e *AlertConfigurationsApi_Expecter) ToggleAlertConfigurationExecute(r interface{}) *AlertConfigurationsApi_ToggleAlertConfigurationExecute_Call {
+func (_e *AlertConfigurationsApi_Expecter) ToggleAlertConfigurationExecute(r any) *AlertConfigurationsApi_ToggleAlertConfigurationExecute_Call {
 	return &AlertConfigurationsApi_ToggleAlertConfigurationExecute_Call{Call: _e.mock.On("ToggleAlertConfigurationExecute", r)}
 }
 
@@ -1127,7 +1127,7 @@ type AlertConfigurationsApi_ToggleAlertConfigurationWithParams_Call struct {
 // ToggleAlertConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ToggleAlertConfigurationApiParams
-func (_e *AlertConfigurationsApi_Expecter) ToggleAlertConfigurationWithParams(ctx interface{}, args interface{}) *AlertConfigurationsApi_ToggleAlertConfigurationWithParams_Call {
+func (_e *AlertConfigurationsApi_Expecter) ToggleAlertConfigurationWithParams(ctx any, args any) *AlertConfigurationsApi_ToggleAlertConfigurationWithParams_Call {
 	return &AlertConfigurationsApi_ToggleAlertConfigurationWithParams_Call{Call: _e.mock.On("ToggleAlertConfigurationWithParams", ctx, args)}
 }
 
@@ -1176,7 +1176,7 @@ type AlertConfigurationsApi_UpdateAlertConfiguration_Call struct {
 //   - groupId string
 //   - alertConfigId string
 //   - groupAlertsConfig *admin.GroupAlertsConfig
-func (_e *AlertConfigurationsApi_Expecter) UpdateAlertConfiguration(ctx interface{}, groupId interface{}, alertConfigId interface{}, groupAlertsConfig interface{}) *AlertConfigurationsApi_UpdateAlertConfiguration_Call {
+func (_e *AlertConfigurationsApi_Expecter) UpdateAlertConfiguration(ctx any, groupId any, alertConfigId any, groupAlertsConfig any) *AlertConfigurationsApi_UpdateAlertConfiguration_Call {
 	return &AlertConfigurationsApi_UpdateAlertConfiguration_Call{Call: _e.mock.On("UpdateAlertConfiguration", ctx, groupId, alertConfigId, groupAlertsConfig)}
 }
 
@@ -1243,7 +1243,7 @@ type AlertConfigurationsApi_UpdateAlertConfigurationExecute_Call struct {
 
 // UpdateAlertConfigurationExecute is a helper method to define mock.On call
 //   - r admin.UpdateAlertConfigurationApiRequest
-func (_e *AlertConfigurationsApi_Expecter) UpdateAlertConfigurationExecute(r interface{}) *AlertConfigurationsApi_UpdateAlertConfigurationExecute_Call {
+func (_e *AlertConfigurationsApi_Expecter) UpdateAlertConfigurationExecute(r any) *AlertConfigurationsApi_UpdateAlertConfigurationExecute_Call {
 	return &AlertConfigurationsApi_UpdateAlertConfigurationExecute_Call{Call: _e.mock.On("UpdateAlertConfigurationExecute", r)}
 }
 
@@ -1290,7 +1290,7 @@ type AlertConfigurationsApi_UpdateAlertConfigurationWithParams_Call struct {
 // UpdateAlertConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateAlertConfigurationApiParams
-func (_e *AlertConfigurationsApi_Expecter) UpdateAlertConfigurationWithParams(ctx interface{}, args interface{}) *AlertConfigurationsApi_UpdateAlertConfigurationWithParams_Call {
+func (_e *AlertConfigurationsApi_Expecter) UpdateAlertConfigurationWithParams(ctx any, args any) *AlertConfigurationsApi_UpdateAlertConfigurationWithParams_Call {
 	return &AlertConfigurationsApi_UpdateAlertConfigurationWithParams_Call{Call: _e.mock.On("UpdateAlertConfigurationWithParams", ctx, args)}
 }
 

--- a/mockadmin/alerts_api.go
+++ b/mockadmin/alerts_api.go
@@ -53,7 +53,7 @@ type AlertsApi_AcknowledgeAlert_Call struct {
 //   - groupId string
 //   - alertId string
 //   - acknowledgeAlert *admin.AcknowledgeAlert
-func (_e *AlertsApi_Expecter) AcknowledgeAlert(ctx interface{}, groupId interface{}, alertId interface{}, acknowledgeAlert interface{}) *AlertsApi_AcknowledgeAlert_Call {
+func (_e *AlertsApi_Expecter) AcknowledgeAlert(ctx any, groupId any, alertId any, acknowledgeAlert any) *AlertsApi_AcknowledgeAlert_Call {
 	return &AlertsApi_AcknowledgeAlert_Call{Call: _e.mock.On("AcknowledgeAlert", ctx, groupId, alertId, acknowledgeAlert)}
 }
 
@@ -120,7 +120,7 @@ type AlertsApi_AcknowledgeAlertExecute_Call struct {
 
 // AcknowledgeAlertExecute is a helper method to define mock.On call
 //   - r admin.AcknowledgeAlertApiRequest
-func (_e *AlertsApi_Expecter) AcknowledgeAlertExecute(r interface{}) *AlertsApi_AcknowledgeAlertExecute_Call {
+func (_e *AlertsApi_Expecter) AcknowledgeAlertExecute(r any) *AlertsApi_AcknowledgeAlertExecute_Call {
 	return &AlertsApi_AcknowledgeAlertExecute_Call{Call: _e.mock.On("AcknowledgeAlertExecute", r)}
 }
 
@@ -167,7 +167,7 @@ type AlertsApi_AcknowledgeAlertWithParams_Call struct {
 // AcknowledgeAlertWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.AcknowledgeAlertApiParams
-func (_e *AlertsApi_Expecter) AcknowledgeAlertWithParams(ctx interface{}, args interface{}) *AlertsApi_AcknowledgeAlertWithParams_Call {
+func (_e *AlertsApi_Expecter) AcknowledgeAlertWithParams(ctx any, args any) *AlertsApi_AcknowledgeAlertWithParams_Call {
 	return &AlertsApi_AcknowledgeAlertWithParams_Call{Call: _e.mock.On("AcknowledgeAlertWithParams", ctx, args)}
 }
 
@@ -215,7 +215,7 @@ type AlertsApi_GetAlert_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - alertId string
-func (_e *AlertsApi_Expecter) GetAlert(ctx interface{}, groupId interface{}, alertId interface{}) *AlertsApi_GetAlert_Call {
+func (_e *AlertsApi_Expecter) GetAlert(ctx any, groupId any, alertId any) *AlertsApi_GetAlert_Call {
 	return &AlertsApi_GetAlert_Call{Call: _e.mock.On("GetAlert", ctx, groupId, alertId)}
 }
 
@@ -282,7 +282,7 @@ type AlertsApi_GetAlertExecute_Call struct {
 
 // GetAlertExecute is a helper method to define mock.On call
 //   - r admin.GetAlertApiRequest
-func (_e *AlertsApi_Expecter) GetAlertExecute(r interface{}) *AlertsApi_GetAlertExecute_Call {
+func (_e *AlertsApi_Expecter) GetAlertExecute(r any) *AlertsApi_GetAlertExecute_Call {
 	return &AlertsApi_GetAlertExecute_Call{Call: _e.mock.On("GetAlertExecute", r)}
 }
 
@@ -329,7 +329,7 @@ type AlertsApi_GetAlertWithParams_Call struct {
 // GetAlertWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetAlertApiParams
-func (_e *AlertsApi_Expecter) GetAlertWithParams(ctx interface{}, args interface{}) *AlertsApi_GetAlertWithParams_Call {
+func (_e *AlertsApi_Expecter) GetAlertWithParams(ctx any, args any) *AlertsApi_GetAlertWithParams_Call {
 	return &AlertsApi_GetAlertWithParams_Call{Call: _e.mock.On("GetAlertWithParams", ctx, args)}
 }
 
@@ -376,7 +376,7 @@ type AlertsApi_ListAlerts_Call struct {
 // ListAlerts is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *AlertsApi_Expecter) ListAlerts(ctx interface{}, groupId interface{}) *AlertsApi_ListAlerts_Call {
+func (_e *AlertsApi_Expecter) ListAlerts(ctx any, groupId any) *AlertsApi_ListAlerts_Call {
 	return &AlertsApi_ListAlerts_Call{Call: _e.mock.On("ListAlerts", ctx, groupId)}
 }
 
@@ -424,7 +424,7 @@ type AlertsApi_ListAlertsByAlertConfigurationId_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - alertConfigId string
-func (_e *AlertsApi_Expecter) ListAlertsByAlertConfigurationId(ctx interface{}, groupId interface{}, alertConfigId interface{}) *AlertsApi_ListAlertsByAlertConfigurationId_Call {
+func (_e *AlertsApi_Expecter) ListAlertsByAlertConfigurationId(ctx any, groupId any, alertConfigId any) *AlertsApi_ListAlertsByAlertConfigurationId_Call {
 	return &AlertsApi_ListAlertsByAlertConfigurationId_Call{Call: _e.mock.On("ListAlertsByAlertConfigurationId", ctx, groupId, alertConfigId)}
 }
 
@@ -491,7 +491,7 @@ type AlertsApi_ListAlertsByAlertConfigurationIdExecute_Call struct {
 
 // ListAlertsByAlertConfigurationIdExecute is a helper method to define mock.On call
 //   - r admin.ListAlertsByAlertConfigurationIdApiRequest
-func (_e *AlertsApi_Expecter) ListAlertsByAlertConfigurationIdExecute(r interface{}) *AlertsApi_ListAlertsByAlertConfigurationIdExecute_Call {
+func (_e *AlertsApi_Expecter) ListAlertsByAlertConfigurationIdExecute(r any) *AlertsApi_ListAlertsByAlertConfigurationIdExecute_Call {
 	return &AlertsApi_ListAlertsByAlertConfigurationIdExecute_Call{Call: _e.mock.On("ListAlertsByAlertConfigurationIdExecute", r)}
 }
 
@@ -538,7 +538,7 @@ type AlertsApi_ListAlertsByAlertConfigurationIdWithParams_Call struct {
 // ListAlertsByAlertConfigurationIdWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListAlertsByAlertConfigurationIdApiParams
-func (_e *AlertsApi_Expecter) ListAlertsByAlertConfigurationIdWithParams(ctx interface{}, args interface{}) *AlertsApi_ListAlertsByAlertConfigurationIdWithParams_Call {
+func (_e *AlertsApi_Expecter) ListAlertsByAlertConfigurationIdWithParams(ctx any, args any) *AlertsApi_ListAlertsByAlertConfigurationIdWithParams_Call {
 	return &AlertsApi_ListAlertsByAlertConfigurationIdWithParams_Call{Call: _e.mock.On("ListAlertsByAlertConfigurationIdWithParams", ctx, args)}
 }
 
@@ -605,7 +605,7 @@ type AlertsApi_ListAlertsExecute_Call struct {
 
 // ListAlertsExecute is a helper method to define mock.On call
 //   - r admin.ListAlertsApiRequest
-func (_e *AlertsApi_Expecter) ListAlertsExecute(r interface{}) *AlertsApi_ListAlertsExecute_Call {
+func (_e *AlertsApi_Expecter) ListAlertsExecute(r any) *AlertsApi_ListAlertsExecute_Call {
 	return &AlertsApi_ListAlertsExecute_Call{Call: _e.mock.On("ListAlertsExecute", r)}
 }
 
@@ -652,7 +652,7 @@ type AlertsApi_ListAlertsWithParams_Call struct {
 // ListAlertsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListAlertsApiParams
-func (_e *AlertsApi_Expecter) ListAlertsWithParams(ctx interface{}, args interface{}) *AlertsApi_ListAlertsWithParams_Call {
+func (_e *AlertsApi_Expecter) ListAlertsWithParams(ctx any, args any) *AlertsApi_ListAlertsWithParams_Call {
 	return &AlertsApi_ListAlertsWithParams_Call{Call: _e.mock.On("ListAlertsWithParams", ctx, args)}
 }
 

--- a/mockadmin/atlas_search_api.go
+++ b/mockadmin/atlas_search_api.go
@@ -53,7 +53,7 @@ type AtlasSearchApi_CreateAtlasSearchDeployment_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - apiSearchDeploymentRequest *admin.ApiSearchDeploymentRequest
-func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchDeployment(ctx interface{}, groupId interface{}, clusterName interface{}, apiSearchDeploymentRequest interface{}) *AtlasSearchApi_CreateAtlasSearchDeployment_Call {
+func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchDeployment(ctx any, groupId any, clusterName any, apiSearchDeploymentRequest any) *AtlasSearchApi_CreateAtlasSearchDeployment_Call {
 	return &AtlasSearchApi_CreateAtlasSearchDeployment_Call{Call: _e.mock.On("CreateAtlasSearchDeployment", ctx, groupId, clusterName, apiSearchDeploymentRequest)}
 }
 
@@ -120,7 +120,7 @@ type AtlasSearchApi_CreateAtlasSearchDeploymentExecute_Call struct {
 
 // CreateAtlasSearchDeploymentExecute is a helper method to define mock.On call
 //   - r admin.CreateAtlasSearchDeploymentApiRequest
-func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchDeploymentExecute(r interface{}) *AtlasSearchApi_CreateAtlasSearchDeploymentExecute_Call {
+func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchDeploymentExecute(r any) *AtlasSearchApi_CreateAtlasSearchDeploymentExecute_Call {
 	return &AtlasSearchApi_CreateAtlasSearchDeploymentExecute_Call{Call: _e.mock.On("CreateAtlasSearchDeploymentExecute", r)}
 }
 
@@ -167,7 +167,7 @@ type AtlasSearchApi_CreateAtlasSearchDeploymentWithParams_Call struct {
 // CreateAtlasSearchDeploymentWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateAtlasSearchDeploymentApiParams
-func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchDeploymentWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_CreateAtlasSearchDeploymentWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchDeploymentWithParams(ctx any, args any) *AtlasSearchApi_CreateAtlasSearchDeploymentWithParams_Call {
 	return &AtlasSearchApi_CreateAtlasSearchDeploymentWithParams_Call{Call: _e.mock.On("CreateAtlasSearchDeploymentWithParams", ctx, args)}
 }
 
@@ -216,7 +216,7 @@ type AtlasSearchApi_CreateAtlasSearchIndex_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - searchIndexCreateRequest *admin.SearchIndexCreateRequest
-func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchIndex(ctx interface{}, groupId interface{}, clusterName interface{}, searchIndexCreateRequest interface{}) *AtlasSearchApi_CreateAtlasSearchIndex_Call {
+func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchIndex(ctx any, groupId any, clusterName any, searchIndexCreateRequest any) *AtlasSearchApi_CreateAtlasSearchIndex_Call {
 	return &AtlasSearchApi_CreateAtlasSearchIndex_Call{Call: _e.mock.On("CreateAtlasSearchIndex", ctx, groupId, clusterName, searchIndexCreateRequest)}
 }
 
@@ -265,7 +265,7 @@ type AtlasSearchApi_CreateAtlasSearchIndexDeprecated_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - clusterSearchIndex *admin.ClusterSearchIndex
-func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchIndexDeprecated(ctx interface{}, groupId interface{}, clusterName interface{}, clusterSearchIndex interface{}) *AtlasSearchApi_CreateAtlasSearchIndexDeprecated_Call {
+func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchIndexDeprecated(ctx any, groupId any, clusterName any, clusterSearchIndex any) *AtlasSearchApi_CreateAtlasSearchIndexDeprecated_Call {
 	return &AtlasSearchApi_CreateAtlasSearchIndexDeprecated_Call{Call: _e.mock.On("CreateAtlasSearchIndexDeprecated", ctx, groupId, clusterName, clusterSearchIndex)}
 }
 
@@ -332,7 +332,7 @@ type AtlasSearchApi_CreateAtlasSearchIndexDeprecatedExecute_Call struct {
 
 // CreateAtlasSearchIndexDeprecatedExecute is a helper method to define mock.On call
 //   - r admin.CreateAtlasSearchIndexDeprecatedApiRequest
-func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchIndexDeprecatedExecute(r interface{}) *AtlasSearchApi_CreateAtlasSearchIndexDeprecatedExecute_Call {
+func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchIndexDeprecatedExecute(r any) *AtlasSearchApi_CreateAtlasSearchIndexDeprecatedExecute_Call {
 	return &AtlasSearchApi_CreateAtlasSearchIndexDeprecatedExecute_Call{Call: _e.mock.On("CreateAtlasSearchIndexDeprecatedExecute", r)}
 }
 
@@ -379,7 +379,7 @@ type AtlasSearchApi_CreateAtlasSearchIndexDeprecatedWithParams_Call struct {
 // CreateAtlasSearchIndexDeprecatedWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateAtlasSearchIndexDeprecatedApiParams
-func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchIndexDeprecatedWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_CreateAtlasSearchIndexDeprecatedWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchIndexDeprecatedWithParams(ctx any, args any) *AtlasSearchApi_CreateAtlasSearchIndexDeprecatedWithParams_Call {
 	return &AtlasSearchApi_CreateAtlasSearchIndexDeprecatedWithParams_Call{Call: _e.mock.On("CreateAtlasSearchIndexDeprecatedWithParams", ctx, args)}
 }
 
@@ -446,7 +446,7 @@ type AtlasSearchApi_CreateAtlasSearchIndexExecute_Call struct {
 
 // CreateAtlasSearchIndexExecute is a helper method to define mock.On call
 //   - r admin.CreateAtlasSearchIndexApiRequest
-func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchIndexExecute(r interface{}) *AtlasSearchApi_CreateAtlasSearchIndexExecute_Call {
+func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchIndexExecute(r any) *AtlasSearchApi_CreateAtlasSearchIndexExecute_Call {
 	return &AtlasSearchApi_CreateAtlasSearchIndexExecute_Call{Call: _e.mock.On("CreateAtlasSearchIndexExecute", r)}
 }
 
@@ -493,7 +493,7 @@ type AtlasSearchApi_CreateAtlasSearchIndexWithParams_Call struct {
 // CreateAtlasSearchIndexWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateAtlasSearchIndexApiParams
-func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchIndexWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_CreateAtlasSearchIndexWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) CreateAtlasSearchIndexWithParams(ctx any, args any) *AtlasSearchApi_CreateAtlasSearchIndexWithParams_Call {
 	return &AtlasSearchApi_CreateAtlasSearchIndexWithParams_Call{Call: _e.mock.On("CreateAtlasSearchIndexWithParams", ctx, args)}
 }
 
@@ -541,7 +541,7 @@ type AtlasSearchApi_DeleteAtlasSearchDeployment_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchDeployment(ctx interface{}, groupId interface{}, clusterName interface{}) *AtlasSearchApi_DeleteAtlasSearchDeployment_Call {
+func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchDeployment(ctx any, groupId any, clusterName any) *AtlasSearchApi_DeleteAtlasSearchDeployment_Call {
 	return &AtlasSearchApi_DeleteAtlasSearchDeployment_Call{Call: _e.mock.On("DeleteAtlasSearchDeployment", ctx, groupId, clusterName)}
 }
 
@@ -563,24 +563,24 @@ func (_c *AtlasSearchApi_DeleteAtlasSearchDeployment_Call) RunAndReturn(run func
 }
 
 // DeleteAtlasSearchDeploymentExecute provides a mock function with given fields: r
-func (_m *AtlasSearchApi) DeleteAtlasSearchDeploymentExecute(r admin.DeleteAtlasSearchDeploymentApiRequest) (interface{}, *http.Response, error) {
+func (_m *AtlasSearchApi) DeleteAtlasSearchDeploymentExecute(r admin.DeleteAtlasSearchDeploymentApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteAtlasSearchDeploymentExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchDeploymentApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchDeploymentApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchDeploymentApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchDeploymentApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -608,7 +608,7 @@ type AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call struct {
 
 // DeleteAtlasSearchDeploymentExecute is a helper method to define mock.On call
 //   - r admin.DeleteAtlasSearchDeploymentApiRequest
-func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchDeploymentExecute(r interface{}) *AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call {
+func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchDeploymentExecute(r any) *AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call {
 	return &AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call{Call: _e.mock.On("DeleteAtlasSearchDeploymentExecute", r)}
 }
 
@@ -619,12 +619,12 @@ func (_c *AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call) Run(run func(r
 	return _c
 }
 
-func (_c *AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call {
+func (_c *AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call) RunAndReturn(run func(admin.DeleteAtlasSearchDeploymentApiRequest) (interface{}, *http.Response, error)) *AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call {
+func (_c *AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call) RunAndReturn(run func(admin.DeleteAtlasSearchDeploymentApiRequest) (any, *http.Response, error)) *AtlasSearchApi_DeleteAtlasSearchDeploymentExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -655,7 +655,7 @@ type AtlasSearchApi_DeleteAtlasSearchDeploymentWithParams_Call struct {
 // DeleteAtlasSearchDeploymentWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteAtlasSearchDeploymentApiParams
-func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchDeploymentWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_DeleteAtlasSearchDeploymentWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchDeploymentWithParams(ctx any, args any) *AtlasSearchApi_DeleteAtlasSearchDeploymentWithParams_Call {
 	return &AtlasSearchApi_DeleteAtlasSearchDeploymentWithParams_Call{Call: _e.mock.On("DeleteAtlasSearchDeploymentWithParams", ctx, args)}
 }
 
@@ -704,7 +704,7 @@ type AtlasSearchApi_DeleteAtlasSearchIndex_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - indexId string
-func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndex(ctx interface{}, groupId interface{}, clusterName interface{}, indexId interface{}) *AtlasSearchApi_DeleteAtlasSearchIndex_Call {
+func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndex(ctx any, groupId any, clusterName any, indexId any) *AtlasSearchApi_DeleteAtlasSearchIndex_Call {
 	return &AtlasSearchApi_DeleteAtlasSearchIndex_Call{Call: _e.mock.On("DeleteAtlasSearchIndex", ctx, groupId, clusterName, indexId)}
 }
 
@@ -755,7 +755,7 @@ type AtlasSearchApi_DeleteAtlasSearchIndexByName_Call struct {
 //   - collectionName string
 //   - databaseName string
 //   - indexName string
-func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexByName(ctx interface{}, groupId interface{}, clusterName interface{}, collectionName interface{}, databaseName interface{}, indexName interface{}) *AtlasSearchApi_DeleteAtlasSearchIndexByName_Call {
+func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexByName(ctx any, groupId any, clusterName any, collectionName any, databaseName any, indexName any) *AtlasSearchApi_DeleteAtlasSearchIndexByName_Call {
 	return &AtlasSearchApi_DeleteAtlasSearchIndexByName_Call{Call: _e.mock.On("DeleteAtlasSearchIndexByName", ctx, groupId, clusterName, collectionName, databaseName, indexName)}
 }
 
@@ -777,24 +777,24 @@ func (_c *AtlasSearchApi_DeleteAtlasSearchIndexByName_Call) RunAndReturn(run fun
 }
 
 // DeleteAtlasSearchIndexByNameExecute provides a mock function with given fields: r
-func (_m *AtlasSearchApi) DeleteAtlasSearchIndexByNameExecute(r admin.DeleteAtlasSearchIndexByNameApiRequest) (interface{}, *http.Response, error) {
+func (_m *AtlasSearchApi) DeleteAtlasSearchIndexByNameExecute(r admin.DeleteAtlasSearchIndexByNameApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteAtlasSearchIndexByNameExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchIndexByNameApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchIndexByNameApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchIndexByNameApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchIndexByNameApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -822,7 +822,7 @@ type AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call struct {
 
 // DeleteAtlasSearchIndexByNameExecute is a helper method to define mock.On call
 //   - r admin.DeleteAtlasSearchIndexByNameApiRequest
-func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexByNameExecute(r interface{}) *AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call {
+func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexByNameExecute(r any) *AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call {
 	return &AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call{Call: _e.mock.On("DeleteAtlasSearchIndexByNameExecute", r)}
 }
 
@@ -833,12 +833,12 @@ func (_c *AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call) Run(run func(
 	return _c
 }
 
-func (_c *AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call {
+func (_c *AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call) RunAndReturn(run func(admin.DeleteAtlasSearchIndexByNameApiRequest) (interface{}, *http.Response, error)) *AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call {
+func (_c *AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call) RunAndReturn(run func(admin.DeleteAtlasSearchIndexByNameApiRequest) (any, *http.Response, error)) *AtlasSearchApi_DeleteAtlasSearchIndexByNameExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -869,7 +869,7 @@ type AtlasSearchApi_DeleteAtlasSearchIndexByNameWithParams_Call struct {
 // DeleteAtlasSearchIndexByNameWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteAtlasSearchIndexByNameApiParams
-func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexByNameWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_DeleteAtlasSearchIndexByNameWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexByNameWithParams(ctx any, args any) *AtlasSearchApi_DeleteAtlasSearchIndexByNameWithParams_Call {
 	return &AtlasSearchApi_DeleteAtlasSearchIndexByNameWithParams_Call{Call: _e.mock.On("DeleteAtlasSearchIndexByNameWithParams", ctx, args)}
 }
 
@@ -918,7 +918,7 @@ type AtlasSearchApi_DeleteAtlasSearchIndexDeprecated_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - indexId string
-func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexDeprecated(ctx interface{}, groupId interface{}, clusterName interface{}, indexId interface{}) *AtlasSearchApi_DeleteAtlasSearchIndexDeprecated_Call {
+func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexDeprecated(ctx any, groupId any, clusterName any, indexId any) *AtlasSearchApi_DeleteAtlasSearchIndexDeprecated_Call {
 	return &AtlasSearchApi_DeleteAtlasSearchIndexDeprecated_Call{Call: _e.mock.On("DeleteAtlasSearchIndexDeprecated", ctx, groupId, clusterName, indexId)}
 }
 
@@ -940,24 +940,24 @@ func (_c *AtlasSearchApi_DeleteAtlasSearchIndexDeprecated_Call) RunAndReturn(run
 }
 
 // DeleteAtlasSearchIndexDeprecatedExecute provides a mock function with given fields: r
-func (_m *AtlasSearchApi) DeleteAtlasSearchIndexDeprecatedExecute(r admin.DeleteAtlasSearchIndexDeprecatedApiRequest) (interface{}, *http.Response, error) {
+func (_m *AtlasSearchApi) DeleteAtlasSearchIndexDeprecatedExecute(r admin.DeleteAtlasSearchIndexDeprecatedApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteAtlasSearchIndexDeprecatedExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchIndexDeprecatedApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchIndexDeprecatedApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchIndexDeprecatedApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchIndexDeprecatedApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -985,7 +985,7 @@ type AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call struct {
 
 // DeleteAtlasSearchIndexDeprecatedExecute is a helper method to define mock.On call
 //   - r admin.DeleteAtlasSearchIndexDeprecatedApiRequest
-func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexDeprecatedExecute(r interface{}) *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call {
+func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexDeprecatedExecute(r any) *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call {
 	return &AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call{Call: _e.mock.On("DeleteAtlasSearchIndexDeprecatedExecute", r)}
 }
 
@@ -996,12 +996,12 @@ func (_c *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call) Run(run f
 	return _c
 }
 
-func (_c *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call {
+func (_c *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call) RunAndReturn(run func(admin.DeleteAtlasSearchIndexDeprecatedApiRequest) (interface{}, *http.Response, error)) *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call {
+func (_c *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call) RunAndReturn(run func(admin.DeleteAtlasSearchIndexDeprecatedApiRequest) (any, *http.Response, error)) *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1032,7 +1032,7 @@ type AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedWithParams_Call struct {
 // DeleteAtlasSearchIndexDeprecatedWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteAtlasSearchIndexDeprecatedApiParams
-func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexDeprecatedWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexDeprecatedWithParams(ctx any, args any) *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedWithParams_Call {
 	return &AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedWithParams_Call{Call: _e.mock.On("DeleteAtlasSearchIndexDeprecatedWithParams", ctx, args)}
 }
 
@@ -1054,24 +1054,24 @@ func (_c *AtlasSearchApi_DeleteAtlasSearchIndexDeprecatedWithParams_Call) RunAnd
 }
 
 // DeleteAtlasSearchIndexExecute provides a mock function with given fields: r
-func (_m *AtlasSearchApi) DeleteAtlasSearchIndexExecute(r admin.DeleteAtlasSearchIndexApiRequest) (interface{}, *http.Response, error) {
+func (_m *AtlasSearchApi) DeleteAtlasSearchIndexExecute(r admin.DeleteAtlasSearchIndexApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteAtlasSearchIndexExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchIndexApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchIndexApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchIndexApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasSearchIndexApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -1099,7 +1099,7 @@ type AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call struct {
 
 // DeleteAtlasSearchIndexExecute is a helper method to define mock.On call
 //   - r admin.DeleteAtlasSearchIndexApiRequest
-func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexExecute(r interface{}) *AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call {
+func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexExecute(r any) *AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call {
 	return &AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call{Call: _e.mock.On("DeleteAtlasSearchIndexExecute", r)}
 }
 
@@ -1110,12 +1110,12 @@ func (_c *AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call) Run(run func(r admi
 	return _c
 }
 
-func (_c *AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call {
+func (_c *AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call) RunAndReturn(run func(admin.DeleteAtlasSearchIndexApiRequest) (interface{}, *http.Response, error)) *AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call {
+func (_c *AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call) RunAndReturn(run func(admin.DeleteAtlasSearchIndexApiRequest) (any, *http.Response, error)) *AtlasSearchApi_DeleteAtlasSearchIndexExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1146,7 +1146,7 @@ type AtlasSearchApi_DeleteAtlasSearchIndexWithParams_Call struct {
 // DeleteAtlasSearchIndexWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteAtlasSearchIndexApiParams
-func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_DeleteAtlasSearchIndexWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) DeleteAtlasSearchIndexWithParams(ctx any, args any) *AtlasSearchApi_DeleteAtlasSearchIndexWithParams_Call {
 	return &AtlasSearchApi_DeleteAtlasSearchIndexWithParams_Call{Call: _e.mock.On("DeleteAtlasSearchIndexWithParams", ctx, args)}
 }
 
@@ -1194,7 +1194,7 @@ type AtlasSearchApi_GetAtlasSearchDeployment_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *AtlasSearchApi_Expecter) GetAtlasSearchDeployment(ctx interface{}, groupId interface{}, clusterName interface{}) *AtlasSearchApi_GetAtlasSearchDeployment_Call {
+func (_e *AtlasSearchApi_Expecter) GetAtlasSearchDeployment(ctx any, groupId any, clusterName any) *AtlasSearchApi_GetAtlasSearchDeployment_Call {
 	return &AtlasSearchApi_GetAtlasSearchDeployment_Call{Call: _e.mock.On("GetAtlasSearchDeployment", ctx, groupId, clusterName)}
 }
 
@@ -1261,7 +1261,7 @@ type AtlasSearchApi_GetAtlasSearchDeploymentExecute_Call struct {
 
 // GetAtlasSearchDeploymentExecute is a helper method to define mock.On call
 //   - r admin.GetAtlasSearchDeploymentApiRequest
-func (_e *AtlasSearchApi_Expecter) GetAtlasSearchDeploymentExecute(r interface{}) *AtlasSearchApi_GetAtlasSearchDeploymentExecute_Call {
+func (_e *AtlasSearchApi_Expecter) GetAtlasSearchDeploymentExecute(r any) *AtlasSearchApi_GetAtlasSearchDeploymentExecute_Call {
 	return &AtlasSearchApi_GetAtlasSearchDeploymentExecute_Call{Call: _e.mock.On("GetAtlasSearchDeploymentExecute", r)}
 }
 
@@ -1308,7 +1308,7 @@ type AtlasSearchApi_GetAtlasSearchDeploymentWithParams_Call struct {
 // GetAtlasSearchDeploymentWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetAtlasSearchDeploymentApiParams
-func (_e *AtlasSearchApi_Expecter) GetAtlasSearchDeploymentWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_GetAtlasSearchDeploymentWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) GetAtlasSearchDeploymentWithParams(ctx any, args any) *AtlasSearchApi_GetAtlasSearchDeploymentWithParams_Call {
 	return &AtlasSearchApi_GetAtlasSearchDeploymentWithParams_Call{Call: _e.mock.On("GetAtlasSearchDeploymentWithParams", ctx, args)}
 }
 
@@ -1357,7 +1357,7 @@ type AtlasSearchApi_GetAtlasSearchIndex_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - indexId string
-func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndex(ctx interface{}, groupId interface{}, clusterName interface{}, indexId interface{}) *AtlasSearchApi_GetAtlasSearchIndex_Call {
+func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndex(ctx any, groupId any, clusterName any, indexId any) *AtlasSearchApi_GetAtlasSearchIndex_Call {
 	return &AtlasSearchApi_GetAtlasSearchIndex_Call{Call: _e.mock.On("GetAtlasSearchIndex", ctx, groupId, clusterName, indexId)}
 }
 
@@ -1408,7 +1408,7 @@ type AtlasSearchApi_GetAtlasSearchIndexByName_Call struct {
 //   - collectionName string
 //   - databaseName string
 //   - indexName string
-func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexByName(ctx interface{}, groupId interface{}, clusterName interface{}, collectionName interface{}, databaseName interface{}, indexName interface{}) *AtlasSearchApi_GetAtlasSearchIndexByName_Call {
+func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexByName(ctx any, groupId any, clusterName any, collectionName any, databaseName any, indexName any) *AtlasSearchApi_GetAtlasSearchIndexByName_Call {
 	return &AtlasSearchApi_GetAtlasSearchIndexByName_Call{Call: _e.mock.On("GetAtlasSearchIndexByName", ctx, groupId, clusterName, collectionName, databaseName, indexName)}
 }
 
@@ -1475,7 +1475,7 @@ type AtlasSearchApi_GetAtlasSearchIndexByNameExecute_Call struct {
 
 // GetAtlasSearchIndexByNameExecute is a helper method to define mock.On call
 //   - r admin.GetAtlasSearchIndexByNameApiRequest
-func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexByNameExecute(r interface{}) *AtlasSearchApi_GetAtlasSearchIndexByNameExecute_Call {
+func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexByNameExecute(r any) *AtlasSearchApi_GetAtlasSearchIndexByNameExecute_Call {
 	return &AtlasSearchApi_GetAtlasSearchIndexByNameExecute_Call{Call: _e.mock.On("GetAtlasSearchIndexByNameExecute", r)}
 }
 
@@ -1522,7 +1522,7 @@ type AtlasSearchApi_GetAtlasSearchIndexByNameWithParams_Call struct {
 // GetAtlasSearchIndexByNameWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetAtlasSearchIndexByNameApiParams
-func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexByNameWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_GetAtlasSearchIndexByNameWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexByNameWithParams(ctx any, args any) *AtlasSearchApi_GetAtlasSearchIndexByNameWithParams_Call {
 	return &AtlasSearchApi_GetAtlasSearchIndexByNameWithParams_Call{Call: _e.mock.On("GetAtlasSearchIndexByNameWithParams", ctx, args)}
 }
 
@@ -1571,7 +1571,7 @@ type AtlasSearchApi_GetAtlasSearchIndexDeprecated_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - indexId string
-func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexDeprecated(ctx interface{}, groupId interface{}, clusterName interface{}, indexId interface{}) *AtlasSearchApi_GetAtlasSearchIndexDeprecated_Call {
+func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexDeprecated(ctx any, groupId any, clusterName any, indexId any) *AtlasSearchApi_GetAtlasSearchIndexDeprecated_Call {
 	return &AtlasSearchApi_GetAtlasSearchIndexDeprecated_Call{Call: _e.mock.On("GetAtlasSearchIndexDeprecated", ctx, groupId, clusterName, indexId)}
 }
 
@@ -1638,7 +1638,7 @@ type AtlasSearchApi_GetAtlasSearchIndexDeprecatedExecute_Call struct {
 
 // GetAtlasSearchIndexDeprecatedExecute is a helper method to define mock.On call
 //   - r admin.GetAtlasSearchIndexDeprecatedApiRequest
-func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexDeprecatedExecute(r interface{}) *AtlasSearchApi_GetAtlasSearchIndexDeprecatedExecute_Call {
+func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexDeprecatedExecute(r any) *AtlasSearchApi_GetAtlasSearchIndexDeprecatedExecute_Call {
 	return &AtlasSearchApi_GetAtlasSearchIndexDeprecatedExecute_Call{Call: _e.mock.On("GetAtlasSearchIndexDeprecatedExecute", r)}
 }
 
@@ -1685,7 +1685,7 @@ type AtlasSearchApi_GetAtlasSearchIndexDeprecatedWithParams_Call struct {
 // GetAtlasSearchIndexDeprecatedWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetAtlasSearchIndexDeprecatedApiParams
-func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexDeprecatedWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_GetAtlasSearchIndexDeprecatedWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexDeprecatedWithParams(ctx any, args any) *AtlasSearchApi_GetAtlasSearchIndexDeprecatedWithParams_Call {
 	return &AtlasSearchApi_GetAtlasSearchIndexDeprecatedWithParams_Call{Call: _e.mock.On("GetAtlasSearchIndexDeprecatedWithParams", ctx, args)}
 }
 
@@ -1752,7 +1752,7 @@ type AtlasSearchApi_GetAtlasSearchIndexExecute_Call struct {
 
 // GetAtlasSearchIndexExecute is a helper method to define mock.On call
 //   - r admin.GetAtlasSearchIndexApiRequest
-func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexExecute(r interface{}) *AtlasSearchApi_GetAtlasSearchIndexExecute_Call {
+func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexExecute(r any) *AtlasSearchApi_GetAtlasSearchIndexExecute_Call {
 	return &AtlasSearchApi_GetAtlasSearchIndexExecute_Call{Call: _e.mock.On("GetAtlasSearchIndexExecute", r)}
 }
 
@@ -1799,7 +1799,7 @@ type AtlasSearchApi_GetAtlasSearchIndexWithParams_Call struct {
 // GetAtlasSearchIndexWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetAtlasSearchIndexApiParams
-func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_GetAtlasSearchIndexWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) GetAtlasSearchIndexWithParams(ctx any, args any) *AtlasSearchApi_GetAtlasSearchIndexWithParams_Call {
 	return &AtlasSearchApi_GetAtlasSearchIndexWithParams_Call{Call: _e.mock.On("GetAtlasSearchIndexWithParams", ctx, args)}
 }
 
@@ -1849,7 +1849,7 @@ type AtlasSearchApi_ListAtlasSearchIndexes_Call struct {
 //   - clusterName string
 //   - collectionName string
 //   - databaseName string
-func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexes(ctx interface{}, groupId interface{}, clusterName interface{}, collectionName interface{}, databaseName interface{}) *AtlasSearchApi_ListAtlasSearchIndexes_Call {
+func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexes(ctx any, groupId any, clusterName any, collectionName any, databaseName any) *AtlasSearchApi_ListAtlasSearchIndexes_Call {
 	return &AtlasSearchApi_ListAtlasSearchIndexes_Call{Call: _e.mock.On("ListAtlasSearchIndexes", ctx, groupId, clusterName, collectionName, databaseName)}
 }
 
@@ -1897,7 +1897,7 @@ type AtlasSearchApi_ListAtlasSearchIndexesCluster_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesCluster(ctx interface{}, groupId interface{}, clusterName interface{}) *AtlasSearchApi_ListAtlasSearchIndexesCluster_Call {
+func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesCluster(ctx any, groupId any, clusterName any) *AtlasSearchApi_ListAtlasSearchIndexesCluster_Call {
 	return &AtlasSearchApi_ListAtlasSearchIndexesCluster_Call{Call: _e.mock.On("ListAtlasSearchIndexesCluster", ctx, groupId, clusterName)}
 }
 
@@ -1964,7 +1964,7 @@ type AtlasSearchApi_ListAtlasSearchIndexesClusterExecute_Call struct {
 
 // ListAtlasSearchIndexesClusterExecute is a helper method to define mock.On call
 //   - r admin.ListAtlasSearchIndexesClusterApiRequest
-func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesClusterExecute(r interface{}) *AtlasSearchApi_ListAtlasSearchIndexesClusterExecute_Call {
+func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesClusterExecute(r any) *AtlasSearchApi_ListAtlasSearchIndexesClusterExecute_Call {
 	return &AtlasSearchApi_ListAtlasSearchIndexesClusterExecute_Call{Call: _e.mock.On("ListAtlasSearchIndexesClusterExecute", r)}
 }
 
@@ -2011,7 +2011,7 @@ type AtlasSearchApi_ListAtlasSearchIndexesClusterWithParams_Call struct {
 // ListAtlasSearchIndexesClusterWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListAtlasSearchIndexesClusterApiParams
-func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesClusterWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_ListAtlasSearchIndexesClusterWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesClusterWithParams(ctx any, args any) *AtlasSearchApi_ListAtlasSearchIndexesClusterWithParams_Call {
 	return &AtlasSearchApi_ListAtlasSearchIndexesClusterWithParams_Call{Call: _e.mock.On("ListAtlasSearchIndexesClusterWithParams", ctx, args)}
 }
 
@@ -2061,7 +2061,7 @@ type AtlasSearchApi_ListAtlasSearchIndexesDeprecated_Call struct {
 //   - clusterName string
 //   - collectionName string
 //   - databaseName string
-func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesDeprecated(ctx interface{}, groupId interface{}, clusterName interface{}, collectionName interface{}, databaseName interface{}) *AtlasSearchApi_ListAtlasSearchIndexesDeprecated_Call {
+func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesDeprecated(ctx any, groupId any, clusterName any, collectionName any, databaseName any) *AtlasSearchApi_ListAtlasSearchIndexesDeprecated_Call {
 	return &AtlasSearchApi_ListAtlasSearchIndexesDeprecated_Call{Call: _e.mock.On("ListAtlasSearchIndexesDeprecated", ctx, groupId, clusterName, collectionName, databaseName)}
 }
 
@@ -2128,7 +2128,7 @@ type AtlasSearchApi_ListAtlasSearchIndexesDeprecatedExecute_Call struct {
 
 // ListAtlasSearchIndexesDeprecatedExecute is a helper method to define mock.On call
 //   - r admin.ListAtlasSearchIndexesDeprecatedApiRequest
-func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesDeprecatedExecute(r interface{}) *AtlasSearchApi_ListAtlasSearchIndexesDeprecatedExecute_Call {
+func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesDeprecatedExecute(r any) *AtlasSearchApi_ListAtlasSearchIndexesDeprecatedExecute_Call {
 	return &AtlasSearchApi_ListAtlasSearchIndexesDeprecatedExecute_Call{Call: _e.mock.On("ListAtlasSearchIndexesDeprecatedExecute", r)}
 }
 
@@ -2175,7 +2175,7 @@ type AtlasSearchApi_ListAtlasSearchIndexesDeprecatedWithParams_Call struct {
 // ListAtlasSearchIndexesDeprecatedWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListAtlasSearchIndexesDeprecatedApiParams
-func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesDeprecatedWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_ListAtlasSearchIndexesDeprecatedWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesDeprecatedWithParams(ctx any, args any) *AtlasSearchApi_ListAtlasSearchIndexesDeprecatedWithParams_Call {
 	return &AtlasSearchApi_ListAtlasSearchIndexesDeprecatedWithParams_Call{Call: _e.mock.On("ListAtlasSearchIndexesDeprecatedWithParams", ctx, args)}
 }
 
@@ -2242,7 +2242,7 @@ type AtlasSearchApi_ListAtlasSearchIndexesExecute_Call struct {
 
 // ListAtlasSearchIndexesExecute is a helper method to define mock.On call
 //   - r admin.ListAtlasSearchIndexesApiRequest
-func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesExecute(r interface{}) *AtlasSearchApi_ListAtlasSearchIndexesExecute_Call {
+func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesExecute(r any) *AtlasSearchApi_ListAtlasSearchIndexesExecute_Call {
 	return &AtlasSearchApi_ListAtlasSearchIndexesExecute_Call{Call: _e.mock.On("ListAtlasSearchIndexesExecute", r)}
 }
 
@@ -2289,7 +2289,7 @@ type AtlasSearchApi_ListAtlasSearchIndexesWithParams_Call struct {
 // ListAtlasSearchIndexesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListAtlasSearchIndexesApiParams
-func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_ListAtlasSearchIndexesWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) ListAtlasSearchIndexesWithParams(ctx any, args any) *AtlasSearchApi_ListAtlasSearchIndexesWithParams_Call {
 	return &AtlasSearchApi_ListAtlasSearchIndexesWithParams_Call{Call: _e.mock.On("ListAtlasSearchIndexesWithParams", ctx, args)}
 }
 
@@ -2338,7 +2338,7 @@ type AtlasSearchApi_UpdateAtlasSearchDeployment_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - apiSearchDeploymentRequest *admin.ApiSearchDeploymentRequest
-func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchDeployment(ctx interface{}, groupId interface{}, clusterName interface{}, apiSearchDeploymentRequest interface{}) *AtlasSearchApi_UpdateAtlasSearchDeployment_Call {
+func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchDeployment(ctx any, groupId any, clusterName any, apiSearchDeploymentRequest any) *AtlasSearchApi_UpdateAtlasSearchDeployment_Call {
 	return &AtlasSearchApi_UpdateAtlasSearchDeployment_Call{Call: _e.mock.On("UpdateAtlasSearchDeployment", ctx, groupId, clusterName, apiSearchDeploymentRequest)}
 }
 
@@ -2405,7 +2405,7 @@ type AtlasSearchApi_UpdateAtlasSearchDeploymentExecute_Call struct {
 
 // UpdateAtlasSearchDeploymentExecute is a helper method to define mock.On call
 //   - r admin.UpdateAtlasSearchDeploymentApiRequest
-func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchDeploymentExecute(r interface{}) *AtlasSearchApi_UpdateAtlasSearchDeploymentExecute_Call {
+func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchDeploymentExecute(r any) *AtlasSearchApi_UpdateAtlasSearchDeploymentExecute_Call {
 	return &AtlasSearchApi_UpdateAtlasSearchDeploymentExecute_Call{Call: _e.mock.On("UpdateAtlasSearchDeploymentExecute", r)}
 }
 
@@ -2452,7 +2452,7 @@ type AtlasSearchApi_UpdateAtlasSearchDeploymentWithParams_Call struct {
 // UpdateAtlasSearchDeploymentWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateAtlasSearchDeploymentApiParams
-func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchDeploymentWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_UpdateAtlasSearchDeploymentWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchDeploymentWithParams(ctx any, args any) *AtlasSearchApi_UpdateAtlasSearchDeploymentWithParams_Call {
 	return &AtlasSearchApi_UpdateAtlasSearchDeploymentWithParams_Call{Call: _e.mock.On("UpdateAtlasSearchDeploymentWithParams", ctx, args)}
 }
 
@@ -2502,7 +2502,7 @@ type AtlasSearchApi_UpdateAtlasSearchIndex_Call struct {
 //   - clusterName string
 //   - indexId string
 //   - searchIndexUpdateRequest *admin.SearchIndexUpdateRequest
-func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndex(ctx interface{}, groupId interface{}, clusterName interface{}, indexId interface{}, searchIndexUpdateRequest interface{}) *AtlasSearchApi_UpdateAtlasSearchIndex_Call {
+func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndex(ctx any, groupId any, clusterName any, indexId any, searchIndexUpdateRequest any) *AtlasSearchApi_UpdateAtlasSearchIndex_Call {
 	return &AtlasSearchApi_UpdateAtlasSearchIndex_Call{Call: _e.mock.On("UpdateAtlasSearchIndex", ctx, groupId, clusterName, indexId, searchIndexUpdateRequest)}
 }
 
@@ -2554,7 +2554,7 @@ type AtlasSearchApi_UpdateAtlasSearchIndexByName_Call struct {
 //   - databaseName string
 //   - indexName string
 //   - searchIndexUpdateRequest *admin.SearchIndexUpdateRequest
-func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexByName(ctx interface{}, groupId interface{}, clusterName interface{}, collectionName interface{}, databaseName interface{}, indexName interface{}, searchIndexUpdateRequest interface{}) *AtlasSearchApi_UpdateAtlasSearchIndexByName_Call {
+func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexByName(ctx any, groupId any, clusterName any, collectionName any, databaseName any, indexName any, searchIndexUpdateRequest any) *AtlasSearchApi_UpdateAtlasSearchIndexByName_Call {
 	return &AtlasSearchApi_UpdateAtlasSearchIndexByName_Call{Call: _e.mock.On("UpdateAtlasSearchIndexByName", ctx, groupId, clusterName, collectionName, databaseName, indexName, searchIndexUpdateRequest)}
 }
 
@@ -2621,7 +2621,7 @@ type AtlasSearchApi_UpdateAtlasSearchIndexByNameExecute_Call struct {
 
 // UpdateAtlasSearchIndexByNameExecute is a helper method to define mock.On call
 //   - r admin.UpdateAtlasSearchIndexByNameApiRequest
-func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexByNameExecute(r interface{}) *AtlasSearchApi_UpdateAtlasSearchIndexByNameExecute_Call {
+func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexByNameExecute(r any) *AtlasSearchApi_UpdateAtlasSearchIndexByNameExecute_Call {
 	return &AtlasSearchApi_UpdateAtlasSearchIndexByNameExecute_Call{Call: _e.mock.On("UpdateAtlasSearchIndexByNameExecute", r)}
 }
 
@@ -2668,7 +2668,7 @@ type AtlasSearchApi_UpdateAtlasSearchIndexByNameWithParams_Call struct {
 // UpdateAtlasSearchIndexByNameWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateAtlasSearchIndexByNameApiParams
-func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexByNameWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_UpdateAtlasSearchIndexByNameWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexByNameWithParams(ctx any, args any) *AtlasSearchApi_UpdateAtlasSearchIndexByNameWithParams_Call {
 	return &AtlasSearchApi_UpdateAtlasSearchIndexByNameWithParams_Call{Call: _e.mock.On("UpdateAtlasSearchIndexByNameWithParams", ctx, args)}
 }
 
@@ -2718,7 +2718,7 @@ type AtlasSearchApi_UpdateAtlasSearchIndexDeprecated_Call struct {
 //   - clusterName string
 //   - indexId string
 //   - clusterSearchIndex *admin.ClusterSearchIndex
-func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexDeprecated(ctx interface{}, groupId interface{}, clusterName interface{}, indexId interface{}, clusterSearchIndex interface{}) *AtlasSearchApi_UpdateAtlasSearchIndexDeprecated_Call {
+func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexDeprecated(ctx any, groupId any, clusterName any, indexId any, clusterSearchIndex any) *AtlasSearchApi_UpdateAtlasSearchIndexDeprecated_Call {
 	return &AtlasSearchApi_UpdateAtlasSearchIndexDeprecated_Call{Call: _e.mock.On("UpdateAtlasSearchIndexDeprecated", ctx, groupId, clusterName, indexId, clusterSearchIndex)}
 }
 
@@ -2785,7 +2785,7 @@ type AtlasSearchApi_UpdateAtlasSearchIndexDeprecatedExecute_Call struct {
 
 // UpdateAtlasSearchIndexDeprecatedExecute is a helper method to define mock.On call
 //   - r admin.UpdateAtlasSearchIndexDeprecatedApiRequest
-func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexDeprecatedExecute(r interface{}) *AtlasSearchApi_UpdateAtlasSearchIndexDeprecatedExecute_Call {
+func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexDeprecatedExecute(r any) *AtlasSearchApi_UpdateAtlasSearchIndexDeprecatedExecute_Call {
 	return &AtlasSearchApi_UpdateAtlasSearchIndexDeprecatedExecute_Call{Call: _e.mock.On("UpdateAtlasSearchIndexDeprecatedExecute", r)}
 }
 
@@ -2832,7 +2832,7 @@ type AtlasSearchApi_UpdateAtlasSearchIndexDeprecatedWithParams_Call struct {
 // UpdateAtlasSearchIndexDeprecatedWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateAtlasSearchIndexDeprecatedApiParams
-func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexDeprecatedWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_UpdateAtlasSearchIndexDeprecatedWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexDeprecatedWithParams(ctx any, args any) *AtlasSearchApi_UpdateAtlasSearchIndexDeprecatedWithParams_Call {
 	return &AtlasSearchApi_UpdateAtlasSearchIndexDeprecatedWithParams_Call{Call: _e.mock.On("UpdateAtlasSearchIndexDeprecatedWithParams", ctx, args)}
 }
 
@@ -2899,7 +2899,7 @@ type AtlasSearchApi_UpdateAtlasSearchIndexExecute_Call struct {
 
 // UpdateAtlasSearchIndexExecute is a helper method to define mock.On call
 //   - r admin.UpdateAtlasSearchIndexApiRequest
-func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexExecute(r interface{}) *AtlasSearchApi_UpdateAtlasSearchIndexExecute_Call {
+func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexExecute(r any) *AtlasSearchApi_UpdateAtlasSearchIndexExecute_Call {
 	return &AtlasSearchApi_UpdateAtlasSearchIndexExecute_Call{Call: _e.mock.On("UpdateAtlasSearchIndexExecute", r)}
 }
 
@@ -2946,7 +2946,7 @@ type AtlasSearchApi_UpdateAtlasSearchIndexWithParams_Call struct {
 // UpdateAtlasSearchIndexWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateAtlasSearchIndexApiParams
-func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexWithParams(ctx interface{}, args interface{}) *AtlasSearchApi_UpdateAtlasSearchIndexWithParams_Call {
+func (_e *AtlasSearchApi_Expecter) UpdateAtlasSearchIndexWithParams(ctx any, args any) *AtlasSearchApi_UpdateAtlasSearchIndexWithParams_Call {
 	return &AtlasSearchApi_UpdateAtlasSearchIndexWithParams_Call{Call: _e.mock.On("UpdateAtlasSearchIndexWithParams", ctx, args)}
 }
 

--- a/mockadmin/auditing_api.go
+++ b/mockadmin/auditing_api.go
@@ -51,7 +51,7 @@ type AuditingApi_GetAuditingConfiguration_Call struct {
 // GetAuditingConfiguration is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *AuditingApi_Expecter) GetAuditingConfiguration(ctx interface{}, groupId interface{}) *AuditingApi_GetAuditingConfiguration_Call {
+func (_e *AuditingApi_Expecter) GetAuditingConfiguration(ctx any, groupId any) *AuditingApi_GetAuditingConfiguration_Call {
 	return &AuditingApi_GetAuditingConfiguration_Call{Call: _e.mock.On("GetAuditingConfiguration", ctx, groupId)}
 }
 
@@ -118,7 +118,7 @@ type AuditingApi_GetAuditingConfigurationExecute_Call struct {
 
 // GetAuditingConfigurationExecute is a helper method to define mock.On call
 //   - r admin.GetAuditingConfigurationApiRequest
-func (_e *AuditingApi_Expecter) GetAuditingConfigurationExecute(r interface{}) *AuditingApi_GetAuditingConfigurationExecute_Call {
+func (_e *AuditingApi_Expecter) GetAuditingConfigurationExecute(r any) *AuditingApi_GetAuditingConfigurationExecute_Call {
 	return &AuditingApi_GetAuditingConfigurationExecute_Call{Call: _e.mock.On("GetAuditingConfigurationExecute", r)}
 }
 
@@ -165,7 +165,7 @@ type AuditingApi_GetAuditingConfigurationWithParams_Call struct {
 // GetAuditingConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetAuditingConfigurationApiParams
-func (_e *AuditingApi_Expecter) GetAuditingConfigurationWithParams(ctx interface{}, args interface{}) *AuditingApi_GetAuditingConfigurationWithParams_Call {
+func (_e *AuditingApi_Expecter) GetAuditingConfigurationWithParams(ctx any, args any) *AuditingApi_GetAuditingConfigurationWithParams_Call {
 	return &AuditingApi_GetAuditingConfigurationWithParams_Call{Call: _e.mock.On("GetAuditingConfigurationWithParams", ctx, args)}
 }
 
@@ -213,7 +213,7 @@ type AuditingApi_UpdateAuditingConfiguration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - auditLog *admin.AuditLog
-func (_e *AuditingApi_Expecter) UpdateAuditingConfiguration(ctx interface{}, groupId interface{}, auditLog interface{}) *AuditingApi_UpdateAuditingConfiguration_Call {
+func (_e *AuditingApi_Expecter) UpdateAuditingConfiguration(ctx any, groupId any, auditLog any) *AuditingApi_UpdateAuditingConfiguration_Call {
 	return &AuditingApi_UpdateAuditingConfiguration_Call{Call: _e.mock.On("UpdateAuditingConfiguration", ctx, groupId, auditLog)}
 }
 
@@ -280,7 +280,7 @@ type AuditingApi_UpdateAuditingConfigurationExecute_Call struct {
 
 // UpdateAuditingConfigurationExecute is a helper method to define mock.On call
 //   - r admin.UpdateAuditingConfigurationApiRequest
-func (_e *AuditingApi_Expecter) UpdateAuditingConfigurationExecute(r interface{}) *AuditingApi_UpdateAuditingConfigurationExecute_Call {
+func (_e *AuditingApi_Expecter) UpdateAuditingConfigurationExecute(r any) *AuditingApi_UpdateAuditingConfigurationExecute_Call {
 	return &AuditingApi_UpdateAuditingConfigurationExecute_Call{Call: _e.mock.On("UpdateAuditingConfigurationExecute", r)}
 }
 
@@ -327,7 +327,7 @@ type AuditingApi_UpdateAuditingConfigurationWithParams_Call struct {
 // UpdateAuditingConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateAuditingConfigurationApiParams
-func (_e *AuditingApi_Expecter) UpdateAuditingConfigurationWithParams(ctx interface{}, args interface{}) *AuditingApi_UpdateAuditingConfigurationWithParams_Call {
+func (_e *AuditingApi_Expecter) UpdateAuditingConfigurationWithParams(ctx any, args any) *AuditingApi_UpdateAuditingConfigurationWithParams_Call {
 	return &AuditingApi_UpdateAuditingConfigurationWithParams_Call{Call: _e.mock.On("UpdateAuditingConfigurationWithParams", ctx, args)}
 }
 

--- a/mockadmin/aws_clusters_dns_api.go
+++ b/mockadmin/aws_clusters_dns_api.go
@@ -51,7 +51,7 @@ type AWSClustersDNSApi_GetAWSCustomDNS_Call struct {
 // GetAWSCustomDNS is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *AWSClustersDNSApi_Expecter) GetAWSCustomDNS(ctx interface{}, groupId interface{}) *AWSClustersDNSApi_GetAWSCustomDNS_Call {
+func (_e *AWSClustersDNSApi_Expecter) GetAWSCustomDNS(ctx any, groupId any) *AWSClustersDNSApi_GetAWSCustomDNS_Call {
 	return &AWSClustersDNSApi_GetAWSCustomDNS_Call{Call: _e.mock.On("GetAWSCustomDNS", ctx, groupId)}
 }
 
@@ -118,7 +118,7 @@ type AWSClustersDNSApi_GetAWSCustomDNSExecute_Call struct {
 
 // GetAWSCustomDNSExecute is a helper method to define mock.On call
 //   - r admin.GetAWSCustomDNSApiRequest
-func (_e *AWSClustersDNSApi_Expecter) GetAWSCustomDNSExecute(r interface{}) *AWSClustersDNSApi_GetAWSCustomDNSExecute_Call {
+func (_e *AWSClustersDNSApi_Expecter) GetAWSCustomDNSExecute(r any) *AWSClustersDNSApi_GetAWSCustomDNSExecute_Call {
 	return &AWSClustersDNSApi_GetAWSCustomDNSExecute_Call{Call: _e.mock.On("GetAWSCustomDNSExecute", r)}
 }
 
@@ -165,7 +165,7 @@ type AWSClustersDNSApi_GetAWSCustomDNSWithParams_Call struct {
 // GetAWSCustomDNSWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetAWSCustomDNSApiParams
-func (_e *AWSClustersDNSApi_Expecter) GetAWSCustomDNSWithParams(ctx interface{}, args interface{}) *AWSClustersDNSApi_GetAWSCustomDNSWithParams_Call {
+func (_e *AWSClustersDNSApi_Expecter) GetAWSCustomDNSWithParams(ctx any, args any) *AWSClustersDNSApi_GetAWSCustomDNSWithParams_Call {
 	return &AWSClustersDNSApi_GetAWSCustomDNSWithParams_Call{Call: _e.mock.On("GetAWSCustomDNSWithParams", ctx, args)}
 }
 
@@ -213,7 +213,7 @@ type AWSClustersDNSApi_ToggleAWSCustomDNS_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - aWSCustomDNSEnabled *admin.AWSCustomDNSEnabled
-func (_e *AWSClustersDNSApi_Expecter) ToggleAWSCustomDNS(ctx interface{}, groupId interface{}, aWSCustomDNSEnabled interface{}) *AWSClustersDNSApi_ToggleAWSCustomDNS_Call {
+func (_e *AWSClustersDNSApi_Expecter) ToggleAWSCustomDNS(ctx any, groupId any, aWSCustomDNSEnabled any) *AWSClustersDNSApi_ToggleAWSCustomDNS_Call {
 	return &AWSClustersDNSApi_ToggleAWSCustomDNS_Call{Call: _e.mock.On("ToggleAWSCustomDNS", ctx, groupId, aWSCustomDNSEnabled)}
 }
 
@@ -280,7 +280,7 @@ type AWSClustersDNSApi_ToggleAWSCustomDNSExecute_Call struct {
 
 // ToggleAWSCustomDNSExecute is a helper method to define mock.On call
 //   - r admin.ToggleAWSCustomDNSApiRequest
-func (_e *AWSClustersDNSApi_Expecter) ToggleAWSCustomDNSExecute(r interface{}) *AWSClustersDNSApi_ToggleAWSCustomDNSExecute_Call {
+func (_e *AWSClustersDNSApi_Expecter) ToggleAWSCustomDNSExecute(r any) *AWSClustersDNSApi_ToggleAWSCustomDNSExecute_Call {
 	return &AWSClustersDNSApi_ToggleAWSCustomDNSExecute_Call{Call: _e.mock.On("ToggleAWSCustomDNSExecute", r)}
 }
 
@@ -327,7 +327,7 @@ type AWSClustersDNSApi_ToggleAWSCustomDNSWithParams_Call struct {
 // ToggleAWSCustomDNSWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ToggleAWSCustomDNSApiParams
-func (_e *AWSClustersDNSApi_Expecter) ToggleAWSCustomDNSWithParams(ctx interface{}, args interface{}) *AWSClustersDNSApi_ToggleAWSCustomDNSWithParams_Call {
+func (_e *AWSClustersDNSApi_Expecter) ToggleAWSCustomDNSWithParams(ctx any, args any) *AWSClustersDNSApi_ToggleAWSCustomDNSWithParams_Call {
 	return &AWSClustersDNSApi_ToggleAWSCustomDNSWithParams_Call{Call: _e.mock.On("ToggleAWSCustomDNSWithParams", ctx, args)}
 }
 

--- a/mockadmin/cloud_backups_api.go
+++ b/mockadmin/cloud_backups_api.go
@@ -53,7 +53,7 @@ type CloudBackupsApi_CancelBackupRestoreJob_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - restoreJobId string
-func (_e *CloudBackupsApi_Expecter) CancelBackupRestoreJob(ctx interface{}, groupId interface{}, clusterName interface{}, restoreJobId interface{}) *CloudBackupsApi_CancelBackupRestoreJob_Call {
+func (_e *CloudBackupsApi_Expecter) CancelBackupRestoreJob(ctx any, groupId any, clusterName any, restoreJobId any) *CloudBackupsApi_CancelBackupRestoreJob_Call {
 	return &CloudBackupsApi_CancelBackupRestoreJob_Call{Call: _e.mock.On("CancelBackupRestoreJob", ctx, groupId, clusterName, restoreJobId)}
 }
 
@@ -75,24 +75,24 @@ func (_c *CloudBackupsApi_CancelBackupRestoreJob_Call) RunAndReturn(run func(con
 }
 
 // CancelBackupRestoreJobExecute provides a mock function with given fields: r
-func (_m *CloudBackupsApi) CancelBackupRestoreJobExecute(r admin.CancelBackupRestoreJobApiRequest) (interface{}, *http.Response, error) {
+func (_m *CloudBackupsApi) CancelBackupRestoreJobExecute(r admin.CancelBackupRestoreJobApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CancelBackupRestoreJobExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.CancelBackupRestoreJobApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.CancelBackupRestoreJobApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.CancelBackupRestoreJobApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.CancelBackupRestoreJobApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -120,7 +120,7 @@ type CloudBackupsApi_CancelBackupRestoreJobExecute_Call struct {
 
 // CancelBackupRestoreJobExecute is a helper method to define mock.On call
 //   - r admin.CancelBackupRestoreJobApiRequest
-func (_e *CloudBackupsApi_Expecter) CancelBackupRestoreJobExecute(r interface{}) *CloudBackupsApi_CancelBackupRestoreJobExecute_Call {
+func (_e *CloudBackupsApi_Expecter) CancelBackupRestoreJobExecute(r any) *CloudBackupsApi_CancelBackupRestoreJobExecute_Call {
 	return &CloudBackupsApi_CancelBackupRestoreJobExecute_Call{Call: _e.mock.On("CancelBackupRestoreJobExecute", r)}
 }
 
@@ -131,12 +131,12 @@ func (_c *CloudBackupsApi_CancelBackupRestoreJobExecute_Call) Run(run func(r adm
 	return _c
 }
 
-func (_c *CloudBackupsApi_CancelBackupRestoreJobExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *CloudBackupsApi_CancelBackupRestoreJobExecute_Call {
+func (_c *CloudBackupsApi_CancelBackupRestoreJobExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *CloudBackupsApi_CancelBackupRestoreJobExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *CloudBackupsApi_CancelBackupRestoreJobExecute_Call) RunAndReturn(run func(admin.CancelBackupRestoreJobApiRequest) (interface{}, *http.Response, error)) *CloudBackupsApi_CancelBackupRestoreJobExecute_Call {
+func (_c *CloudBackupsApi_CancelBackupRestoreJobExecute_Call) RunAndReturn(run func(admin.CancelBackupRestoreJobApiRequest) (any, *http.Response, error)) *CloudBackupsApi_CancelBackupRestoreJobExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -167,7 +167,7 @@ type CloudBackupsApi_CancelBackupRestoreJobWithParams_Call struct {
 // CancelBackupRestoreJobWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CancelBackupRestoreJobApiParams
-func (_e *CloudBackupsApi_Expecter) CancelBackupRestoreJobWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_CancelBackupRestoreJobWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) CancelBackupRestoreJobWithParams(ctx any, args any) *CloudBackupsApi_CancelBackupRestoreJobWithParams_Call {
 	return &CloudBackupsApi_CancelBackupRestoreJobWithParams_Call{Call: _e.mock.On("CancelBackupRestoreJobWithParams", ctx, args)}
 }
 
@@ -216,7 +216,7 @@ type CloudBackupsApi_CreateBackupExportJob_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - diskBackupExportJobRequest *admin.DiskBackupExportJobRequest
-func (_e *CloudBackupsApi_Expecter) CreateBackupExportJob(ctx interface{}, groupId interface{}, clusterName interface{}, diskBackupExportJobRequest interface{}) *CloudBackupsApi_CreateBackupExportJob_Call {
+func (_e *CloudBackupsApi_Expecter) CreateBackupExportJob(ctx any, groupId any, clusterName any, diskBackupExportJobRequest any) *CloudBackupsApi_CreateBackupExportJob_Call {
 	return &CloudBackupsApi_CreateBackupExportJob_Call{Call: _e.mock.On("CreateBackupExportJob", ctx, groupId, clusterName, diskBackupExportJobRequest)}
 }
 
@@ -283,7 +283,7 @@ type CloudBackupsApi_CreateBackupExportJobExecute_Call struct {
 
 // CreateBackupExportJobExecute is a helper method to define mock.On call
 //   - r admin.CreateBackupExportJobApiRequest
-func (_e *CloudBackupsApi_Expecter) CreateBackupExportJobExecute(r interface{}) *CloudBackupsApi_CreateBackupExportJobExecute_Call {
+func (_e *CloudBackupsApi_Expecter) CreateBackupExportJobExecute(r any) *CloudBackupsApi_CreateBackupExportJobExecute_Call {
 	return &CloudBackupsApi_CreateBackupExportJobExecute_Call{Call: _e.mock.On("CreateBackupExportJobExecute", r)}
 }
 
@@ -330,7 +330,7 @@ type CloudBackupsApi_CreateBackupExportJobWithParams_Call struct {
 // CreateBackupExportJobWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateBackupExportJobApiParams
-func (_e *CloudBackupsApi_Expecter) CreateBackupExportJobWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_CreateBackupExportJobWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) CreateBackupExportJobWithParams(ctx any, args any) *CloudBackupsApi_CreateBackupExportJobWithParams_Call {
 	return &CloudBackupsApi_CreateBackupExportJobWithParams_Call{Call: _e.mock.On("CreateBackupExportJobWithParams", ctx, args)}
 }
 
@@ -379,7 +379,7 @@ type CloudBackupsApi_CreateBackupRestoreJob_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - diskBackupSnapshotRestoreJob *admin.DiskBackupSnapshotRestoreJob
-func (_e *CloudBackupsApi_Expecter) CreateBackupRestoreJob(ctx interface{}, groupId interface{}, clusterName interface{}, diskBackupSnapshotRestoreJob interface{}) *CloudBackupsApi_CreateBackupRestoreJob_Call {
+func (_e *CloudBackupsApi_Expecter) CreateBackupRestoreJob(ctx any, groupId any, clusterName any, diskBackupSnapshotRestoreJob any) *CloudBackupsApi_CreateBackupRestoreJob_Call {
 	return &CloudBackupsApi_CreateBackupRestoreJob_Call{Call: _e.mock.On("CreateBackupRestoreJob", ctx, groupId, clusterName, diskBackupSnapshotRestoreJob)}
 }
 
@@ -446,7 +446,7 @@ type CloudBackupsApi_CreateBackupRestoreJobExecute_Call struct {
 
 // CreateBackupRestoreJobExecute is a helper method to define mock.On call
 //   - r admin.CreateBackupRestoreJobApiRequest
-func (_e *CloudBackupsApi_Expecter) CreateBackupRestoreJobExecute(r interface{}) *CloudBackupsApi_CreateBackupRestoreJobExecute_Call {
+func (_e *CloudBackupsApi_Expecter) CreateBackupRestoreJobExecute(r any) *CloudBackupsApi_CreateBackupRestoreJobExecute_Call {
 	return &CloudBackupsApi_CreateBackupRestoreJobExecute_Call{Call: _e.mock.On("CreateBackupRestoreJobExecute", r)}
 }
 
@@ -493,7 +493,7 @@ type CloudBackupsApi_CreateBackupRestoreJobWithParams_Call struct {
 // CreateBackupRestoreJobWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateBackupRestoreJobApiParams
-func (_e *CloudBackupsApi_Expecter) CreateBackupRestoreJobWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_CreateBackupRestoreJobWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) CreateBackupRestoreJobWithParams(ctx any, args any) *CloudBackupsApi_CreateBackupRestoreJobWithParams_Call {
 	return &CloudBackupsApi_CreateBackupRestoreJobWithParams_Call{Call: _e.mock.On("CreateBackupRestoreJobWithParams", ctx, args)}
 }
 
@@ -541,7 +541,7 @@ type CloudBackupsApi_CreateExportBucket_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - diskBackupSnapshotExportBucket *admin.DiskBackupSnapshotExportBucket
-func (_e *CloudBackupsApi_Expecter) CreateExportBucket(ctx interface{}, groupId interface{}, diskBackupSnapshotExportBucket interface{}) *CloudBackupsApi_CreateExportBucket_Call {
+func (_e *CloudBackupsApi_Expecter) CreateExportBucket(ctx any, groupId any, diskBackupSnapshotExportBucket any) *CloudBackupsApi_CreateExportBucket_Call {
 	return &CloudBackupsApi_CreateExportBucket_Call{Call: _e.mock.On("CreateExportBucket", ctx, groupId, diskBackupSnapshotExportBucket)}
 }
 
@@ -608,7 +608,7 @@ type CloudBackupsApi_CreateExportBucketExecute_Call struct {
 
 // CreateExportBucketExecute is a helper method to define mock.On call
 //   - r admin.CreateExportBucketApiRequest
-func (_e *CloudBackupsApi_Expecter) CreateExportBucketExecute(r interface{}) *CloudBackupsApi_CreateExportBucketExecute_Call {
+func (_e *CloudBackupsApi_Expecter) CreateExportBucketExecute(r any) *CloudBackupsApi_CreateExportBucketExecute_Call {
 	return &CloudBackupsApi_CreateExportBucketExecute_Call{Call: _e.mock.On("CreateExportBucketExecute", r)}
 }
 
@@ -655,7 +655,7 @@ type CloudBackupsApi_CreateExportBucketWithParams_Call struct {
 // CreateExportBucketWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateExportBucketApiParams
-func (_e *CloudBackupsApi_Expecter) CreateExportBucketWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_CreateExportBucketWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) CreateExportBucketWithParams(ctx any, args any) *CloudBackupsApi_CreateExportBucketWithParams_Call {
 	return &CloudBackupsApi_CreateExportBucketWithParams_Call{Call: _e.mock.On("CreateExportBucketWithParams", ctx, args)}
 }
 
@@ -704,7 +704,7 @@ type CloudBackupsApi_CreateServerlessBackupRestoreJob_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - serverlessBackupRestoreJob *admin.ServerlessBackupRestoreJob
-func (_e *CloudBackupsApi_Expecter) CreateServerlessBackupRestoreJob(ctx interface{}, groupId interface{}, clusterName interface{}, serverlessBackupRestoreJob interface{}) *CloudBackupsApi_CreateServerlessBackupRestoreJob_Call {
+func (_e *CloudBackupsApi_Expecter) CreateServerlessBackupRestoreJob(ctx any, groupId any, clusterName any, serverlessBackupRestoreJob any) *CloudBackupsApi_CreateServerlessBackupRestoreJob_Call {
 	return &CloudBackupsApi_CreateServerlessBackupRestoreJob_Call{Call: _e.mock.On("CreateServerlessBackupRestoreJob", ctx, groupId, clusterName, serverlessBackupRestoreJob)}
 }
 
@@ -771,7 +771,7 @@ type CloudBackupsApi_CreateServerlessBackupRestoreJobExecute_Call struct {
 
 // CreateServerlessBackupRestoreJobExecute is a helper method to define mock.On call
 //   - r admin.CreateServerlessBackupRestoreJobApiRequest
-func (_e *CloudBackupsApi_Expecter) CreateServerlessBackupRestoreJobExecute(r interface{}) *CloudBackupsApi_CreateServerlessBackupRestoreJobExecute_Call {
+func (_e *CloudBackupsApi_Expecter) CreateServerlessBackupRestoreJobExecute(r any) *CloudBackupsApi_CreateServerlessBackupRestoreJobExecute_Call {
 	return &CloudBackupsApi_CreateServerlessBackupRestoreJobExecute_Call{Call: _e.mock.On("CreateServerlessBackupRestoreJobExecute", r)}
 }
 
@@ -818,7 +818,7 @@ type CloudBackupsApi_CreateServerlessBackupRestoreJobWithParams_Call struct {
 // CreateServerlessBackupRestoreJobWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateServerlessBackupRestoreJobApiParams
-func (_e *CloudBackupsApi_Expecter) CreateServerlessBackupRestoreJobWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_CreateServerlessBackupRestoreJobWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) CreateServerlessBackupRestoreJobWithParams(ctx any, args any) *CloudBackupsApi_CreateServerlessBackupRestoreJobWithParams_Call {
 	return &CloudBackupsApi_CreateServerlessBackupRestoreJobWithParams_Call{Call: _e.mock.On("CreateServerlessBackupRestoreJobWithParams", ctx, args)}
 }
 
@@ -866,7 +866,7 @@ type CloudBackupsApi_DeleteAllBackupSchedules_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *CloudBackupsApi_Expecter) DeleteAllBackupSchedules(ctx interface{}, groupId interface{}, clusterName interface{}) *CloudBackupsApi_DeleteAllBackupSchedules_Call {
+func (_e *CloudBackupsApi_Expecter) DeleteAllBackupSchedules(ctx any, groupId any, clusterName any) *CloudBackupsApi_DeleteAllBackupSchedules_Call {
 	return &CloudBackupsApi_DeleteAllBackupSchedules_Call{Call: _e.mock.On("DeleteAllBackupSchedules", ctx, groupId, clusterName)}
 }
 
@@ -933,7 +933,7 @@ type CloudBackupsApi_DeleteAllBackupSchedulesExecute_Call struct {
 
 // DeleteAllBackupSchedulesExecute is a helper method to define mock.On call
 //   - r admin.DeleteAllBackupSchedulesApiRequest
-func (_e *CloudBackupsApi_Expecter) DeleteAllBackupSchedulesExecute(r interface{}) *CloudBackupsApi_DeleteAllBackupSchedulesExecute_Call {
+func (_e *CloudBackupsApi_Expecter) DeleteAllBackupSchedulesExecute(r any) *CloudBackupsApi_DeleteAllBackupSchedulesExecute_Call {
 	return &CloudBackupsApi_DeleteAllBackupSchedulesExecute_Call{Call: _e.mock.On("DeleteAllBackupSchedulesExecute", r)}
 }
 
@@ -980,7 +980,7 @@ type CloudBackupsApi_DeleteAllBackupSchedulesWithParams_Call struct {
 // DeleteAllBackupSchedulesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteAllBackupSchedulesApiParams
-func (_e *CloudBackupsApi_Expecter) DeleteAllBackupSchedulesWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_DeleteAllBackupSchedulesWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) DeleteAllBackupSchedulesWithParams(ctx any, args any) *CloudBackupsApi_DeleteAllBackupSchedulesWithParams_Call {
 	return &CloudBackupsApi_DeleteAllBackupSchedulesWithParams_Call{Call: _e.mock.On("DeleteAllBackupSchedulesWithParams", ctx, args)}
 }
 
@@ -1028,7 +1028,7 @@ type CloudBackupsApi_DeleteExportBucket_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - exportBucketId string
-func (_e *CloudBackupsApi_Expecter) DeleteExportBucket(ctx interface{}, groupId interface{}, exportBucketId interface{}) *CloudBackupsApi_DeleteExportBucket_Call {
+func (_e *CloudBackupsApi_Expecter) DeleteExportBucket(ctx any, groupId any, exportBucketId any) *CloudBackupsApi_DeleteExportBucket_Call {
 	return &CloudBackupsApi_DeleteExportBucket_Call{Call: _e.mock.On("DeleteExportBucket", ctx, groupId, exportBucketId)}
 }
 
@@ -1050,24 +1050,24 @@ func (_c *CloudBackupsApi_DeleteExportBucket_Call) RunAndReturn(run func(context
 }
 
 // DeleteExportBucketExecute provides a mock function with given fields: r
-func (_m *CloudBackupsApi) DeleteExportBucketExecute(r admin.DeleteExportBucketApiRequest) (interface{}, *http.Response, error) {
+func (_m *CloudBackupsApi) DeleteExportBucketExecute(r admin.DeleteExportBucketApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteExportBucketExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteExportBucketApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteExportBucketApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteExportBucketApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteExportBucketApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -1095,7 +1095,7 @@ type CloudBackupsApi_DeleteExportBucketExecute_Call struct {
 
 // DeleteExportBucketExecute is a helper method to define mock.On call
 //   - r admin.DeleteExportBucketApiRequest
-func (_e *CloudBackupsApi_Expecter) DeleteExportBucketExecute(r interface{}) *CloudBackupsApi_DeleteExportBucketExecute_Call {
+func (_e *CloudBackupsApi_Expecter) DeleteExportBucketExecute(r any) *CloudBackupsApi_DeleteExportBucketExecute_Call {
 	return &CloudBackupsApi_DeleteExportBucketExecute_Call{Call: _e.mock.On("DeleteExportBucketExecute", r)}
 }
 
@@ -1106,12 +1106,12 @@ func (_c *CloudBackupsApi_DeleteExportBucketExecute_Call) Run(run func(r admin.D
 	return _c
 }
 
-func (_c *CloudBackupsApi_DeleteExportBucketExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *CloudBackupsApi_DeleteExportBucketExecute_Call {
+func (_c *CloudBackupsApi_DeleteExportBucketExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *CloudBackupsApi_DeleteExportBucketExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *CloudBackupsApi_DeleteExportBucketExecute_Call) RunAndReturn(run func(admin.DeleteExportBucketApiRequest) (interface{}, *http.Response, error)) *CloudBackupsApi_DeleteExportBucketExecute_Call {
+func (_c *CloudBackupsApi_DeleteExportBucketExecute_Call) RunAndReturn(run func(admin.DeleteExportBucketApiRequest) (any, *http.Response, error)) *CloudBackupsApi_DeleteExportBucketExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1142,7 +1142,7 @@ type CloudBackupsApi_DeleteExportBucketWithParams_Call struct {
 // DeleteExportBucketWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteExportBucketApiParams
-func (_e *CloudBackupsApi_Expecter) DeleteExportBucketWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_DeleteExportBucketWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) DeleteExportBucketWithParams(ctx any, args any) *CloudBackupsApi_DeleteExportBucketWithParams_Call {
 	return &CloudBackupsApi_DeleteExportBucketWithParams_Call{Call: _e.mock.On("DeleteExportBucketWithParams", ctx, args)}
 }
 
@@ -1191,7 +1191,7 @@ type CloudBackupsApi_DeleteReplicaSetBackup_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - snapshotId string
-func (_e *CloudBackupsApi_Expecter) DeleteReplicaSetBackup(ctx interface{}, groupId interface{}, clusterName interface{}, snapshotId interface{}) *CloudBackupsApi_DeleteReplicaSetBackup_Call {
+func (_e *CloudBackupsApi_Expecter) DeleteReplicaSetBackup(ctx any, groupId any, clusterName any, snapshotId any) *CloudBackupsApi_DeleteReplicaSetBackup_Call {
 	return &CloudBackupsApi_DeleteReplicaSetBackup_Call{Call: _e.mock.On("DeleteReplicaSetBackup", ctx, groupId, clusterName, snapshotId)}
 }
 
@@ -1213,24 +1213,24 @@ func (_c *CloudBackupsApi_DeleteReplicaSetBackup_Call) RunAndReturn(run func(con
 }
 
 // DeleteReplicaSetBackupExecute provides a mock function with given fields: r
-func (_m *CloudBackupsApi) DeleteReplicaSetBackupExecute(r admin.DeleteReplicaSetBackupApiRequest) (interface{}, *http.Response, error) {
+func (_m *CloudBackupsApi) DeleteReplicaSetBackupExecute(r admin.DeleteReplicaSetBackupApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteReplicaSetBackupExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteReplicaSetBackupApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteReplicaSetBackupApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteReplicaSetBackupApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteReplicaSetBackupApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -1258,7 +1258,7 @@ type CloudBackupsApi_DeleteReplicaSetBackupExecute_Call struct {
 
 // DeleteReplicaSetBackupExecute is a helper method to define mock.On call
 //   - r admin.DeleteReplicaSetBackupApiRequest
-func (_e *CloudBackupsApi_Expecter) DeleteReplicaSetBackupExecute(r interface{}) *CloudBackupsApi_DeleteReplicaSetBackupExecute_Call {
+func (_e *CloudBackupsApi_Expecter) DeleteReplicaSetBackupExecute(r any) *CloudBackupsApi_DeleteReplicaSetBackupExecute_Call {
 	return &CloudBackupsApi_DeleteReplicaSetBackupExecute_Call{Call: _e.mock.On("DeleteReplicaSetBackupExecute", r)}
 }
 
@@ -1269,12 +1269,12 @@ func (_c *CloudBackupsApi_DeleteReplicaSetBackupExecute_Call) Run(run func(r adm
 	return _c
 }
 
-func (_c *CloudBackupsApi_DeleteReplicaSetBackupExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *CloudBackupsApi_DeleteReplicaSetBackupExecute_Call {
+func (_c *CloudBackupsApi_DeleteReplicaSetBackupExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *CloudBackupsApi_DeleteReplicaSetBackupExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *CloudBackupsApi_DeleteReplicaSetBackupExecute_Call) RunAndReturn(run func(admin.DeleteReplicaSetBackupApiRequest) (interface{}, *http.Response, error)) *CloudBackupsApi_DeleteReplicaSetBackupExecute_Call {
+func (_c *CloudBackupsApi_DeleteReplicaSetBackupExecute_Call) RunAndReturn(run func(admin.DeleteReplicaSetBackupApiRequest) (any, *http.Response, error)) *CloudBackupsApi_DeleteReplicaSetBackupExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1305,7 +1305,7 @@ type CloudBackupsApi_DeleteReplicaSetBackupWithParams_Call struct {
 // DeleteReplicaSetBackupWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteReplicaSetBackupApiParams
-func (_e *CloudBackupsApi_Expecter) DeleteReplicaSetBackupWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_DeleteReplicaSetBackupWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) DeleteReplicaSetBackupWithParams(ctx any, args any) *CloudBackupsApi_DeleteReplicaSetBackupWithParams_Call {
 	return &CloudBackupsApi_DeleteReplicaSetBackupWithParams_Call{Call: _e.mock.On("DeleteReplicaSetBackupWithParams", ctx, args)}
 }
 
@@ -1354,7 +1354,7 @@ type CloudBackupsApi_DeleteShardedClusterBackup_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - snapshotId string
-func (_e *CloudBackupsApi_Expecter) DeleteShardedClusterBackup(ctx interface{}, groupId interface{}, clusterName interface{}, snapshotId interface{}) *CloudBackupsApi_DeleteShardedClusterBackup_Call {
+func (_e *CloudBackupsApi_Expecter) DeleteShardedClusterBackup(ctx any, groupId any, clusterName any, snapshotId any) *CloudBackupsApi_DeleteShardedClusterBackup_Call {
 	return &CloudBackupsApi_DeleteShardedClusterBackup_Call{Call: _e.mock.On("DeleteShardedClusterBackup", ctx, groupId, clusterName, snapshotId)}
 }
 
@@ -1376,24 +1376,24 @@ func (_c *CloudBackupsApi_DeleteShardedClusterBackup_Call) RunAndReturn(run func
 }
 
 // DeleteShardedClusterBackupExecute provides a mock function with given fields: r
-func (_m *CloudBackupsApi) DeleteShardedClusterBackupExecute(r admin.DeleteShardedClusterBackupApiRequest) (interface{}, *http.Response, error) {
+func (_m *CloudBackupsApi) DeleteShardedClusterBackupExecute(r admin.DeleteShardedClusterBackupApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteShardedClusterBackupExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteShardedClusterBackupApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteShardedClusterBackupApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteShardedClusterBackupApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteShardedClusterBackupApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -1421,7 +1421,7 @@ type CloudBackupsApi_DeleteShardedClusterBackupExecute_Call struct {
 
 // DeleteShardedClusterBackupExecute is a helper method to define mock.On call
 //   - r admin.DeleteShardedClusterBackupApiRequest
-func (_e *CloudBackupsApi_Expecter) DeleteShardedClusterBackupExecute(r interface{}) *CloudBackupsApi_DeleteShardedClusterBackupExecute_Call {
+func (_e *CloudBackupsApi_Expecter) DeleteShardedClusterBackupExecute(r any) *CloudBackupsApi_DeleteShardedClusterBackupExecute_Call {
 	return &CloudBackupsApi_DeleteShardedClusterBackupExecute_Call{Call: _e.mock.On("DeleteShardedClusterBackupExecute", r)}
 }
 
@@ -1432,12 +1432,12 @@ func (_c *CloudBackupsApi_DeleteShardedClusterBackupExecute_Call) Run(run func(r
 	return _c
 }
 
-func (_c *CloudBackupsApi_DeleteShardedClusterBackupExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *CloudBackupsApi_DeleteShardedClusterBackupExecute_Call {
+func (_c *CloudBackupsApi_DeleteShardedClusterBackupExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *CloudBackupsApi_DeleteShardedClusterBackupExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *CloudBackupsApi_DeleteShardedClusterBackupExecute_Call) RunAndReturn(run func(admin.DeleteShardedClusterBackupApiRequest) (interface{}, *http.Response, error)) *CloudBackupsApi_DeleteShardedClusterBackupExecute_Call {
+func (_c *CloudBackupsApi_DeleteShardedClusterBackupExecute_Call) RunAndReturn(run func(admin.DeleteShardedClusterBackupApiRequest) (any, *http.Response, error)) *CloudBackupsApi_DeleteShardedClusterBackupExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1468,7 +1468,7 @@ type CloudBackupsApi_DeleteShardedClusterBackupWithParams_Call struct {
 // DeleteShardedClusterBackupWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteShardedClusterBackupApiParams
-func (_e *CloudBackupsApi_Expecter) DeleteShardedClusterBackupWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_DeleteShardedClusterBackupWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) DeleteShardedClusterBackupWithParams(ctx any, args any) *CloudBackupsApi_DeleteShardedClusterBackupWithParams_Call {
 	return &CloudBackupsApi_DeleteShardedClusterBackupWithParams_Call{Call: _e.mock.On("DeleteShardedClusterBackupWithParams", ctx, args)}
 }
 
@@ -1517,7 +1517,7 @@ type CloudBackupsApi_GetBackupExportJob_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - exportId string
-func (_e *CloudBackupsApi_Expecter) GetBackupExportJob(ctx interface{}, groupId interface{}, clusterName interface{}, exportId interface{}) *CloudBackupsApi_GetBackupExportJob_Call {
+func (_e *CloudBackupsApi_Expecter) GetBackupExportJob(ctx any, groupId any, clusterName any, exportId any) *CloudBackupsApi_GetBackupExportJob_Call {
 	return &CloudBackupsApi_GetBackupExportJob_Call{Call: _e.mock.On("GetBackupExportJob", ctx, groupId, clusterName, exportId)}
 }
 
@@ -1584,7 +1584,7 @@ type CloudBackupsApi_GetBackupExportJobExecute_Call struct {
 
 // GetBackupExportJobExecute is a helper method to define mock.On call
 //   - r admin.GetBackupExportJobApiRequest
-func (_e *CloudBackupsApi_Expecter) GetBackupExportJobExecute(r interface{}) *CloudBackupsApi_GetBackupExportJobExecute_Call {
+func (_e *CloudBackupsApi_Expecter) GetBackupExportJobExecute(r any) *CloudBackupsApi_GetBackupExportJobExecute_Call {
 	return &CloudBackupsApi_GetBackupExportJobExecute_Call{Call: _e.mock.On("GetBackupExportJobExecute", r)}
 }
 
@@ -1631,7 +1631,7 @@ type CloudBackupsApi_GetBackupExportJobWithParams_Call struct {
 // GetBackupExportJobWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetBackupExportJobApiParams
-func (_e *CloudBackupsApi_Expecter) GetBackupExportJobWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_GetBackupExportJobWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) GetBackupExportJobWithParams(ctx any, args any) *CloudBackupsApi_GetBackupExportJobWithParams_Call {
 	return &CloudBackupsApi_GetBackupExportJobWithParams_Call{Call: _e.mock.On("GetBackupExportJobWithParams", ctx, args)}
 }
 
@@ -1680,7 +1680,7 @@ type CloudBackupsApi_GetBackupRestoreJob_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - restoreJobId string
-func (_e *CloudBackupsApi_Expecter) GetBackupRestoreJob(ctx interface{}, groupId interface{}, clusterName interface{}, restoreJobId interface{}) *CloudBackupsApi_GetBackupRestoreJob_Call {
+func (_e *CloudBackupsApi_Expecter) GetBackupRestoreJob(ctx any, groupId any, clusterName any, restoreJobId any) *CloudBackupsApi_GetBackupRestoreJob_Call {
 	return &CloudBackupsApi_GetBackupRestoreJob_Call{Call: _e.mock.On("GetBackupRestoreJob", ctx, groupId, clusterName, restoreJobId)}
 }
 
@@ -1747,7 +1747,7 @@ type CloudBackupsApi_GetBackupRestoreJobExecute_Call struct {
 
 // GetBackupRestoreJobExecute is a helper method to define mock.On call
 //   - r admin.GetBackupRestoreJobApiRequest
-func (_e *CloudBackupsApi_Expecter) GetBackupRestoreJobExecute(r interface{}) *CloudBackupsApi_GetBackupRestoreJobExecute_Call {
+func (_e *CloudBackupsApi_Expecter) GetBackupRestoreJobExecute(r any) *CloudBackupsApi_GetBackupRestoreJobExecute_Call {
 	return &CloudBackupsApi_GetBackupRestoreJobExecute_Call{Call: _e.mock.On("GetBackupRestoreJobExecute", r)}
 }
 
@@ -1794,7 +1794,7 @@ type CloudBackupsApi_GetBackupRestoreJobWithParams_Call struct {
 // GetBackupRestoreJobWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetBackupRestoreJobApiParams
-func (_e *CloudBackupsApi_Expecter) GetBackupRestoreJobWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_GetBackupRestoreJobWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) GetBackupRestoreJobWithParams(ctx any, args any) *CloudBackupsApi_GetBackupRestoreJobWithParams_Call {
 	return &CloudBackupsApi_GetBackupRestoreJobWithParams_Call{Call: _e.mock.On("GetBackupRestoreJobWithParams", ctx, args)}
 }
 
@@ -1842,7 +1842,7 @@ type CloudBackupsApi_GetBackupSchedule_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *CloudBackupsApi_Expecter) GetBackupSchedule(ctx interface{}, groupId interface{}, clusterName interface{}) *CloudBackupsApi_GetBackupSchedule_Call {
+func (_e *CloudBackupsApi_Expecter) GetBackupSchedule(ctx any, groupId any, clusterName any) *CloudBackupsApi_GetBackupSchedule_Call {
 	return &CloudBackupsApi_GetBackupSchedule_Call{Call: _e.mock.On("GetBackupSchedule", ctx, groupId, clusterName)}
 }
 
@@ -1909,7 +1909,7 @@ type CloudBackupsApi_GetBackupScheduleExecute_Call struct {
 
 // GetBackupScheduleExecute is a helper method to define mock.On call
 //   - r admin.GetBackupScheduleApiRequest
-func (_e *CloudBackupsApi_Expecter) GetBackupScheduleExecute(r interface{}) *CloudBackupsApi_GetBackupScheduleExecute_Call {
+func (_e *CloudBackupsApi_Expecter) GetBackupScheduleExecute(r any) *CloudBackupsApi_GetBackupScheduleExecute_Call {
 	return &CloudBackupsApi_GetBackupScheduleExecute_Call{Call: _e.mock.On("GetBackupScheduleExecute", r)}
 }
 
@@ -1956,7 +1956,7 @@ type CloudBackupsApi_GetBackupScheduleWithParams_Call struct {
 // GetBackupScheduleWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetBackupScheduleApiParams
-func (_e *CloudBackupsApi_Expecter) GetBackupScheduleWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_GetBackupScheduleWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) GetBackupScheduleWithParams(ctx any, args any) *CloudBackupsApi_GetBackupScheduleWithParams_Call {
 	return &CloudBackupsApi_GetBackupScheduleWithParams_Call{Call: _e.mock.On("GetBackupScheduleWithParams", ctx, args)}
 }
 
@@ -2003,7 +2003,7 @@ type CloudBackupsApi_GetDataProtectionSettings_Call struct {
 // GetDataProtectionSettings is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *CloudBackupsApi_Expecter) GetDataProtectionSettings(ctx interface{}, groupId interface{}) *CloudBackupsApi_GetDataProtectionSettings_Call {
+func (_e *CloudBackupsApi_Expecter) GetDataProtectionSettings(ctx any, groupId any) *CloudBackupsApi_GetDataProtectionSettings_Call {
 	return &CloudBackupsApi_GetDataProtectionSettings_Call{Call: _e.mock.On("GetDataProtectionSettings", ctx, groupId)}
 }
 
@@ -2070,7 +2070,7 @@ type CloudBackupsApi_GetDataProtectionSettingsExecute_Call struct {
 
 // GetDataProtectionSettingsExecute is a helper method to define mock.On call
 //   - r admin.GetDataProtectionSettingsApiRequest
-func (_e *CloudBackupsApi_Expecter) GetDataProtectionSettingsExecute(r interface{}) *CloudBackupsApi_GetDataProtectionSettingsExecute_Call {
+func (_e *CloudBackupsApi_Expecter) GetDataProtectionSettingsExecute(r any) *CloudBackupsApi_GetDataProtectionSettingsExecute_Call {
 	return &CloudBackupsApi_GetDataProtectionSettingsExecute_Call{Call: _e.mock.On("GetDataProtectionSettingsExecute", r)}
 }
 
@@ -2117,7 +2117,7 @@ type CloudBackupsApi_GetDataProtectionSettingsWithParams_Call struct {
 // GetDataProtectionSettingsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetDataProtectionSettingsApiParams
-func (_e *CloudBackupsApi_Expecter) GetDataProtectionSettingsWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_GetDataProtectionSettingsWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) GetDataProtectionSettingsWithParams(ctx any, args any) *CloudBackupsApi_GetDataProtectionSettingsWithParams_Call {
 	return &CloudBackupsApi_GetDataProtectionSettingsWithParams_Call{Call: _e.mock.On("GetDataProtectionSettingsWithParams", ctx, args)}
 }
 
@@ -2165,7 +2165,7 @@ type CloudBackupsApi_GetExportBucket_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - exportBucketId string
-func (_e *CloudBackupsApi_Expecter) GetExportBucket(ctx interface{}, groupId interface{}, exportBucketId interface{}) *CloudBackupsApi_GetExportBucket_Call {
+func (_e *CloudBackupsApi_Expecter) GetExportBucket(ctx any, groupId any, exportBucketId any) *CloudBackupsApi_GetExportBucket_Call {
 	return &CloudBackupsApi_GetExportBucket_Call{Call: _e.mock.On("GetExportBucket", ctx, groupId, exportBucketId)}
 }
 
@@ -2232,7 +2232,7 @@ type CloudBackupsApi_GetExportBucketExecute_Call struct {
 
 // GetExportBucketExecute is a helper method to define mock.On call
 //   - r admin.GetExportBucketApiRequest
-func (_e *CloudBackupsApi_Expecter) GetExportBucketExecute(r interface{}) *CloudBackupsApi_GetExportBucketExecute_Call {
+func (_e *CloudBackupsApi_Expecter) GetExportBucketExecute(r any) *CloudBackupsApi_GetExportBucketExecute_Call {
 	return &CloudBackupsApi_GetExportBucketExecute_Call{Call: _e.mock.On("GetExportBucketExecute", r)}
 }
 
@@ -2279,7 +2279,7 @@ type CloudBackupsApi_GetExportBucketWithParams_Call struct {
 // GetExportBucketWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetExportBucketApiParams
-func (_e *CloudBackupsApi_Expecter) GetExportBucketWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_GetExportBucketWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) GetExportBucketWithParams(ctx any, args any) *CloudBackupsApi_GetExportBucketWithParams_Call {
 	return &CloudBackupsApi_GetExportBucketWithParams_Call{Call: _e.mock.On("GetExportBucketWithParams", ctx, args)}
 }
 
@@ -2328,7 +2328,7 @@ type CloudBackupsApi_GetReplicaSetBackup_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - snapshotId string
-func (_e *CloudBackupsApi_Expecter) GetReplicaSetBackup(ctx interface{}, groupId interface{}, clusterName interface{}, snapshotId interface{}) *CloudBackupsApi_GetReplicaSetBackup_Call {
+func (_e *CloudBackupsApi_Expecter) GetReplicaSetBackup(ctx any, groupId any, clusterName any, snapshotId any) *CloudBackupsApi_GetReplicaSetBackup_Call {
 	return &CloudBackupsApi_GetReplicaSetBackup_Call{Call: _e.mock.On("GetReplicaSetBackup", ctx, groupId, clusterName, snapshotId)}
 }
 
@@ -2395,7 +2395,7 @@ type CloudBackupsApi_GetReplicaSetBackupExecute_Call struct {
 
 // GetReplicaSetBackupExecute is a helper method to define mock.On call
 //   - r admin.GetReplicaSetBackupApiRequest
-func (_e *CloudBackupsApi_Expecter) GetReplicaSetBackupExecute(r interface{}) *CloudBackupsApi_GetReplicaSetBackupExecute_Call {
+func (_e *CloudBackupsApi_Expecter) GetReplicaSetBackupExecute(r any) *CloudBackupsApi_GetReplicaSetBackupExecute_Call {
 	return &CloudBackupsApi_GetReplicaSetBackupExecute_Call{Call: _e.mock.On("GetReplicaSetBackupExecute", r)}
 }
 
@@ -2442,7 +2442,7 @@ type CloudBackupsApi_GetReplicaSetBackupWithParams_Call struct {
 // GetReplicaSetBackupWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetReplicaSetBackupApiParams
-func (_e *CloudBackupsApi_Expecter) GetReplicaSetBackupWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_GetReplicaSetBackupWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) GetReplicaSetBackupWithParams(ctx any, args any) *CloudBackupsApi_GetReplicaSetBackupWithParams_Call {
 	return &CloudBackupsApi_GetReplicaSetBackupWithParams_Call{Call: _e.mock.On("GetReplicaSetBackupWithParams", ctx, args)}
 }
 
@@ -2491,7 +2491,7 @@ type CloudBackupsApi_GetServerlessBackup_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - snapshotId string
-func (_e *CloudBackupsApi_Expecter) GetServerlessBackup(ctx interface{}, groupId interface{}, clusterName interface{}, snapshotId interface{}) *CloudBackupsApi_GetServerlessBackup_Call {
+func (_e *CloudBackupsApi_Expecter) GetServerlessBackup(ctx any, groupId any, clusterName any, snapshotId any) *CloudBackupsApi_GetServerlessBackup_Call {
 	return &CloudBackupsApi_GetServerlessBackup_Call{Call: _e.mock.On("GetServerlessBackup", ctx, groupId, clusterName, snapshotId)}
 }
 
@@ -2558,7 +2558,7 @@ type CloudBackupsApi_GetServerlessBackupExecute_Call struct {
 
 // GetServerlessBackupExecute is a helper method to define mock.On call
 //   - r admin.GetServerlessBackupApiRequest
-func (_e *CloudBackupsApi_Expecter) GetServerlessBackupExecute(r interface{}) *CloudBackupsApi_GetServerlessBackupExecute_Call {
+func (_e *CloudBackupsApi_Expecter) GetServerlessBackupExecute(r any) *CloudBackupsApi_GetServerlessBackupExecute_Call {
 	return &CloudBackupsApi_GetServerlessBackupExecute_Call{Call: _e.mock.On("GetServerlessBackupExecute", r)}
 }
 
@@ -2607,7 +2607,7 @@ type CloudBackupsApi_GetServerlessBackupRestoreJob_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - restoreJobId string
-func (_e *CloudBackupsApi_Expecter) GetServerlessBackupRestoreJob(ctx interface{}, groupId interface{}, clusterName interface{}, restoreJobId interface{}) *CloudBackupsApi_GetServerlessBackupRestoreJob_Call {
+func (_e *CloudBackupsApi_Expecter) GetServerlessBackupRestoreJob(ctx any, groupId any, clusterName any, restoreJobId any) *CloudBackupsApi_GetServerlessBackupRestoreJob_Call {
 	return &CloudBackupsApi_GetServerlessBackupRestoreJob_Call{Call: _e.mock.On("GetServerlessBackupRestoreJob", ctx, groupId, clusterName, restoreJobId)}
 }
 
@@ -2674,7 +2674,7 @@ type CloudBackupsApi_GetServerlessBackupRestoreJobExecute_Call struct {
 
 // GetServerlessBackupRestoreJobExecute is a helper method to define mock.On call
 //   - r admin.GetServerlessBackupRestoreJobApiRequest
-func (_e *CloudBackupsApi_Expecter) GetServerlessBackupRestoreJobExecute(r interface{}) *CloudBackupsApi_GetServerlessBackupRestoreJobExecute_Call {
+func (_e *CloudBackupsApi_Expecter) GetServerlessBackupRestoreJobExecute(r any) *CloudBackupsApi_GetServerlessBackupRestoreJobExecute_Call {
 	return &CloudBackupsApi_GetServerlessBackupRestoreJobExecute_Call{Call: _e.mock.On("GetServerlessBackupRestoreJobExecute", r)}
 }
 
@@ -2721,7 +2721,7 @@ type CloudBackupsApi_GetServerlessBackupRestoreJobWithParams_Call struct {
 // GetServerlessBackupRestoreJobWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetServerlessBackupRestoreJobApiParams
-func (_e *CloudBackupsApi_Expecter) GetServerlessBackupRestoreJobWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_GetServerlessBackupRestoreJobWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) GetServerlessBackupRestoreJobWithParams(ctx any, args any) *CloudBackupsApi_GetServerlessBackupRestoreJobWithParams_Call {
 	return &CloudBackupsApi_GetServerlessBackupRestoreJobWithParams_Call{Call: _e.mock.On("GetServerlessBackupRestoreJobWithParams", ctx, args)}
 }
 
@@ -2768,7 +2768,7 @@ type CloudBackupsApi_GetServerlessBackupWithParams_Call struct {
 // GetServerlessBackupWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetServerlessBackupApiParams
-func (_e *CloudBackupsApi_Expecter) GetServerlessBackupWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_GetServerlessBackupWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) GetServerlessBackupWithParams(ctx any, args any) *CloudBackupsApi_GetServerlessBackupWithParams_Call {
 	return &CloudBackupsApi_GetServerlessBackupWithParams_Call{Call: _e.mock.On("GetServerlessBackupWithParams", ctx, args)}
 }
 
@@ -2817,7 +2817,7 @@ type CloudBackupsApi_GetShardedClusterBackup_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - snapshotId string
-func (_e *CloudBackupsApi_Expecter) GetShardedClusterBackup(ctx interface{}, groupId interface{}, clusterName interface{}, snapshotId interface{}) *CloudBackupsApi_GetShardedClusterBackup_Call {
+func (_e *CloudBackupsApi_Expecter) GetShardedClusterBackup(ctx any, groupId any, clusterName any, snapshotId any) *CloudBackupsApi_GetShardedClusterBackup_Call {
 	return &CloudBackupsApi_GetShardedClusterBackup_Call{Call: _e.mock.On("GetShardedClusterBackup", ctx, groupId, clusterName, snapshotId)}
 }
 
@@ -2884,7 +2884,7 @@ type CloudBackupsApi_GetShardedClusterBackupExecute_Call struct {
 
 // GetShardedClusterBackupExecute is a helper method to define mock.On call
 //   - r admin.GetShardedClusterBackupApiRequest
-func (_e *CloudBackupsApi_Expecter) GetShardedClusterBackupExecute(r interface{}) *CloudBackupsApi_GetShardedClusterBackupExecute_Call {
+func (_e *CloudBackupsApi_Expecter) GetShardedClusterBackupExecute(r any) *CloudBackupsApi_GetShardedClusterBackupExecute_Call {
 	return &CloudBackupsApi_GetShardedClusterBackupExecute_Call{Call: _e.mock.On("GetShardedClusterBackupExecute", r)}
 }
 
@@ -2931,7 +2931,7 @@ type CloudBackupsApi_GetShardedClusterBackupWithParams_Call struct {
 // GetShardedClusterBackupWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetShardedClusterBackupApiParams
-func (_e *CloudBackupsApi_Expecter) GetShardedClusterBackupWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_GetShardedClusterBackupWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) GetShardedClusterBackupWithParams(ctx any, args any) *CloudBackupsApi_GetShardedClusterBackupWithParams_Call {
 	return &CloudBackupsApi_GetShardedClusterBackupWithParams_Call{Call: _e.mock.On("GetShardedClusterBackupWithParams", ctx, args)}
 }
 
@@ -2979,7 +2979,7 @@ type CloudBackupsApi_ListBackupExportJobs_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *CloudBackupsApi_Expecter) ListBackupExportJobs(ctx interface{}, groupId interface{}, clusterName interface{}) *CloudBackupsApi_ListBackupExportJobs_Call {
+func (_e *CloudBackupsApi_Expecter) ListBackupExportJobs(ctx any, groupId any, clusterName any) *CloudBackupsApi_ListBackupExportJobs_Call {
 	return &CloudBackupsApi_ListBackupExportJobs_Call{Call: _e.mock.On("ListBackupExportJobs", ctx, groupId, clusterName)}
 }
 
@@ -3046,7 +3046,7 @@ type CloudBackupsApi_ListBackupExportJobsExecute_Call struct {
 
 // ListBackupExportJobsExecute is a helper method to define mock.On call
 //   - r admin.ListBackupExportJobsApiRequest
-func (_e *CloudBackupsApi_Expecter) ListBackupExportJobsExecute(r interface{}) *CloudBackupsApi_ListBackupExportJobsExecute_Call {
+func (_e *CloudBackupsApi_Expecter) ListBackupExportJobsExecute(r any) *CloudBackupsApi_ListBackupExportJobsExecute_Call {
 	return &CloudBackupsApi_ListBackupExportJobsExecute_Call{Call: _e.mock.On("ListBackupExportJobsExecute", r)}
 }
 
@@ -3093,7 +3093,7 @@ type CloudBackupsApi_ListBackupExportJobsWithParams_Call struct {
 // ListBackupExportJobsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListBackupExportJobsApiParams
-func (_e *CloudBackupsApi_Expecter) ListBackupExportJobsWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_ListBackupExportJobsWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) ListBackupExportJobsWithParams(ctx any, args any) *CloudBackupsApi_ListBackupExportJobsWithParams_Call {
 	return &CloudBackupsApi_ListBackupExportJobsWithParams_Call{Call: _e.mock.On("ListBackupExportJobsWithParams", ctx, args)}
 }
 
@@ -3141,7 +3141,7 @@ type CloudBackupsApi_ListBackupRestoreJobs_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *CloudBackupsApi_Expecter) ListBackupRestoreJobs(ctx interface{}, groupId interface{}, clusterName interface{}) *CloudBackupsApi_ListBackupRestoreJobs_Call {
+func (_e *CloudBackupsApi_Expecter) ListBackupRestoreJobs(ctx any, groupId any, clusterName any) *CloudBackupsApi_ListBackupRestoreJobs_Call {
 	return &CloudBackupsApi_ListBackupRestoreJobs_Call{Call: _e.mock.On("ListBackupRestoreJobs", ctx, groupId, clusterName)}
 }
 
@@ -3208,7 +3208,7 @@ type CloudBackupsApi_ListBackupRestoreJobsExecute_Call struct {
 
 // ListBackupRestoreJobsExecute is a helper method to define mock.On call
 //   - r admin.ListBackupRestoreJobsApiRequest
-func (_e *CloudBackupsApi_Expecter) ListBackupRestoreJobsExecute(r interface{}) *CloudBackupsApi_ListBackupRestoreJobsExecute_Call {
+func (_e *CloudBackupsApi_Expecter) ListBackupRestoreJobsExecute(r any) *CloudBackupsApi_ListBackupRestoreJobsExecute_Call {
 	return &CloudBackupsApi_ListBackupRestoreJobsExecute_Call{Call: _e.mock.On("ListBackupRestoreJobsExecute", r)}
 }
 
@@ -3255,7 +3255,7 @@ type CloudBackupsApi_ListBackupRestoreJobsWithParams_Call struct {
 // ListBackupRestoreJobsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListBackupRestoreJobsApiParams
-func (_e *CloudBackupsApi_Expecter) ListBackupRestoreJobsWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_ListBackupRestoreJobsWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) ListBackupRestoreJobsWithParams(ctx any, args any) *CloudBackupsApi_ListBackupRestoreJobsWithParams_Call {
 	return &CloudBackupsApi_ListBackupRestoreJobsWithParams_Call{Call: _e.mock.On("ListBackupRestoreJobsWithParams", ctx, args)}
 }
 
@@ -3302,7 +3302,7 @@ type CloudBackupsApi_ListExportBuckets_Call struct {
 // ListExportBuckets is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *CloudBackupsApi_Expecter) ListExportBuckets(ctx interface{}, groupId interface{}) *CloudBackupsApi_ListExportBuckets_Call {
+func (_e *CloudBackupsApi_Expecter) ListExportBuckets(ctx any, groupId any) *CloudBackupsApi_ListExportBuckets_Call {
 	return &CloudBackupsApi_ListExportBuckets_Call{Call: _e.mock.On("ListExportBuckets", ctx, groupId)}
 }
 
@@ -3369,7 +3369,7 @@ type CloudBackupsApi_ListExportBucketsExecute_Call struct {
 
 // ListExportBucketsExecute is a helper method to define mock.On call
 //   - r admin.ListExportBucketsApiRequest
-func (_e *CloudBackupsApi_Expecter) ListExportBucketsExecute(r interface{}) *CloudBackupsApi_ListExportBucketsExecute_Call {
+func (_e *CloudBackupsApi_Expecter) ListExportBucketsExecute(r any) *CloudBackupsApi_ListExportBucketsExecute_Call {
 	return &CloudBackupsApi_ListExportBucketsExecute_Call{Call: _e.mock.On("ListExportBucketsExecute", r)}
 }
 
@@ -3416,7 +3416,7 @@ type CloudBackupsApi_ListExportBucketsWithParams_Call struct {
 // ListExportBucketsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListExportBucketsApiParams
-func (_e *CloudBackupsApi_Expecter) ListExportBucketsWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_ListExportBucketsWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) ListExportBucketsWithParams(ctx any, args any) *CloudBackupsApi_ListExportBucketsWithParams_Call {
 	return &CloudBackupsApi_ListExportBucketsWithParams_Call{Call: _e.mock.On("ListExportBucketsWithParams", ctx, args)}
 }
 
@@ -3464,7 +3464,7 @@ type CloudBackupsApi_ListReplicaSetBackups_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *CloudBackupsApi_Expecter) ListReplicaSetBackups(ctx interface{}, groupId interface{}, clusterName interface{}) *CloudBackupsApi_ListReplicaSetBackups_Call {
+func (_e *CloudBackupsApi_Expecter) ListReplicaSetBackups(ctx any, groupId any, clusterName any) *CloudBackupsApi_ListReplicaSetBackups_Call {
 	return &CloudBackupsApi_ListReplicaSetBackups_Call{Call: _e.mock.On("ListReplicaSetBackups", ctx, groupId, clusterName)}
 }
 
@@ -3531,7 +3531,7 @@ type CloudBackupsApi_ListReplicaSetBackupsExecute_Call struct {
 
 // ListReplicaSetBackupsExecute is a helper method to define mock.On call
 //   - r admin.ListReplicaSetBackupsApiRequest
-func (_e *CloudBackupsApi_Expecter) ListReplicaSetBackupsExecute(r interface{}) *CloudBackupsApi_ListReplicaSetBackupsExecute_Call {
+func (_e *CloudBackupsApi_Expecter) ListReplicaSetBackupsExecute(r any) *CloudBackupsApi_ListReplicaSetBackupsExecute_Call {
 	return &CloudBackupsApi_ListReplicaSetBackupsExecute_Call{Call: _e.mock.On("ListReplicaSetBackupsExecute", r)}
 }
 
@@ -3578,7 +3578,7 @@ type CloudBackupsApi_ListReplicaSetBackupsWithParams_Call struct {
 // ListReplicaSetBackupsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListReplicaSetBackupsApiParams
-func (_e *CloudBackupsApi_Expecter) ListReplicaSetBackupsWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_ListReplicaSetBackupsWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) ListReplicaSetBackupsWithParams(ctx any, args any) *CloudBackupsApi_ListReplicaSetBackupsWithParams_Call {
 	return &CloudBackupsApi_ListReplicaSetBackupsWithParams_Call{Call: _e.mock.On("ListReplicaSetBackupsWithParams", ctx, args)}
 }
 
@@ -3626,7 +3626,7 @@ type CloudBackupsApi_ListServerlessBackupRestoreJobs_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *CloudBackupsApi_Expecter) ListServerlessBackupRestoreJobs(ctx interface{}, groupId interface{}, clusterName interface{}) *CloudBackupsApi_ListServerlessBackupRestoreJobs_Call {
+func (_e *CloudBackupsApi_Expecter) ListServerlessBackupRestoreJobs(ctx any, groupId any, clusterName any) *CloudBackupsApi_ListServerlessBackupRestoreJobs_Call {
 	return &CloudBackupsApi_ListServerlessBackupRestoreJobs_Call{Call: _e.mock.On("ListServerlessBackupRestoreJobs", ctx, groupId, clusterName)}
 }
 
@@ -3693,7 +3693,7 @@ type CloudBackupsApi_ListServerlessBackupRestoreJobsExecute_Call struct {
 
 // ListServerlessBackupRestoreJobsExecute is a helper method to define mock.On call
 //   - r admin.ListServerlessBackupRestoreJobsApiRequest
-func (_e *CloudBackupsApi_Expecter) ListServerlessBackupRestoreJobsExecute(r interface{}) *CloudBackupsApi_ListServerlessBackupRestoreJobsExecute_Call {
+func (_e *CloudBackupsApi_Expecter) ListServerlessBackupRestoreJobsExecute(r any) *CloudBackupsApi_ListServerlessBackupRestoreJobsExecute_Call {
 	return &CloudBackupsApi_ListServerlessBackupRestoreJobsExecute_Call{Call: _e.mock.On("ListServerlessBackupRestoreJobsExecute", r)}
 }
 
@@ -3740,7 +3740,7 @@ type CloudBackupsApi_ListServerlessBackupRestoreJobsWithParams_Call struct {
 // ListServerlessBackupRestoreJobsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListServerlessBackupRestoreJobsApiParams
-func (_e *CloudBackupsApi_Expecter) ListServerlessBackupRestoreJobsWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_ListServerlessBackupRestoreJobsWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) ListServerlessBackupRestoreJobsWithParams(ctx any, args any) *CloudBackupsApi_ListServerlessBackupRestoreJobsWithParams_Call {
 	return &CloudBackupsApi_ListServerlessBackupRestoreJobsWithParams_Call{Call: _e.mock.On("ListServerlessBackupRestoreJobsWithParams", ctx, args)}
 }
 
@@ -3788,7 +3788,7 @@ type CloudBackupsApi_ListServerlessBackups_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *CloudBackupsApi_Expecter) ListServerlessBackups(ctx interface{}, groupId interface{}, clusterName interface{}) *CloudBackupsApi_ListServerlessBackups_Call {
+func (_e *CloudBackupsApi_Expecter) ListServerlessBackups(ctx any, groupId any, clusterName any) *CloudBackupsApi_ListServerlessBackups_Call {
 	return &CloudBackupsApi_ListServerlessBackups_Call{Call: _e.mock.On("ListServerlessBackups", ctx, groupId, clusterName)}
 }
 
@@ -3855,7 +3855,7 @@ type CloudBackupsApi_ListServerlessBackupsExecute_Call struct {
 
 // ListServerlessBackupsExecute is a helper method to define mock.On call
 //   - r admin.ListServerlessBackupsApiRequest
-func (_e *CloudBackupsApi_Expecter) ListServerlessBackupsExecute(r interface{}) *CloudBackupsApi_ListServerlessBackupsExecute_Call {
+func (_e *CloudBackupsApi_Expecter) ListServerlessBackupsExecute(r any) *CloudBackupsApi_ListServerlessBackupsExecute_Call {
 	return &CloudBackupsApi_ListServerlessBackupsExecute_Call{Call: _e.mock.On("ListServerlessBackupsExecute", r)}
 }
 
@@ -3902,7 +3902,7 @@ type CloudBackupsApi_ListServerlessBackupsWithParams_Call struct {
 // ListServerlessBackupsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListServerlessBackupsApiParams
-func (_e *CloudBackupsApi_Expecter) ListServerlessBackupsWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_ListServerlessBackupsWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) ListServerlessBackupsWithParams(ctx any, args any) *CloudBackupsApi_ListServerlessBackupsWithParams_Call {
 	return &CloudBackupsApi_ListServerlessBackupsWithParams_Call{Call: _e.mock.On("ListServerlessBackupsWithParams", ctx, args)}
 }
 
@@ -3950,7 +3950,7 @@ type CloudBackupsApi_ListShardedClusterBackups_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *CloudBackupsApi_Expecter) ListShardedClusterBackups(ctx interface{}, groupId interface{}, clusterName interface{}) *CloudBackupsApi_ListShardedClusterBackups_Call {
+func (_e *CloudBackupsApi_Expecter) ListShardedClusterBackups(ctx any, groupId any, clusterName any) *CloudBackupsApi_ListShardedClusterBackups_Call {
 	return &CloudBackupsApi_ListShardedClusterBackups_Call{Call: _e.mock.On("ListShardedClusterBackups", ctx, groupId, clusterName)}
 }
 
@@ -4017,7 +4017,7 @@ type CloudBackupsApi_ListShardedClusterBackupsExecute_Call struct {
 
 // ListShardedClusterBackupsExecute is a helper method to define mock.On call
 //   - r admin.ListShardedClusterBackupsApiRequest
-func (_e *CloudBackupsApi_Expecter) ListShardedClusterBackupsExecute(r interface{}) *CloudBackupsApi_ListShardedClusterBackupsExecute_Call {
+func (_e *CloudBackupsApi_Expecter) ListShardedClusterBackupsExecute(r any) *CloudBackupsApi_ListShardedClusterBackupsExecute_Call {
 	return &CloudBackupsApi_ListShardedClusterBackupsExecute_Call{Call: _e.mock.On("ListShardedClusterBackupsExecute", r)}
 }
 
@@ -4064,7 +4064,7 @@ type CloudBackupsApi_ListShardedClusterBackupsWithParams_Call struct {
 // ListShardedClusterBackupsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListShardedClusterBackupsApiParams
-func (_e *CloudBackupsApi_Expecter) ListShardedClusterBackupsWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_ListShardedClusterBackupsWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) ListShardedClusterBackupsWithParams(ctx any, args any) *CloudBackupsApi_ListShardedClusterBackupsWithParams_Call {
 	return &CloudBackupsApi_ListShardedClusterBackupsWithParams_Call{Call: _e.mock.On("ListShardedClusterBackupsWithParams", ctx, args)}
 }
 
@@ -4113,7 +4113,7 @@ type CloudBackupsApi_TakeSnapshot_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - diskBackupOnDemandSnapshotRequest *admin.DiskBackupOnDemandSnapshotRequest
-func (_e *CloudBackupsApi_Expecter) TakeSnapshot(ctx interface{}, groupId interface{}, clusterName interface{}, diskBackupOnDemandSnapshotRequest interface{}) *CloudBackupsApi_TakeSnapshot_Call {
+func (_e *CloudBackupsApi_Expecter) TakeSnapshot(ctx any, groupId any, clusterName any, diskBackupOnDemandSnapshotRequest any) *CloudBackupsApi_TakeSnapshot_Call {
 	return &CloudBackupsApi_TakeSnapshot_Call{Call: _e.mock.On("TakeSnapshot", ctx, groupId, clusterName, diskBackupOnDemandSnapshotRequest)}
 }
 
@@ -4180,7 +4180,7 @@ type CloudBackupsApi_TakeSnapshotExecute_Call struct {
 
 // TakeSnapshotExecute is a helper method to define mock.On call
 //   - r admin.TakeSnapshotApiRequest
-func (_e *CloudBackupsApi_Expecter) TakeSnapshotExecute(r interface{}) *CloudBackupsApi_TakeSnapshotExecute_Call {
+func (_e *CloudBackupsApi_Expecter) TakeSnapshotExecute(r any) *CloudBackupsApi_TakeSnapshotExecute_Call {
 	return &CloudBackupsApi_TakeSnapshotExecute_Call{Call: _e.mock.On("TakeSnapshotExecute", r)}
 }
 
@@ -4227,7 +4227,7 @@ type CloudBackupsApi_TakeSnapshotWithParams_Call struct {
 // TakeSnapshotWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.TakeSnapshotApiParams
-func (_e *CloudBackupsApi_Expecter) TakeSnapshotWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_TakeSnapshotWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) TakeSnapshotWithParams(ctx any, args any) *CloudBackupsApi_TakeSnapshotWithParams_Call {
 	return &CloudBackupsApi_TakeSnapshotWithParams_Call{Call: _e.mock.On("TakeSnapshotWithParams", ctx, args)}
 }
 
@@ -4276,7 +4276,7 @@ type CloudBackupsApi_UpdateBackupSchedule_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - diskBackupSnapshotSchedule20240805 *admin.DiskBackupSnapshotSchedule20240805
-func (_e *CloudBackupsApi_Expecter) UpdateBackupSchedule(ctx interface{}, groupId interface{}, clusterName interface{}, diskBackupSnapshotSchedule20240805 interface{}) *CloudBackupsApi_UpdateBackupSchedule_Call {
+func (_e *CloudBackupsApi_Expecter) UpdateBackupSchedule(ctx any, groupId any, clusterName any, diskBackupSnapshotSchedule20240805 any) *CloudBackupsApi_UpdateBackupSchedule_Call {
 	return &CloudBackupsApi_UpdateBackupSchedule_Call{Call: _e.mock.On("UpdateBackupSchedule", ctx, groupId, clusterName, diskBackupSnapshotSchedule20240805)}
 }
 
@@ -4343,7 +4343,7 @@ type CloudBackupsApi_UpdateBackupScheduleExecute_Call struct {
 
 // UpdateBackupScheduleExecute is a helper method to define mock.On call
 //   - r admin.UpdateBackupScheduleApiRequest
-func (_e *CloudBackupsApi_Expecter) UpdateBackupScheduleExecute(r interface{}) *CloudBackupsApi_UpdateBackupScheduleExecute_Call {
+func (_e *CloudBackupsApi_Expecter) UpdateBackupScheduleExecute(r any) *CloudBackupsApi_UpdateBackupScheduleExecute_Call {
 	return &CloudBackupsApi_UpdateBackupScheduleExecute_Call{Call: _e.mock.On("UpdateBackupScheduleExecute", r)}
 }
 
@@ -4390,7 +4390,7 @@ type CloudBackupsApi_UpdateBackupScheduleWithParams_Call struct {
 // UpdateBackupScheduleWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateBackupScheduleApiParams
-func (_e *CloudBackupsApi_Expecter) UpdateBackupScheduleWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_UpdateBackupScheduleWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) UpdateBackupScheduleWithParams(ctx any, args any) *CloudBackupsApi_UpdateBackupScheduleWithParams_Call {
 	return &CloudBackupsApi_UpdateBackupScheduleWithParams_Call{Call: _e.mock.On("UpdateBackupScheduleWithParams", ctx, args)}
 }
 
@@ -4438,7 +4438,7 @@ type CloudBackupsApi_UpdateDataProtectionSettings_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - dataProtectionSettings20231001 *admin.DataProtectionSettings20231001
-func (_e *CloudBackupsApi_Expecter) UpdateDataProtectionSettings(ctx interface{}, groupId interface{}, dataProtectionSettings20231001 interface{}) *CloudBackupsApi_UpdateDataProtectionSettings_Call {
+func (_e *CloudBackupsApi_Expecter) UpdateDataProtectionSettings(ctx any, groupId any, dataProtectionSettings20231001 any) *CloudBackupsApi_UpdateDataProtectionSettings_Call {
 	return &CloudBackupsApi_UpdateDataProtectionSettings_Call{Call: _e.mock.On("UpdateDataProtectionSettings", ctx, groupId, dataProtectionSettings20231001)}
 }
 
@@ -4505,7 +4505,7 @@ type CloudBackupsApi_UpdateDataProtectionSettingsExecute_Call struct {
 
 // UpdateDataProtectionSettingsExecute is a helper method to define mock.On call
 //   - r admin.UpdateDataProtectionSettingsApiRequest
-func (_e *CloudBackupsApi_Expecter) UpdateDataProtectionSettingsExecute(r interface{}) *CloudBackupsApi_UpdateDataProtectionSettingsExecute_Call {
+func (_e *CloudBackupsApi_Expecter) UpdateDataProtectionSettingsExecute(r any) *CloudBackupsApi_UpdateDataProtectionSettingsExecute_Call {
 	return &CloudBackupsApi_UpdateDataProtectionSettingsExecute_Call{Call: _e.mock.On("UpdateDataProtectionSettingsExecute", r)}
 }
 
@@ -4552,7 +4552,7 @@ type CloudBackupsApi_UpdateDataProtectionSettingsWithParams_Call struct {
 // UpdateDataProtectionSettingsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateDataProtectionSettingsApiParams
-func (_e *CloudBackupsApi_Expecter) UpdateDataProtectionSettingsWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_UpdateDataProtectionSettingsWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) UpdateDataProtectionSettingsWithParams(ctx any, args any) *CloudBackupsApi_UpdateDataProtectionSettingsWithParams_Call {
 	return &CloudBackupsApi_UpdateDataProtectionSettingsWithParams_Call{Call: _e.mock.On("UpdateDataProtectionSettingsWithParams", ctx, args)}
 }
 
@@ -4602,7 +4602,7 @@ type CloudBackupsApi_UpdateSnapshotRetention_Call struct {
 //   - clusterName string
 //   - snapshotId string
 //   - backupSnapshotRetention *admin.BackupSnapshotRetention
-func (_e *CloudBackupsApi_Expecter) UpdateSnapshotRetention(ctx interface{}, groupId interface{}, clusterName interface{}, snapshotId interface{}, backupSnapshotRetention interface{}) *CloudBackupsApi_UpdateSnapshotRetention_Call {
+func (_e *CloudBackupsApi_Expecter) UpdateSnapshotRetention(ctx any, groupId any, clusterName any, snapshotId any, backupSnapshotRetention any) *CloudBackupsApi_UpdateSnapshotRetention_Call {
 	return &CloudBackupsApi_UpdateSnapshotRetention_Call{Call: _e.mock.On("UpdateSnapshotRetention", ctx, groupId, clusterName, snapshotId, backupSnapshotRetention)}
 }
 
@@ -4669,7 +4669,7 @@ type CloudBackupsApi_UpdateSnapshotRetentionExecute_Call struct {
 
 // UpdateSnapshotRetentionExecute is a helper method to define mock.On call
 //   - r admin.UpdateSnapshotRetentionApiRequest
-func (_e *CloudBackupsApi_Expecter) UpdateSnapshotRetentionExecute(r interface{}) *CloudBackupsApi_UpdateSnapshotRetentionExecute_Call {
+func (_e *CloudBackupsApi_Expecter) UpdateSnapshotRetentionExecute(r any) *CloudBackupsApi_UpdateSnapshotRetentionExecute_Call {
 	return &CloudBackupsApi_UpdateSnapshotRetentionExecute_Call{Call: _e.mock.On("UpdateSnapshotRetentionExecute", r)}
 }
 
@@ -4716,7 +4716,7 @@ type CloudBackupsApi_UpdateSnapshotRetentionWithParams_Call struct {
 // UpdateSnapshotRetentionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateSnapshotRetentionApiParams
-func (_e *CloudBackupsApi_Expecter) UpdateSnapshotRetentionWithParams(ctx interface{}, args interface{}) *CloudBackupsApi_UpdateSnapshotRetentionWithParams_Call {
+func (_e *CloudBackupsApi_Expecter) UpdateSnapshotRetentionWithParams(ctx any, args any) *CloudBackupsApi_UpdateSnapshotRetentionWithParams_Call {
 	return &CloudBackupsApi_UpdateSnapshotRetentionWithParams_Call{Call: _e.mock.On("UpdateSnapshotRetentionWithParams", ctx, args)}
 }
 

--- a/mockadmin/cloud_migration_service_api.go
+++ b/mockadmin/cloud_migration_service_api.go
@@ -52,7 +52,7 @@ type CloudMigrationServiceApi_CreateLinkToken_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - targetOrgRequest *admin.TargetOrgRequest
-func (_e *CloudMigrationServiceApi_Expecter) CreateLinkToken(ctx interface{}, orgId interface{}, targetOrgRequest interface{}) *CloudMigrationServiceApi_CreateLinkToken_Call {
+func (_e *CloudMigrationServiceApi_Expecter) CreateLinkToken(ctx any, orgId any, targetOrgRequest any) *CloudMigrationServiceApi_CreateLinkToken_Call {
 	return &CloudMigrationServiceApi_CreateLinkToken_Call{Call: _e.mock.On("CreateLinkToken", ctx, orgId, targetOrgRequest)}
 }
 
@@ -119,7 +119,7 @@ type CloudMigrationServiceApi_CreateLinkTokenExecute_Call struct {
 
 // CreateLinkTokenExecute is a helper method to define mock.On call
 //   - r admin.CreateLinkTokenApiRequest
-func (_e *CloudMigrationServiceApi_Expecter) CreateLinkTokenExecute(r interface{}) *CloudMigrationServiceApi_CreateLinkTokenExecute_Call {
+func (_e *CloudMigrationServiceApi_Expecter) CreateLinkTokenExecute(r any) *CloudMigrationServiceApi_CreateLinkTokenExecute_Call {
 	return &CloudMigrationServiceApi_CreateLinkTokenExecute_Call{Call: _e.mock.On("CreateLinkTokenExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type CloudMigrationServiceApi_CreateLinkTokenWithParams_Call struct {
 // CreateLinkTokenWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateLinkTokenApiParams
-func (_e *CloudMigrationServiceApi_Expecter) CreateLinkTokenWithParams(ctx interface{}, args interface{}) *CloudMigrationServiceApi_CreateLinkTokenWithParams_Call {
+func (_e *CloudMigrationServiceApi_Expecter) CreateLinkTokenWithParams(ctx any, args any) *CloudMigrationServiceApi_CreateLinkTokenWithParams_Call {
 	return &CloudMigrationServiceApi_CreateLinkTokenWithParams_Call{Call: _e.mock.On("CreateLinkTokenWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type CloudMigrationServiceApi_CreatePushMigration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - liveMigrationRequest20240530 *admin.LiveMigrationRequest20240530
-func (_e *CloudMigrationServiceApi_Expecter) CreatePushMigration(ctx interface{}, groupId interface{}, liveMigrationRequest20240530 interface{}) *CloudMigrationServiceApi_CreatePushMigration_Call {
+func (_e *CloudMigrationServiceApi_Expecter) CreatePushMigration(ctx any, groupId any, liveMigrationRequest20240530 any) *CloudMigrationServiceApi_CreatePushMigration_Call {
 	return &CloudMigrationServiceApi_CreatePushMigration_Call{Call: _e.mock.On("CreatePushMigration", ctx, groupId, liveMigrationRequest20240530)}
 }
 
@@ -281,7 +281,7 @@ type CloudMigrationServiceApi_CreatePushMigrationExecute_Call struct {
 
 // CreatePushMigrationExecute is a helper method to define mock.On call
 //   - r admin.CreatePushMigrationApiRequest
-func (_e *CloudMigrationServiceApi_Expecter) CreatePushMigrationExecute(r interface{}) *CloudMigrationServiceApi_CreatePushMigrationExecute_Call {
+func (_e *CloudMigrationServiceApi_Expecter) CreatePushMigrationExecute(r any) *CloudMigrationServiceApi_CreatePushMigrationExecute_Call {
 	return &CloudMigrationServiceApi_CreatePushMigrationExecute_Call{Call: _e.mock.On("CreatePushMigrationExecute", r)}
 }
 
@@ -328,7 +328,7 @@ type CloudMigrationServiceApi_CreatePushMigrationWithParams_Call struct {
 // CreatePushMigrationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreatePushMigrationApiParams
-func (_e *CloudMigrationServiceApi_Expecter) CreatePushMigrationWithParams(ctx interface{}, args interface{}) *CloudMigrationServiceApi_CreatePushMigrationWithParams_Call {
+func (_e *CloudMigrationServiceApi_Expecter) CreatePushMigrationWithParams(ctx any, args any) *CloudMigrationServiceApi_CreatePushMigrationWithParams_Call {
 	return &CloudMigrationServiceApi_CreatePushMigrationWithParams_Call{Call: _e.mock.On("CreatePushMigrationWithParams", ctx, args)}
 }
 
@@ -376,7 +376,7 @@ type CloudMigrationServiceApi_CutoverMigration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - liveMigrationId string
-func (_e *CloudMigrationServiceApi_Expecter) CutoverMigration(ctx interface{}, groupId interface{}, liveMigrationId interface{}) *CloudMigrationServiceApi_CutoverMigration_Call {
+func (_e *CloudMigrationServiceApi_Expecter) CutoverMigration(ctx any, groupId any, liveMigrationId any) *CloudMigrationServiceApi_CutoverMigration_Call {
 	return &CloudMigrationServiceApi_CutoverMigration_Call{Call: _e.mock.On("CutoverMigration", ctx, groupId, liveMigrationId)}
 }
 
@@ -434,7 +434,7 @@ type CloudMigrationServiceApi_CutoverMigrationExecute_Call struct {
 
 // CutoverMigrationExecute is a helper method to define mock.On call
 //   - r admin.CutoverMigrationApiRequest
-func (_e *CloudMigrationServiceApi_Expecter) CutoverMigrationExecute(r interface{}) *CloudMigrationServiceApi_CutoverMigrationExecute_Call {
+func (_e *CloudMigrationServiceApi_Expecter) CutoverMigrationExecute(r any) *CloudMigrationServiceApi_CutoverMigrationExecute_Call {
 	return &CloudMigrationServiceApi_CutoverMigrationExecute_Call{Call: _e.mock.On("CutoverMigrationExecute", r)}
 }
 
@@ -481,7 +481,7 @@ type CloudMigrationServiceApi_CutoverMigrationWithParams_Call struct {
 // CutoverMigrationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CutoverMigrationApiParams
-func (_e *CloudMigrationServiceApi_Expecter) CutoverMigrationWithParams(ctx interface{}, args interface{}) *CloudMigrationServiceApi_CutoverMigrationWithParams_Call {
+func (_e *CloudMigrationServiceApi_Expecter) CutoverMigrationWithParams(ctx any, args any) *CloudMigrationServiceApi_CutoverMigrationWithParams_Call {
 	return &CloudMigrationServiceApi_CutoverMigrationWithParams_Call{Call: _e.mock.On("CutoverMigrationWithParams", ctx, args)}
 }
 
@@ -528,7 +528,7 @@ type CloudMigrationServiceApi_DeleteLinkToken_Call struct {
 // DeleteLinkToken is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *CloudMigrationServiceApi_Expecter) DeleteLinkToken(ctx interface{}, orgId interface{}) *CloudMigrationServiceApi_DeleteLinkToken_Call {
+func (_e *CloudMigrationServiceApi_Expecter) DeleteLinkToken(ctx any, orgId any) *CloudMigrationServiceApi_DeleteLinkToken_Call {
 	return &CloudMigrationServiceApi_DeleteLinkToken_Call{Call: _e.mock.On("DeleteLinkToken", ctx, orgId)}
 }
 
@@ -550,24 +550,24 @@ func (_c *CloudMigrationServiceApi_DeleteLinkToken_Call) RunAndReturn(run func(c
 }
 
 // DeleteLinkTokenExecute provides a mock function with given fields: r
-func (_m *CloudMigrationServiceApi) DeleteLinkTokenExecute(r admin.DeleteLinkTokenApiRequest) (interface{}, *http.Response, error) {
+func (_m *CloudMigrationServiceApi) DeleteLinkTokenExecute(r admin.DeleteLinkTokenApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteLinkTokenExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteLinkTokenApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteLinkTokenApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteLinkTokenApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteLinkTokenApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -595,7 +595,7 @@ type CloudMigrationServiceApi_DeleteLinkTokenExecute_Call struct {
 
 // DeleteLinkTokenExecute is a helper method to define mock.On call
 //   - r admin.DeleteLinkTokenApiRequest
-func (_e *CloudMigrationServiceApi_Expecter) DeleteLinkTokenExecute(r interface{}) *CloudMigrationServiceApi_DeleteLinkTokenExecute_Call {
+func (_e *CloudMigrationServiceApi_Expecter) DeleteLinkTokenExecute(r any) *CloudMigrationServiceApi_DeleteLinkTokenExecute_Call {
 	return &CloudMigrationServiceApi_DeleteLinkTokenExecute_Call{Call: _e.mock.On("DeleteLinkTokenExecute", r)}
 }
 
@@ -606,12 +606,12 @@ func (_c *CloudMigrationServiceApi_DeleteLinkTokenExecute_Call) Run(run func(r a
 	return _c
 }
 
-func (_c *CloudMigrationServiceApi_DeleteLinkTokenExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *CloudMigrationServiceApi_DeleteLinkTokenExecute_Call {
+func (_c *CloudMigrationServiceApi_DeleteLinkTokenExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *CloudMigrationServiceApi_DeleteLinkTokenExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *CloudMigrationServiceApi_DeleteLinkTokenExecute_Call) RunAndReturn(run func(admin.DeleteLinkTokenApiRequest) (interface{}, *http.Response, error)) *CloudMigrationServiceApi_DeleteLinkTokenExecute_Call {
+func (_c *CloudMigrationServiceApi_DeleteLinkTokenExecute_Call) RunAndReturn(run func(admin.DeleteLinkTokenApiRequest) (any, *http.Response, error)) *CloudMigrationServiceApi_DeleteLinkTokenExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -642,7 +642,7 @@ type CloudMigrationServiceApi_DeleteLinkTokenWithParams_Call struct {
 // DeleteLinkTokenWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteLinkTokenApiParams
-func (_e *CloudMigrationServiceApi_Expecter) DeleteLinkTokenWithParams(ctx interface{}, args interface{}) *CloudMigrationServiceApi_DeleteLinkTokenWithParams_Call {
+func (_e *CloudMigrationServiceApi_Expecter) DeleteLinkTokenWithParams(ctx any, args any) *CloudMigrationServiceApi_DeleteLinkTokenWithParams_Call {
 	return &CloudMigrationServiceApi_DeleteLinkTokenWithParams_Call{Call: _e.mock.On("DeleteLinkTokenWithParams", ctx, args)}
 }
 
@@ -690,7 +690,7 @@ type CloudMigrationServiceApi_GetPushMigration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - liveMigrationId string
-func (_e *CloudMigrationServiceApi_Expecter) GetPushMigration(ctx interface{}, groupId interface{}, liveMigrationId interface{}) *CloudMigrationServiceApi_GetPushMigration_Call {
+func (_e *CloudMigrationServiceApi_Expecter) GetPushMigration(ctx any, groupId any, liveMigrationId any) *CloudMigrationServiceApi_GetPushMigration_Call {
 	return &CloudMigrationServiceApi_GetPushMigration_Call{Call: _e.mock.On("GetPushMigration", ctx, groupId, liveMigrationId)}
 }
 
@@ -757,7 +757,7 @@ type CloudMigrationServiceApi_GetPushMigrationExecute_Call struct {
 
 // GetPushMigrationExecute is a helper method to define mock.On call
 //   - r admin.GetPushMigrationApiRequest
-func (_e *CloudMigrationServiceApi_Expecter) GetPushMigrationExecute(r interface{}) *CloudMigrationServiceApi_GetPushMigrationExecute_Call {
+func (_e *CloudMigrationServiceApi_Expecter) GetPushMigrationExecute(r any) *CloudMigrationServiceApi_GetPushMigrationExecute_Call {
 	return &CloudMigrationServiceApi_GetPushMigrationExecute_Call{Call: _e.mock.On("GetPushMigrationExecute", r)}
 }
 
@@ -804,7 +804,7 @@ type CloudMigrationServiceApi_GetPushMigrationWithParams_Call struct {
 // GetPushMigrationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetPushMigrationApiParams
-func (_e *CloudMigrationServiceApi_Expecter) GetPushMigrationWithParams(ctx interface{}, args interface{}) *CloudMigrationServiceApi_GetPushMigrationWithParams_Call {
+func (_e *CloudMigrationServiceApi_Expecter) GetPushMigrationWithParams(ctx any, args any) *CloudMigrationServiceApi_GetPushMigrationWithParams_Call {
 	return &CloudMigrationServiceApi_GetPushMigrationWithParams_Call{Call: _e.mock.On("GetPushMigrationWithParams", ctx, args)}
 }
 
@@ -852,7 +852,7 @@ type CloudMigrationServiceApi_GetValidationStatus_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - validationId string
-func (_e *CloudMigrationServiceApi_Expecter) GetValidationStatus(ctx interface{}, groupId interface{}, validationId interface{}) *CloudMigrationServiceApi_GetValidationStatus_Call {
+func (_e *CloudMigrationServiceApi_Expecter) GetValidationStatus(ctx any, groupId any, validationId any) *CloudMigrationServiceApi_GetValidationStatus_Call {
 	return &CloudMigrationServiceApi_GetValidationStatus_Call{Call: _e.mock.On("GetValidationStatus", ctx, groupId, validationId)}
 }
 
@@ -919,7 +919,7 @@ type CloudMigrationServiceApi_GetValidationStatusExecute_Call struct {
 
 // GetValidationStatusExecute is a helper method to define mock.On call
 //   - r admin.GetValidationStatusApiRequest
-func (_e *CloudMigrationServiceApi_Expecter) GetValidationStatusExecute(r interface{}) *CloudMigrationServiceApi_GetValidationStatusExecute_Call {
+func (_e *CloudMigrationServiceApi_Expecter) GetValidationStatusExecute(r any) *CloudMigrationServiceApi_GetValidationStatusExecute_Call {
 	return &CloudMigrationServiceApi_GetValidationStatusExecute_Call{Call: _e.mock.On("GetValidationStatusExecute", r)}
 }
 
@@ -966,7 +966,7 @@ type CloudMigrationServiceApi_GetValidationStatusWithParams_Call struct {
 // GetValidationStatusWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetValidationStatusApiParams
-func (_e *CloudMigrationServiceApi_Expecter) GetValidationStatusWithParams(ctx interface{}, args interface{}) *CloudMigrationServiceApi_GetValidationStatusWithParams_Call {
+func (_e *CloudMigrationServiceApi_Expecter) GetValidationStatusWithParams(ctx any, args any) *CloudMigrationServiceApi_GetValidationStatusWithParams_Call {
 	return &CloudMigrationServiceApi_GetValidationStatusWithParams_Call{Call: _e.mock.On("GetValidationStatusWithParams", ctx, args)}
 }
 
@@ -1013,7 +1013,7 @@ type CloudMigrationServiceApi_ListSourceProjects_Call struct {
 // ListSourceProjects is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *CloudMigrationServiceApi_Expecter) ListSourceProjects(ctx interface{}, orgId interface{}) *CloudMigrationServiceApi_ListSourceProjects_Call {
+func (_e *CloudMigrationServiceApi_Expecter) ListSourceProjects(ctx any, orgId any) *CloudMigrationServiceApi_ListSourceProjects_Call {
 	return &CloudMigrationServiceApi_ListSourceProjects_Call{Call: _e.mock.On("ListSourceProjects", ctx, orgId)}
 }
 
@@ -1080,7 +1080,7 @@ type CloudMigrationServiceApi_ListSourceProjectsExecute_Call struct {
 
 // ListSourceProjectsExecute is a helper method to define mock.On call
 //   - r admin.ListSourceProjectsApiRequest
-func (_e *CloudMigrationServiceApi_Expecter) ListSourceProjectsExecute(r interface{}) *CloudMigrationServiceApi_ListSourceProjectsExecute_Call {
+func (_e *CloudMigrationServiceApi_Expecter) ListSourceProjectsExecute(r any) *CloudMigrationServiceApi_ListSourceProjectsExecute_Call {
 	return &CloudMigrationServiceApi_ListSourceProjectsExecute_Call{Call: _e.mock.On("ListSourceProjectsExecute", r)}
 }
 
@@ -1127,7 +1127,7 @@ type CloudMigrationServiceApi_ListSourceProjectsWithParams_Call struct {
 // ListSourceProjectsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListSourceProjectsApiParams
-func (_e *CloudMigrationServiceApi_Expecter) ListSourceProjectsWithParams(ctx interface{}, args interface{}) *CloudMigrationServiceApi_ListSourceProjectsWithParams_Call {
+func (_e *CloudMigrationServiceApi_Expecter) ListSourceProjectsWithParams(ctx any, args any) *CloudMigrationServiceApi_ListSourceProjectsWithParams_Call {
 	return &CloudMigrationServiceApi_ListSourceProjectsWithParams_Call{Call: _e.mock.On("ListSourceProjectsWithParams", ctx, args)}
 }
 
@@ -1175,7 +1175,7 @@ type CloudMigrationServiceApi_ValidateMigration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - liveMigrationRequest20240530 *admin.LiveMigrationRequest20240530
-func (_e *CloudMigrationServiceApi_Expecter) ValidateMigration(ctx interface{}, groupId interface{}, liveMigrationRequest20240530 interface{}) *CloudMigrationServiceApi_ValidateMigration_Call {
+func (_e *CloudMigrationServiceApi_Expecter) ValidateMigration(ctx any, groupId any, liveMigrationRequest20240530 any) *CloudMigrationServiceApi_ValidateMigration_Call {
 	return &CloudMigrationServiceApi_ValidateMigration_Call{Call: _e.mock.On("ValidateMigration", ctx, groupId, liveMigrationRequest20240530)}
 }
 
@@ -1242,7 +1242,7 @@ type CloudMigrationServiceApi_ValidateMigrationExecute_Call struct {
 
 // ValidateMigrationExecute is a helper method to define mock.On call
 //   - r admin.ValidateMigrationApiRequest
-func (_e *CloudMigrationServiceApi_Expecter) ValidateMigrationExecute(r interface{}) *CloudMigrationServiceApi_ValidateMigrationExecute_Call {
+func (_e *CloudMigrationServiceApi_Expecter) ValidateMigrationExecute(r any) *CloudMigrationServiceApi_ValidateMigrationExecute_Call {
 	return &CloudMigrationServiceApi_ValidateMigrationExecute_Call{Call: _e.mock.On("ValidateMigrationExecute", r)}
 }
 
@@ -1289,7 +1289,7 @@ type CloudMigrationServiceApi_ValidateMigrationWithParams_Call struct {
 // ValidateMigrationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ValidateMigrationApiParams
-func (_e *CloudMigrationServiceApi_Expecter) ValidateMigrationWithParams(ctx interface{}, args interface{}) *CloudMigrationServiceApi_ValidateMigrationWithParams_Call {
+func (_e *CloudMigrationServiceApi_Expecter) ValidateMigrationWithParams(ctx any, args any) *CloudMigrationServiceApi_ValidateMigrationWithParams_Call {
 	return &CloudMigrationServiceApi_ValidateMigrationWithParams_Call{Call: _e.mock.On("ValidateMigrationWithParams", ctx, args)}
 }
 

--- a/mockadmin/cloud_provider_access_api.go
+++ b/mockadmin/cloud_provider_access_api.go
@@ -53,7 +53,7 @@ type CloudProviderAccessApi_AuthorizeCloudProviderAccessRole_Call struct {
 //   - groupId string
 //   - roleId string
 //   - cloudProviderAccessRoleRequestUpdate *admin.CloudProviderAccessRoleRequestUpdate
-func (_e *CloudProviderAccessApi_Expecter) AuthorizeCloudProviderAccessRole(ctx interface{}, groupId interface{}, roleId interface{}, cloudProviderAccessRoleRequestUpdate interface{}) *CloudProviderAccessApi_AuthorizeCloudProviderAccessRole_Call {
+func (_e *CloudProviderAccessApi_Expecter) AuthorizeCloudProviderAccessRole(ctx any, groupId any, roleId any, cloudProviderAccessRoleRequestUpdate any) *CloudProviderAccessApi_AuthorizeCloudProviderAccessRole_Call {
 	return &CloudProviderAccessApi_AuthorizeCloudProviderAccessRole_Call{Call: _e.mock.On("AuthorizeCloudProviderAccessRole", ctx, groupId, roleId, cloudProviderAccessRoleRequestUpdate)}
 }
 
@@ -120,7 +120,7 @@ type CloudProviderAccessApi_AuthorizeCloudProviderAccessRoleExecute_Call struct 
 
 // AuthorizeCloudProviderAccessRoleExecute is a helper method to define mock.On call
 //   - r admin.AuthorizeCloudProviderAccessRoleApiRequest
-func (_e *CloudProviderAccessApi_Expecter) AuthorizeCloudProviderAccessRoleExecute(r interface{}) *CloudProviderAccessApi_AuthorizeCloudProviderAccessRoleExecute_Call {
+func (_e *CloudProviderAccessApi_Expecter) AuthorizeCloudProviderAccessRoleExecute(r any) *CloudProviderAccessApi_AuthorizeCloudProviderAccessRoleExecute_Call {
 	return &CloudProviderAccessApi_AuthorizeCloudProviderAccessRoleExecute_Call{Call: _e.mock.On("AuthorizeCloudProviderAccessRoleExecute", r)}
 }
 
@@ -167,7 +167,7 @@ type CloudProviderAccessApi_AuthorizeCloudProviderAccessRoleWithParams_Call stru
 // AuthorizeCloudProviderAccessRoleWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.AuthorizeCloudProviderAccessRoleApiParams
-func (_e *CloudProviderAccessApi_Expecter) AuthorizeCloudProviderAccessRoleWithParams(ctx interface{}, args interface{}) *CloudProviderAccessApi_AuthorizeCloudProviderAccessRoleWithParams_Call {
+func (_e *CloudProviderAccessApi_Expecter) AuthorizeCloudProviderAccessRoleWithParams(ctx any, args any) *CloudProviderAccessApi_AuthorizeCloudProviderAccessRoleWithParams_Call {
 	return &CloudProviderAccessApi_AuthorizeCloudProviderAccessRoleWithParams_Call{Call: _e.mock.On("AuthorizeCloudProviderAccessRoleWithParams", ctx, args)}
 }
 
@@ -215,7 +215,7 @@ type CloudProviderAccessApi_CreateCloudProviderAccessRole_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - cloudProviderAccessRoleRequest *admin.CloudProviderAccessRoleRequest
-func (_e *CloudProviderAccessApi_Expecter) CreateCloudProviderAccessRole(ctx interface{}, groupId interface{}, cloudProviderAccessRoleRequest interface{}) *CloudProviderAccessApi_CreateCloudProviderAccessRole_Call {
+func (_e *CloudProviderAccessApi_Expecter) CreateCloudProviderAccessRole(ctx any, groupId any, cloudProviderAccessRoleRequest any) *CloudProviderAccessApi_CreateCloudProviderAccessRole_Call {
 	return &CloudProviderAccessApi_CreateCloudProviderAccessRole_Call{Call: _e.mock.On("CreateCloudProviderAccessRole", ctx, groupId, cloudProviderAccessRoleRequest)}
 }
 
@@ -282,7 +282,7 @@ type CloudProviderAccessApi_CreateCloudProviderAccessRoleExecute_Call struct {
 
 // CreateCloudProviderAccessRoleExecute is a helper method to define mock.On call
 //   - r admin.CreateCloudProviderAccessRoleApiRequest
-func (_e *CloudProviderAccessApi_Expecter) CreateCloudProviderAccessRoleExecute(r interface{}) *CloudProviderAccessApi_CreateCloudProviderAccessRoleExecute_Call {
+func (_e *CloudProviderAccessApi_Expecter) CreateCloudProviderAccessRoleExecute(r any) *CloudProviderAccessApi_CreateCloudProviderAccessRoleExecute_Call {
 	return &CloudProviderAccessApi_CreateCloudProviderAccessRoleExecute_Call{Call: _e.mock.On("CreateCloudProviderAccessRoleExecute", r)}
 }
 
@@ -329,7 +329,7 @@ type CloudProviderAccessApi_CreateCloudProviderAccessRoleWithParams_Call struct 
 // CreateCloudProviderAccessRoleWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateCloudProviderAccessRoleApiParams
-func (_e *CloudProviderAccessApi_Expecter) CreateCloudProviderAccessRoleWithParams(ctx interface{}, args interface{}) *CloudProviderAccessApi_CreateCloudProviderAccessRoleWithParams_Call {
+func (_e *CloudProviderAccessApi_Expecter) CreateCloudProviderAccessRoleWithParams(ctx any, args any) *CloudProviderAccessApi_CreateCloudProviderAccessRoleWithParams_Call {
 	return &CloudProviderAccessApi_CreateCloudProviderAccessRoleWithParams_Call{Call: _e.mock.On("CreateCloudProviderAccessRoleWithParams", ctx, args)}
 }
 
@@ -378,7 +378,7 @@ type CloudProviderAccessApi_DeauthorizeCloudProviderAccessRole_Call struct {
 //   - groupId string
 //   - cloudProvider string
 //   - roleId string
-func (_e *CloudProviderAccessApi_Expecter) DeauthorizeCloudProviderAccessRole(ctx interface{}, groupId interface{}, cloudProvider interface{}, roleId interface{}) *CloudProviderAccessApi_DeauthorizeCloudProviderAccessRole_Call {
+func (_e *CloudProviderAccessApi_Expecter) DeauthorizeCloudProviderAccessRole(ctx any, groupId any, cloudProvider any, roleId any) *CloudProviderAccessApi_DeauthorizeCloudProviderAccessRole_Call {
 	return &CloudProviderAccessApi_DeauthorizeCloudProviderAccessRole_Call{Call: _e.mock.On("DeauthorizeCloudProviderAccessRole", ctx, groupId, cloudProvider, roleId)}
 }
 
@@ -436,7 +436,7 @@ type CloudProviderAccessApi_DeauthorizeCloudProviderAccessRoleExecute_Call struc
 
 // DeauthorizeCloudProviderAccessRoleExecute is a helper method to define mock.On call
 //   - r admin.DeauthorizeCloudProviderAccessRoleApiRequest
-func (_e *CloudProviderAccessApi_Expecter) DeauthorizeCloudProviderAccessRoleExecute(r interface{}) *CloudProviderAccessApi_DeauthorizeCloudProviderAccessRoleExecute_Call {
+func (_e *CloudProviderAccessApi_Expecter) DeauthorizeCloudProviderAccessRoleExecute(r any) *CloudProviderAccessApi_DeauthorizeCloudProviderAccessRoleExecute_Call {
 	return &CloudProviderAccessApi_DeauthorizeCloudProviderAccessRoleExecute_Call{Call: _e.mock.On("DeauthorizeCloudProviderAccessRoleExecute", r)}
 }
 
@@ -483,7 +483,7 @@ type CloudProviderAccessApi_DeauthorizeCloudProviderAccessRoleWithParams_Call st
 // DeauthorizeCloudProviderAccessRoleWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeauthorizeCloudProviderAccessRoleApiParams
-func (_e *CloudProviderAccessApi_Expecter) DeauthorizeCloudProviderAccessRoleWithParams(ctx interface{}, args interface{}) *CloudProviderAccessApi_DeauthorizeCloudProviderAccessRoleWithParams_Call {
+func (_e *CloudProviderAccessApi_Expecter) DeauthorizeCloudProviderAccessRoleWithParams(ctx any, args any) *CloudProviderAccessApi_DeauthorizeCloudProviderAccessRoleWithParams_Call {
 	return &CloudProviderAccessApi_DeauthorizeCloudProviderAccessRoleWithParams_Call{Call: _e.mock.On("DeauthorizeCloudProviderAccessRoleWithParams", ctx, args)}
 }
 
@@ -531,7 +531,7 @@ type CloudProviderAccessApi_GetCloudProviderAccessRole_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - roleId string
-func (_e *CloudProviderAccessApi_Expecter) GetCloudProviderAccessRole(ctx interface{}, groupId interface{}, roleId interface{}) *CloudProviderAccessApi_GetCloudProviderAccessRole_Call {
+func (_e *CloudProviderAccessApi_Expecter) GetCloudProviderAccessRole(ctx any, groupId any, roleId any) *CloudProviderAccessApi_GetCloudProviderAccessRole_Call {
 	return &CloudProviderAccessApi_GetCloudProviderAccessRole_Call{Call: _e.mock.On("GetCloudProviderAccessRole", ctx, groupId, roleId)}
 }
 
@@ -598,7 +598,7 @@ type CloudProviderAccessApi_GetCloudProviderAccessRoleExecute_Call struct {
 
 // GetCloudProviderAccessRoleExecute is a helper method to define mock.On call
 //   - r admin.GetCloudProviderAccessRoleApiRequest
-func (_e *CloudProviderAccessApi_Expecter) GetCloudProviderAccessRoleExecute(r interface{}) *CloudProviderAccessApi_GetCloudProviderAccessRoleExecute_Call {
+func (_e *CloudProviderAccessApi_Expecter) GetCloudProviderAccessRoleExecute(r any) *CloudProviderAccessApi_GetCloudProviderAccessRoleExecute_Call {
 	return &CloudProviderAccessApi_GetCloudProviderAccessRoleExecute_Call{Call: _e.mock.On("GetCloudProviderAccessRoleExecute", r)}
 }
 
@@ -645,7 +645,7 @@ type CloudProviderAccessApi_GetCloudProviderAccessRoleWithParams_Call struct {
 // GetCloudProviderAccessRoleWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetCloudProviderAccessRoleApiParams
-func (_e *CloudProviderAccessApi_Expecter) GetCloudProviderAccessRoleWithParams(ctx interface{}, args interface{}) *CloudProviderAccessApi_GetCloudProviderAccessRoleWithParams_Call {
+func (_e *CloudProviderAccessApi_Expecter) GetCloudProviderAccessRoleWithParams(ctx any, args any) *CloudProviderAccessApi_GetCloudProviderAccessRoleWithParams_Call {
 	return &CloudProviderAccessApi_GetCloudProviderAccessRoleWithParams_Call{Call: _e.mock.On("GetCloudProviderAccessRoleWithParams", ctx, args)}
 }
 
@@ -692,7 +692,7 @@ type CloudProviderAccessApi_ListCloudProviderAccessRoles_Call struct {
 // ListCloudProviderAccessRoles is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *CloudProviderAccessApi_Expecter) ListCloudProviderAccessRoles(ctx interface{}, groupId interface{}) *CloudProviderAccessApi_ListCloudProviderAccessRoles_Call {
+func (_e *CloudProviderAccessApi_Expecter) ListCloudProviderAccessRoles(ctx any, groupId any) *CloudProviderAccessApi_ListCloudProviderAccessRoles_Call {
 	return &CloudProviderAccessApi_ListCloudProviderAccessRoles_Call{Call: _e.mock.On("ListCloudProviderAccessRoles", ctx, groupId)}
 }
 
@@ -759,7 +759,7 @@ type CloudProviderAccessApi_ListCloudProviderAccessRolesExecute_Call struct {
 
 // ListCloudProviderAccessRolesExecute is a helper method to define mock.On call
 //   - r admin.ListCloudProviderAccessRolesApiRequest
-func (_e *CloudProviderAccessApi_Expecter) ListCloudProviderAccessRolesExecute(r interface{}) *CloudProviderAccessApi_ListCloudProviderAccessRolesExecute_Call {
+func (_e *CloudProviderAccessApi_Expecter) ListCloudProviderAccessRolesExecute(r any) *CloudProviderAccessApi_ListCloudProviderAccessRolesExecute_Call {
 	return &CloudProviderAccessApi_ListCloudProviderAccessRolesExecute_Call{Call: _e.mock.On("ListCloudProviderAccessRolesExecute", r)}
 }
 
@@ -806,7 +806,7 @@ type CloudProviderAccessApi_ListCloudProviderAccessRolesWithParams_Call struct {
 // ListCloudProviderAccessRolesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListCloudProviderAccessRolesApiParams
-func (_e *CloudProviderAccessApi_Expecter) ListCloudProviderAccessRolesWithParams(ctx interface{}, args interface{}) *CloudProviderAccessApi_ListCloudProviderAccessRolesWithParams_Call {
+func (_e *CloudProviderAccessApi_Expecter) ListCloudProviderAccessRolesWithParams(ctx any, args any) *CloudProviderAccessApi_ListCloudProviderAccessRolesWithParams_Call {
 	return &CloudProviderAccessApi_ListCloudProviderAccessRolesWithParams_Call{Call: _e.mock.On("ListCloudProviderAccessRolesWithParams", ctx, args)}
 }
 

--- a/mockadmin/cluster_outage_simulation_api.go
+++ b/mockadmin/cluster_outage_simulation_api.go
@@ -52,7 +52,7 @@ type ClusterOutageSimulationApi_EndOutageSimulation_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *ClusterOutageSimulationApi_Expecter) EndOutageSimulation(ctx interface{}, groupId interface{}, clusterName interface{}) *ClusterOutageSimulationApi_EndOutageSimulation_Call {
+func (_e *ClusterOutageSimulationApi_Expecter) EndOutageSimulation(ctx any, groupId any, clusterName any) *ClusterOutageSimulationApi_EndOutageSimulation_Call {
 	return &ClusterOutageSimulationApi_EndOutageSimulation_Call{Call: _e.mock.On("EndOutageSimulation", ctx, groupId, clusterName)}
 }
 
@@ -119,7 +119,7 @@ type ClusterOutageSimulationApi_EndOutageSimulationExecute_Call struct {
 
 // EndOutageSimulationExecute is a helper method to define mock.On call
 //   - r admin.EndOutageSimulationApiRequest
-func (_e *ClusterOutageSimulationApi_Expecter) EndOutageSimulationExecute(r interface{}) *ClusterOutageSimulationApi_EndOutageSimulationExecute_Call {
+func (_e *ClusterOutageSimulationApi_Expecter) EndOutageSimulationExecute(r any) *ClusterOutageSimulationApi_EndOutageSimulationExecute_Call {
 	return &ClusterOutageSimulationApi_EndOutageSimulationExecute_Call{Call: _e.mock.On("EndOutageSimulationExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type ClusterOutageSimulationApi_EndOutageSimulationWithParams_Call struct {
 // EndOutageSimulationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.EndOutageSimulationApiParams
-func (_e *ClusterOutageSimulationApi_Expecter) EndOutageSimulationWithParams(ctx interface{}, args interface{}) *ClusterOutageSimulationApi_EndOutageSimulationWithParams_Call {
+func (_e *ClusterOutageSimulationApi_Expecter) EndOutageSimulationWithParams(ctx any, args any) *ClusterOutageSimulationApi_EndOutageSimulationWithParams_Call {
 	return &ClusterOutageSimulationApi_EndOutageSimulationWithParams_Call{Call: _e.mock.On("EndOutageSimulationWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type ClusterOutageSimulationApi_GetOutageSimulation_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *ClusterOutageSimulationApi_Expecter) GetOutageSimulation(ctx interface{}, groupId interface{}, clusterName interface{}) *ClusterOutageSimulationApi_GetOutageSimulation_Call {
+func (_e *ClusterOutageSimulationApi_Expecter) GetOutageSimulation(ctx any, groupId any, clusterName any) *ClusterOutageSimulationApi_GetOutageSimulation_Call {
 	return &ClusterOutageSimulationApi_GetOutageSimulation_Call{Call: _e.mock.On("GetOutageSimulation", ctx, groupId, clusterName)}
 }
 
@@ -281,7 +281,7 @@ type ClusterOutageSimulationApi_GetOutageSimulationExecute_Call struct {
 
 // GetOutageSimulationExecute is a helper method to define mock.On call
 //   - r admin.GetOutageSimulationApiRequest
-func (_e *ClusterOutageSimulationApi_Expecter) GetOutageSimulationExecute(r interface{}) *ClusterOutageSimulationApi_GetOutageSimulationExecute_Call {
+func (_e *ClusterOutageSimulationApi_Expecter) GetOutageSimulationExecute(r any) *ClusterOutageSimulationApi_GetOutageSimulationExecute_Call {
 	return &ClusterOutageSimulationApi_GetOutageSimulationExecute_Call{Call: _e.mock.On("GetOutageSimulationExecute", r)}
 }
 
@@ -328,7 +328,7 @@ type ClusterOutageSimulationApi_GetOutageSimulationWithParams_Call struct {
 // GetOutageSimulationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetOutageSimulationApiParams
-func (_e *ClusterOutageSimulationApi_Expecter) GetOutageSimulationWithParams(ctx interface{}, args interface{}) *ClusterOutageSimulationApi_GetOutageSimulationWithParams_Call {
+func (_e *ClusterOutageSimulationApi_Expecter) GetOutageSimulationWithParams(ctx any, args any) *ClusterOutageSimulationApi_GetOutageSimulationWithParams_Call {
 	return &ClusterOutageSimulationApi_GetOutageSimulationWithParams_Call{Call: _e.mock.On("GetOutageSimulationWithParams", ctx, args)}
 }
 
@@ -377,7 +377,7 @@ type ClusterOutageSimulationApi_StartOutageSimulation_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - clusterOutageSimulation *admin.ClusterOutageSimulation
-func (_e *ClusterOutageSimulationApi_Expecter) StartOutageSimulation(ctx interface{}, groupId interface{}, clusterName interface{}, clusterOutageSimulation interface{}) *ClusterOutageSimulationApi_StartOutageSimulation_Call {
+func (_e *ClusterOutageSimulationApi_Expecter) StartOutageSimulation(ctx any, groupId any, clusterName any, clusterOutageSimulation any) *ClusterOutageSimulationApi_StartOutageSimulation_Call {
 	return &ClusterOutageSimulationApi_StartOutageSimulation_Call{Call: _e.mock.On("StartOutageSimulation", ctx, groupId, clusterName, clusterOutageSimulation)}
 }
 
@@ -444,7 +444,7 @@ type ClusterOutageSimulationApi_StartOutageSimulationExecute_Call struct {
 
 // StartOutageSimulationExecute is a helper method to define mock.On call
 //   - r admin.StartOutageSimulationApiRequest
-func (_e *ClusterOutageSimulationApi_Expecter) StartOutageSimulationExecute(r interface{}) *ClusterOutageSimulationApi_StartOutageSimulationExecute_Call {
+func (_e *ClusterOutageSimulationApi_Expecter) StartOutageSimulationExecute(r any) *ClusterOutageSimulationApi_StartOutageSimulationExecute_Call {
 	return &ClusterOutageSimulationApi_StartOutageSimulationExecute_Call{Call: _e.mock.On("StartOutageSimulationExecute", r)}
 }
 
@@ -491,7 +491,7 @@ type ClusterOutageSimulationApi_StartOutageSimulationWithParams_Call struct {
 // StartOutageSimulationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.StartOutageSimulationApiParams
-func (_e *ClusterOutageSimulationApi_Expecter) StartOutageSimulationWithParams(ctx interface{}, args interface{}) *ClusterOutageSimulationApi_StartOutageSimulationWithParams_Call {
+func (_e *ClusterOutageSimulationApi_Expecter) StartOutageSimulationWithParams(ctx any, args any) *ClusterOutageSimulationApi_StartOutageSimulationWithParams_Call {
 	return &ClusterOutageSimulationApi_StartOutageSimulationWithParams_Call{Call: _e.mock.On("StartOutageSimulationWithParams", ctx, args)}
 }
 

--- a/mockadmin/clusters_api.go
+++ b/mockadmin/clusters_api.go
@@ -52,7 +52,7 @@ type ClustersApi_CreateCluster_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterDescription20240805 *admin.ClusterDescription20240805
-func (_e *ClustersApi_Expecter) CreateCluster(ctx interface{}, groupId interface{}, clusterDescription20240805 interface{}) *ClustersApi_CreateCluster_Call {
+func (_e *ClustersApi_Expecter) CreateCluster(ctx any, groupId any, clusterDescription20240805 any) *ClustersApi_CreateCluster_Call {
 	return &ClustersApi_CreateCluster_Call{Call: _e.mock.On("CreateCluster", ctx, groupId, clusterDescription20240805)}
 }
 
@@ -119,7 +119,7 @@ type ClustersApi_CreateClusterExecute_Call struct {
 
 // CreateClusterExecute is a helper method to define mock.On call
 //   - r admin.CreateClusterApiRequest
-func (_e *ClustersApi_Expecter) CreateClusterExecute(r interface{}) *ClustersApi_CreateClusterExecute_Call {
+func (_e *ClustersApi_Expecter) CreateClusterExecute(r any) *ClustersApi_CreateClusterExecute_Call {
 	return &ClustersApi_CreateClusterExecute_Call{Call: _e.mock.On("CreateClusterExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type ClustersApi_CreateClusterWithParams_Call struct {
 // CreateClusterWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateClusterApiParams
-func (_e *ClustersApi_Expecter) CreateClusterWithParams(ctx interface{}, args interface{}) *ClustersApi_CreateClusterWithParams_Call {
+func (_e *ClustersApi_Expecter) CreateClusterWithParams(ctx any, args any) *ClustersApi_CreateClusterWithParams_Call {
 	return &ClustersApi_CreateClusterWithParams_Call{Call: _e.mock.On("CreateClusterWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type ClustersApi_DeleteCluster_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *ClustersApi_Expecter) DeleteCluster(ctx interface{}, groupId interface{}, clusterName interface{}) *ClustersApi_DeleteCluster_Call {
+func (_e *ClustersApi_Expecter) DeleteCluster(ctx any, groupId any, clusterName any) *ClustersApi_DeleteCluster_Call {
 	return &ClustersApi_DeleteCluster_Call{Call: _e.mock.On("DeleteCluster", ctx, groupId, clusterName)}
 }
 
@@ -272,7 +272,7 @@ type ClustersApi_DeleteClusterExecute_Call struct {
 
 // DeleteClusterExecute is a helper method to define mock.On call
 //   - r admin.DeleteClusterApiRequest
-func (_e *ClustersApi_Expecter) DeleteClusterExecute(r interface{}) *ClustersApi_DeleteClusterExecute_Call {
+func (_e *ClustersApi_Expecter) DeleteClusterExecute(r any) *ClustersApi_DeleteClusterExecute_Call {
 	return &ClustersApi_DeleteClusterExecute_Call{Call: _e.mock.On("DeleteClusterExecute", r)}
 }
 
@@ -319,7 +319,7 @@ type ClustersApi_DeleteClusterWithParams_Call struct {
 // DeleteClusterWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteClusterApiParams
-func (_e *ClustersApi_Expecter) DeleteClusterWithParams(ctx interface{}, args interface{}) *ClustersApi_DeleteClusterWithParams_Call {
+func (_e *ClustersApi_Expecter) DeleteClusterWithParams(ctx any, args any) *ClustersApi_DeleteClusterWithParams_Call {
 	return &ClustersApi_DeleteClusterWithParams_Call{Call: _e.mock.On("DeleteClusterWithParams", ctx, args)}
 }
 
@@ -367,7 +367,7 @@ type ClustersApi_GetCluster_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *ClustersApi_Expecter) GetCluster(ctx interface{}, groupId interface{}, clusterName interface{}) *ClustersApi_GetCluster_Call {
+func (_e *ClustersApi_Expecter) GetCluster(ctx any, groupId any, clusterName any) *ClustersApi_GetCluster_Call {
 	return &ClustersApi_GetCluster_Call{Call: _e.mock.On("GetCluster", ctx, groupId, clusterName)}
 }
 
@@ -415,7 +415,7 @@ type ClustersApi_GetClusterAdvancedConfiguration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *ClustersApi_Expecter) GetClusterAdvancedConfiguration(ctx interface{}, groupId interface{}, clusterName interface{}) *ClustersApi_GetClusterAdvancedConfiguration_Call {
+func (_e *ClustersApi_Expecter) GetClusterAdvancedConfiguration(ctx any, groupId any, clusterName any) *ClustersApi_GetClusterAdvancedConfiguration_Call {
 	return &ClustersApi_GetClusterAdvancedConfiguration_Call{Call: _e.mock.On("GetClusterAdvancedConfiguration", ctx, groupId, clusterName)}
 }
 
@@ -482,7 +482,7 @@ type ClustersApi_GetClusterAdvancedConfigurationExecute_Call struct {
 
 // GetClusterAdvancedConfigurationExecute is a helper method to define mock.On call
 //   - r admin.GetClusterAdvancedConfigurationApiRequest
-func (_e *ClustersApi_Expecter) GetClusterAdvancedConfigurationExecute(r interface{}) *ClustersApi_GetClusterAdvancedConfigurationExecute_Call {
+func (_e *ClustersApi_Expecter) GetClusterAdvancedConfigurationExecute(r any) *ClustersApi_GetClusterAdvancedConfigurationExecute_Call {
 	return &ClustersApi_GetClusterAdvancedConfigurationExecute_Call{Call: _e.mock.On("GetClusterAdvancedConfigurationExecute", r)}
 }
 
@@ -529,7 +529,7 @@ type ClustersApi_GetClusterAdvancedConfigurationWithParams_Call struct {
 // GetClusterAdvancedConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetClusterAdvancedConfigurationApiParams
-func (_e *ClustersApi_Expecter) GetClusterAdvancedConfigurationWithParams(ctx interface{}, args interface{}) *ClustersApi_GetClusterAdvancedConfigurationWithParams_Call {
+func (_e *ClustersApi_Expecter) GetClusterAdvancedConfigurationWithParams(ctx any, args any) *ClustersApi_GetClusterAdvancedConfigurationWithParams_Call {
 	return &ClustersApi_GetClusterAdvancedConfigurationWithParams_Call{Call: _e.mock.On("GetClusterAdvancedConfigurationWithParams", ctx, args)}
 }
 
@@ -596,7 +596,7 @@ type ClustersApi_GetClusterExecute_Call struct {
 
 // GetClusterExecute is a helper method to define mock.On call
 //   - r admin.GetClusterApiRequest
-func (_e *ClustersApi_Expecter) GetClusterExecute(r interface{}) *ClustersApi_GetClusterExecute_Call {
+func (_e *ClustersApi_Expecter) GetClusterExecute(r any) *ClustersApi_GetClusterExecute_Call {
 	return &ClustersApi_GetClusterExecute_Call{Call: _e.mock.On("GetClusterExecute", r)}
 }
 
@@ -644,7 +644,7 @@ type ClustersApi_GetClusterStatus_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *ClustersApi_Expecter) GetClusterStatus(ctx interface{}, groupId interface{}, clusterName interface{}) *ClustersApi_GetClusterStatus_Call {
+func (_e *ClustersApi_Expecter) GetClusterStatus(ctx any, groupId any, clusterName any) *ClustersApi_GetClusterStatus_Call {
 	return &ClustersApi_GetClusterStatus_Call{Call: _e.mock.On("GetClusterStatus", ctx, groupId, clusterName)}
 }
 
@@ -711,7 +711,7 @@ type ClustersApi_GetClusterStatusExecute_Call struct {
 
 // GetClusterStatusExecute is a helper method to define mock.On call
 //   - r admin.GetClusterStatusApiRequest
-func (_e *ClustersApi_Expecter) GetClusterStatusExecute(r interface{}) *ClustersApi_GetClusterStatusExecute_Call {
+func (_e *ClustersApi_Expecter) GetClusterStatusExecute(r any) *ClustersApi_GetClusterStatusExecute_Call {
 	return &ClustersApi_GetClusterStatusExecute_Call{Call: _e.mock.On("GetClusterStatusExecute", r)}
 }
 
@@ -758,7 +758,7 @@ type ClustersApi_GetClusterStatusWithParams_Call struct {
 // GetClusterStatusWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetClusterStatusApiParams
-func (_e *ClustersApi_Expecter) GetClusterStatusWithParams(ctx interface{}, args interface{}) *ClustersApi_GetClusterStatusWithParams_Call {
+func (_e *ClustersApi_Expecter) GetClusterStatusWithParams(ctx any, args any) *ClustersApi_GetClusterStatusWithParams_Call {
 	return &ClustersApi_GetClusterStatusWithParams_Call{Call: _e.mock.On("GetClusterStatusWithParams", ctx, args)}
 }
 
@@ -805,7 +805,7 @@ type ClustersApi_GetClusterWithParams_Call struct {
 // GetClusterWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetClusterApiParams
-func (_e *ClustersApi_Expecter) GetClusterWithParams(ctx interface{}, args interface{}) *ClustersApi_GetClusterWithParams_Call {
+func (_e *ClustersApi_Expecter) GetClusterWithParams(ctx any, args any) *ClustersApi_GetClusterWithParams_Call {
 	return &ClustersApi_GetClusterWithParams_Call{Call: _e.mock.On("GetClusterWithParams", ctx, args)}
 }
 
@@ -853,7 +853,7 @@ type ClustersApi_GetSampleDatasetLoadStatus_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - sampleDatasetId string
-func (_e *ClustersApi_Expecter) GetSampleDatasetLoadStatus(ctx interface{}, groupId interface{}, sampleDatasetId interface{}) *ClustersApi_GetSampleDatasetLoadStatus_Call {
+func (_e *ClustersApi_Expecter) GetSampleDatasetLoadStatus(ctx any, groupId any, sampleDatasetId any) *ClustersApi_GetSampleDatasetLoadStatus_Call {
 	return &ClustersApi_GetSampleDatasetLoadStatus_Call{Call: _e.mock.On("GetSampleDatasetLoadStatus", ctx, groupId, sampleDatasetId)}
 }
 
@@ -920,7 +920,7 @@ type ClustersApi_GetSampleDatasetLoadStatusExecute_Call struct {
 
 // GetSampleDatasetLoadStatusExecute is a helper method to define mock.On call
 //   - r admin.GetSampleDatasetLoadStatusApiRequest
-func (_e *ClustersApi_Expecter) GetSampleDatasetLoadStatusExecute(r interface{}) *ClustersApi_GetSampleDatasetLoadStatusExecute_Call {
+func (_e *ClustersApi_Expecter) GetSampleDatasetLoadStatusExecute(r any) *ClustersApi_GetSampleDatasetLoadStatusExecute_Call {
 	return &ClustersApi_GetSampleDatasetLoadStatusExecute_Call{Call: _e.mock.On("GetSampleDatasetLoadStatusExecute", r)}
 }
 
@@ -967,7 +967,7 @@ type ClustersApi_GetSampleDatasetLoadStatusWithParams_Call struct {
 // GetSampleDatasetLoadStatusWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetSampleDatasetLoadStatusApiParams
-func (_e *ClustersApi_Expecter) GetSampleDatasetLoadStatusWithParams(ctx interface{}, args interface{}) *ClustersApi_GetSampleDatasetLoadStatusWithParams_Call {
+func (_e *ClustersApi_Expecter) GetSampleDatasetLoadStatusWithParams(ctx any, args any) *ClustersApi_GetSampleDatasetLoadStatusWithParams_Call {
 	return &ClustersApi_GetSampleDatasetLoadStatusWithParams_Call{Call: _e.mock.On("GetSampleDatasetLoadStatusWithParams", ctx, args)}
 }
 
@@ -1016,7 +1016,7 @@ type ClustersApi_GrantMongoDBEmployeeAccess_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - employeeAccessGrant *admin.EmployeeAccessGrant
-func (_e *ClustersApi_Expecter) GrantMongoDBEmployeeAccess(ctx interface{}, groupId interface{}, clusterName interface{}, employeeAccessGrant interface{}) *ClustersApi_GrantMongoDBEmployeeAccess_Call {
+func (_e *ClustersApi_Expecter) GrantMongoDBEmployeeAccess(ctx any, groupId any, clusterName any, employeeAccessGrant any) *ClustersApi_GrantMongoDBEmployeeAccess_Call {
 	return &ClustersApi_GrantMongoDBEmployeeAccess_Call{Call: _e.mock.On("GrantMongoDBEmployeeAccess", ctx, groupId, clusterName, employeeAccessGrant)}
 }
 
@@ -1038,24 +1038,24 @@ func (_c *ClustersApi_GrantMongoDBEmployeeAccess_Call) RunAndReturn(run func(con
 }
 
 // GrantMongoDBEmployeeAccessExecute provides a mock function with given fields: r
-func (_m *ClustersApi) GrantMongoDBEmployeeAccessExecute(r admin.GrantMongoDBEmployeeAccessApiRequest) (interface{}, *http.Response, error) {
+func (_m *ClustersApi) GrantMongoDBEmployeeAccessExecute(r admin.GrantMongoDBEmployeeAccessApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GrantMongoDBEmployeeAccessExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.GrantMongoDBEmployeeAccessApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.GrantMongoDBEmployeeAccessApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.GrantMongoDBEmployeeAccessApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.GrantMongoDBEmployeeAccessApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -1083,7 +1083,7 @@ type ClustersApi_GrantMongoDBEmployeeAccessExecute_Call struct {
 
 // GrantMongoDBEmployeeAccessExecute is a helper method to define mock.On call
 //   - r admin.GrantMongoDBEmployeeAccessApiRequest
-func (_e *ClustersApi_Expecter) GrantMongoDBEmployeeAccessExecute(r interface{}) *ClustersApi_GrantMongoDBEmployeeAccessExecute_Call {
+func (_e *ClustersApi_Expecter) GrantMongoDBEmployeeAccessExecute(r any) *ClustersApi_GrantMongoDBEmployeeAccessExecute_Call {
 	return &ClustersApi_GrantMongoDBEmployeeAccessExecute_Call{Call: _e.mock.On("GrantMongoDBEmployeeAccessExecute", r)}
 }
 
@@ -1094,12 +1094,12 @@ func (_c *ClustersApi_GrantMongoDBEmployeeAccessExecute_Call) Run(run func(r adm
 	return _c
 }
 
-func (_c *ClustersApi_GrantMongoDBEmployeeAccessExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ClustersApi_GrantMongoDBEmployeeAccessExecute_Call {
+func (_c *ClustersApi_GrantMongoDBEmployeeAccessExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ClustersApi_GrantMongoDBEmployeeAccessExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ClustersApi_GrantMongoDBEmployeeAccessExecute_Call) RunAndReturn(run func(admin.GrantMongoDBEmployeeAccessApiRequest) (interface{}, *http.Response, error)) *ClustersApi_GrantMongoDBEmployeeAccessExecute_Call {
+func (_c *ClustersApi_GrantMongoDBEmployeeAccessExecute_Call) RunAndReturn(run func(admin.GrantMongoDBEmployeeAccessApiRequest) (any, *http.Response, error)) *ClustersApi_GrantMongoDBEmployeeAccessExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1130,7 +1130,7 @@ type ClustersApi_GrantMongoDBEmployeeAccessWithParams_Call struct {
 // GrantMongoDBEmployeeAccessWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GrantMongoDBEmployeeAccessApiParams
-func (_e *ClustersApi_Expecter) GrantMongoDBEmployeeAccessWithParams(ctx interface{}, args interface{}) *ClustersApi_GrantMongoDBEmployeeAccessWithParams_Call {
+func (_e *ClustersApi_Expecter) GrantMongoDBEmployeeAccessWithParams(ctx any, args any) *ClustersApi_GrantMongoDBEmployeeAccessWithParams_Call {
 	return &ClustersApi_GrantMongoDBEmployeeAccessWithParams_Call{Call: _e.mock.On("GrantMongoDBEmployeeAccessWithParams", ctx, args)}
 }
 
@@ -1177,7 +1177,7 @@ type ClustersApi_ListCloudProviderRegions_Call struct {
 // ListCloudProviderRegions is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ClustersApi_Expecter) ListCloudProviderRegions(ctx interface{}, groupId interface{}) *ClustersApi_ListCloudProviderRegions_Call {
+func (_e *ClustersApi_Expecter) ListCloudProviderRegions(ctx any, groupId any) *ClustersApi_ListCloudProviderRegions_Call {
 	return &ClustersApi_ListCloudProviderRegions_Call{Call: _e.mock.On("ListCloudProviderRegions", ctx, groupId)}
 }
 
@@ -1244,7 +1244,7 @@ type ClustersApi_ListCloudProviderRegionsExecute_Call struct {
 
 // ListCloudProviderRegionsExecute is a helper method to define mock.On call
 //   - r admin.ListCloudProviderRegionsApiRequest
-func (_e *ClustersApi_Expecter) ListCloudProviderRegionsExecute(r interface{}) *ClustersApi_ListCloudProviderRegionsExecute_Call {
+func (_e *ClustersApi_Expecter) ListCloudProviderRegionsExecute(r any) *ClustersApi_ListCloudProviderRegionsExecute_Call {
 	return &ClustersApi_ListCloudProviderRegionsExecute_Call{Call: _e.mock.On("ListCloudProviderRegionsExecute", r)}
 }
 
@@ -1291,7 +1291,7 @@ type ClustersApi_ListCloudProviderRegionsWithParams_Call struct {
 // ListCloudProviderRegionsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListCloudProviderRegionsApiParams
-func (_e *ClustersApi_Expecter) ListCloudProviderRegionsWithParams(ctx interface{}, args interface{}) *ClustersApi_ListCloudProviderRegionsWithParams_Call {
+func (_e *ClustersApi_Expecter) ListCloudProviderRegionsWithParams(ctx any, args any) *ClustersApi_ListCloudProviderRegionsWithParams_Call {
 	return &ClustersApi_ListCloudProviderRegionsWithParams_Call{Call: _e.mock.On("ListCloudProviderRegionsWithParams", ctx, args)}
 }
 
@@ -1338,7 +1338,7 @@ type ClustersApi_ListClusters_Call struct {
 // ListClusters is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ClustersApi_Expecter) ListClusters(ctx interface{}, groupId interface{}) *ClustersApi_ListClusters_Call {
+func (_e *ClustersApi_Expecter) ListClusters(ctx any, groupId any) *ClustersApi_ListClusters_Call {
 	return &ClustersApi_ListClusters_Call{Call: _e.mock.On("ListClusters", ctx, groupId)}
 }
 
@@ -1405,7 +1405,7 @@ type ClustersApi_ListClustersExecute_Call struct {
 
 // ListClustersExecute is a helper method to define mock.On call
 //   - r admin.ListClustersApiRequest
-func (_e *ClustersApi_Expecter) ListClustersExecute(r interface{}) *ClustersApi_ListClustersExecute_Call {
+func (_e *ClustersApi_Expecter) ListClustersExecute(r any) *ClustersApi_ListClustersExecute_Call {
 	return &ClustersApi_ListClustersExecute_Call{Call: _e.mock.On("ListClustersExecute", r)}
 }
 
@@ -1451,7 +1451,7 @@ type ClustersApi_ListClustersForAllProjects_Call struct {
 
 // ListClustersForAllProjects is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *ClustersApi_Expecter) ListClustersForAllProjects(ctx interface{}) *ClustersApi_ListClustersForAllProjects_Call {
+func (_e *ClustersApi_Expecter) ListClustersForAllProjects(ctx any) *ClustersApi_ListClustersForAllProjects_Call {
 	return &ClustersApi_ListClustersForAllProjects_Call{Call: _e.mock.On("ListClustersForAllProjects", ctx)}
 }
 
@@ -1518,7 +1518,7 @@ type ClustersApi_ListClustersForAllProjectsExecute_Call struct {
 
 // ListClustersForAllProjectsExecute is a helper method to define mock.On call
 //   - r admin.ListClustersForAllProjectsApiRequest
-func (_e *ClustersApi_Expecter) ListClustersForAllProjectsExecute(r interface{}) *ClustersApi_ListClustersForAllProjectsExecute_Call {
+func (_e *ClustersApi_Expecter) ListClustersForAllProjectsExecute(r any) *ClustersApi_ListClustersForAllProjectsExecute_Call {
 	return &ClustersApi_ListClustersForAllProjectsExecute_Call{Call: _e.mock.On("ListClustersForAllProjectsExecute", r)}
 }
 
@@ -1565,7 +1565,7 @@ type ClustersApi_ListClustersForAllProjectsWithParams_Call struct {
 // ListClustersForAllProjectsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListClustersForAllProjectsApiParams
-func (_e *ClustersApi_Expecter) ListClustersForAllProjectsWithParams(ctx interface{}, args interface{}) *ClustersApi_ListClustersForAllProjectsWithParams_Call {
+func (_e *ClustersApi_Expecter) ListClustersForAllProjectsWithParams(ctx any, args any) *ClustersApi_ListClustersForAllProjectsWithParams_Call {
 	return &ClustersApi_ListClustersForAllProjectsWithParams_Call{Call: _e.mock.On("ListClustersForAllProjectsWithParams", ctx, args)}
 }
 
@@ -1612,7 +1612,7 @@ type ClustersApi_ListClustersWithParams_Call struct {
 // ListClustersWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListClustersApiParams
-func (_e *ClustersApi_Expecter) ListClustersWithParams(ctx interface{}, args interface{}) *ClustersApi_ListClustersWithParams_Call {
+func (_e *ClustersApi_Expecter) ListClustersWithParams(ctx any, args any) *ClustersApi_ListClustersWithParams_Call {
 	return &ClustersApi_ListClustersWithParams_Call{Call: _e.mock.On("ListClustersWithParams", ctx, args)}
 }
 
@@ -1660,7 +1660,7 @@ type ClustersApi_LoadSampleDataset_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - name string
-func (_e *ClustersApi_Expecter) LoadSampleDataset(ctx interface{}, groupId interface{}, name interface{}) *ClustersApi_LoadSampleDataset_Call {
+func (_e *ClustersApi_Expecter) LoadSampleDataset(ctx any, groupId any, name any) *ClustersApi_LoadSampleDataset_Call {
 	return &ClustersApi_LoadSampleDataset_Call{Call: _e.mock.On("LoadSampleDataset", ctx, groupId, name)}
 }
 
@@ -1727,7 +1727,7 @@ type ClustersApi_LoadSampleDatasetExecute_Call struct {
 
 // LoadSampleDatasetExecute is a helper method to define mock.On call
 //   - r admin.LoadSampleDatasetApiRequest
-func (_e *ClustersApi_Expecter) LoadSampleDatasetExecute(r interface{}) *ClustersApi_LoadSampleDatasetExecute_Call {
+func (_e *ClustersApi_Expecter) LoadSampleDatasetExecute(r any) *ClustersApi_LoadSampleDatasetExecute_Call {
 	return &ClustersApi_LoadSampleDatasetExecute_Call{Call: _e.mock.On("LoadSampleDatasetExecute", r)}
 }
 
@@ -1774,7 +1774,7 @@ type ClustersApi_LoadSampleDatasetWithParams_Call struct {
 // LoadSampleDatasetWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.LoadSampleDatasetApiParams
-func (_e *ClustersApi_Expecter) LoadSampleDatasetWithParams(ctx interface{}, args interface{}) *ClustersApi_LoadSampleDatasetWithParams_Call {
+func (_e *ClustersApi_Expecter) LoadSampleDatasetWithParams(ctx any, args any) *ClustersApi_LoadSampleDatasetWithParams_Call {
 	return &ClustersApi_LoadSampleDatasetWithParams_Call{Call: _e.mock.On("LoadSampleDatasetWithParams", ctx, args)}
 }
 
@@ -1823,7 +1823,7 @@ type ClustersApi_PinFeatureCompatibilityVersion_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - pinFCV *admin.PinFCV
-func (_e *ClustersApi_Expecter) PinFeatureCompatibilityVersion(ctx interface{}, groupId interface{}, clusterName interface{}, pinFCV interface{}) *ClustersApi_PinFeatureCompatibilityVersion_Call {
+func (_e *ClustersApi_Expecter) PinFeatureCompatibilityVersion(ctx any, groupId any, clusterName any, pinFCV any) *ClustersApi_PinFeatureCompatibilityVersion_Call {
 	return &ClustersApi_PinFeatureCompatibilityVersion_Call{Call: _e.mock.On("PinFeatureCompatibilityVersion", ctx, groupId, clusterName, pinFCV)}
 }
 
@@ -1845,24 +1845,24 @@ func (_c *ClustersApi_PinFeatureCompatibilityVersion_Call) RunAndReturn(run func
 }
 
 // PinFeatureCompatibilityVersionExecute provides a mock function with given fields: r
-func (_m *ClustersApi) PinFeatureCompatibilityVersionExecute(r admin.PinFeatureCompatibilityVersionApiRequest) (interface{}, *http.Response, error) {
+func (_m *ClustersApi) PinFeatureCompatibilityVersionExecute(r admin.PinFeatureCompatibilityVersionApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PinFeatureCompatibilityVersionExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.PinFeatureCompatibilityVersionApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.PinFeatureCompatibilityVersionApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.PinFeatureCompatibilityVersionApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.PinFeatureCompatibilityVersionApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -1890,7 +1890,7 @@ type ClustersApi_PinFeatureCompatibilityVersionExecute_Call struct {
 
 // PinFeatureCompatibilityVersionExecute is a helper method to define mock.On call
 //   - r admin.PinFeatureCompatibilityVersionApiRequest
-func (_e *ClustersApi_Expecter) PinFeatureCompatibilityVersionExecute(r interface{}) *ClustersApi_PinFeatureCompatibilityVersionExecute_Call {
+func (_e *ClustersApi_Expecter) PinFeatureCompatibilityVersionExecute(r any) *ClustersApi_PinFeatureCompatibilityVersionExecute_Call {
 	return &ClustersApi_PinFeatureCompatibilityVersionExecute_Call{Call: _e.mock.On("PinFeatureCompatibilityVersionExecute", r)}
 }
 
@@ -1901,12 +1901,12 @@ func (_c *ClustersApi_PinFeatureCompatibilityVersionExecute_Call) Run(run func(r
 	return _c
 }
 
-func (_c *ClustersApi_PinFeatureCompatibilityVersionExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ClustersApi_PinFeatureCompatibilityVersionExecute_Call {
+func (_c *ClustersApi_PinFeatureCompatibilityVersionExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ClustersApi_PinFeatureCompatibilityVersionExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ClustersApi_PinFeatureCompatibilityVersionExecute_Call) RunAndReturn(run func(admin.PinFeatureCompatibilityVersionApiRequest) (interface{}, *http.Response, error)) *ClustersApi_PinFeatureCompatibilityVersionExecute_Call {
+func (_c *ClustersApi_PinFeatureCompatibilityVersionExecute_Call) RunAndReturn(run func(admin.PinFeatureCompatibilityVersionApiRequest) (any, *http.Response, error)) *ClustersApi_PinFeatureCompatibilityVersionExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1937,7 +1937,7 @@ type ClustersApi_PinFeatureCompatibilityVersionWithParams_Call struct {
 // PinFeatureCompatibilityVersionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.PinFeatureCompatibilityVersionApiParams
-func (_e *ClustersApi_Expecter) PinFeatureCompatibilityVersionWithParams(ctx interface{}, args interface{}) *ClustersApi_PinFeatureCompatibilityVersionWithParams_Call {
+func (_e *ClustersApi_Expecter) PinFeatureCompatibilityVersionWithParams(ctx any, args any) *ClustersApi_PinFeatureCompatibilityVersionWithParams_Call {
 	return &ClustersApi_PinFeatureCompatibilityVersionWithParams_Call{Call: _e.mock.On("PinFeatureCompatibilityVersionWithParams", ctx, args)}
 }
 
@@ -1985,7 +1985,7 @@ type ClustersApi_RevokeMongoDBEmployeeAccess_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *ClustersApi_Expecter) RevokeMongoDBEmployeeAccess(ctx interface{}, groupId interface{}, clusterName interface{}) *ClustersApi_RevokeMongoDBEmployeeAccess_Call {
+func (_e *ClustersApi_Expecter) RevokeMongoDBEmployeeAccess(ctx any, groupId any, clusterName any) *ClustersApi_RevokeMongoDBEmployeeAccess_Call {
 	return &ClustersApi_RevokeMongoDBEmployeeAccess_Call{Call: _e.mock.On("RevokeMongoDBEmployeeAccess", ctx, groupId, clusterName)}
 }
 
@@ -2007,24 +2007,24 @@ func (_c *ClustersApi_RevokeMongoDBEmployeeAccess_Call) RunAndReturn(run func(co
 }
 
 // RevokeMongoDBEmployeeAccessExecute provides a mock function with given fields: r
-func (_m *ClustersApi) RevokeMongoDBEmployeeAccessExecute(r admin.RevokeMongoDBEmployeeAccessApiRequest) (interface{}, *http.Response, error) {
+func (_m *ClustersApi) RevokeMongoDBEmployeeAccessExecute(r admin.RevokeMongoDBEmployeeAccessApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RevokeMongoDBEmployeeAccessExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.RevokeMongoDBEmployeeAccessApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.RevokeMongoDBEmployeeAccessApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.RevokeMongoDBEmployeeAccessApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.RevokeMongoDBEmployeeAccessApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -2052,7 +2052,7 @@ type ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call struct {
 
 // RevokeMongoDBEmployeeAccessExecute is a helper method to define mock.On call
 //   - r admin.RevokeMongoDBEmployeeAccessApiRequest
-func (_e *ClustersApi_Expecter) RevokeMongoDBEmployeeAccessExecute(r interface{}) *ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call {
+func (_e *ClustersApi_Expecter) RevokeMongoDBEmployeeAccessExecute(r any) *ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call {
 	return &ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call{Call: _e.mock.On("RevokeMongoDBEmployeeAccessExecute", r)}
 }
 
@@ -2063,12 +2063,12 @@ func (_c *ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call) Run(run func(r ad
 	return _c
 }
 
-func (_c *ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call {
+func (_c *ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call) RunAndReturn(run func(admin.RevokeMongoDBEmployeeAccessApiRequest) (interface{}, *http.Response, error)) *ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call {
+func (_c *ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call) RunAndReturn(run func(admin.RevokeMongoDBEmployeeAccessApiRequest) (any, *http.Response, error)) *ClustersApi_RevokeMongoDBEmployeeAccessExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2099,7 +2099,7 @@ type ClustersApi_RevokeMongoDBEmployeeAccessWithParams_Call struct {
 // RevokeMongoDBEmployeeAccessWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.RevokeMongoDBEmployeeAccessApiParams
-func (_e *ClustersApi_Expecter) RevokeMongoDBEmployeeAccessWithParams(ctx interface{}, args interface{}) *ClustersApi_RevokeMongoDBEmployeeAccessWithParams_Call {
+func (_e *ClustersApi_Expecter) RevokeMongoDBEmployeeAccessWithParams(ctx any, args any) *ClustersApi_RevokeMongoDBEmployeeAccessWithParams_Call {
 	return &ClustersApi_RevokeMongoDBEmployeeAccessWithParams_Call{Call: _e.mock.On("RevokeMongoDBEmployeeAccessWithParams", ctx, args)}
 }
 
@@ -2147,7 +2147,7 @@ type ClustersApi_TestFailover_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *ClustersApi_Expecter) TestFailover(ctx interface{}, groupId interface{}, clusterName interface{}) *ClustersApi_TestFailover_Call {
+func (_e *ClustersApi_Expecter) TestFailover(ctx any, groupId any, clusterName any) *ClustersApi_TestFailover_Call {
 	return &ClustersApi_TestFailover_Call{Call: _e.mock.On("TestFailover", ctx, groupId, clusterName)}
 }
 
@@ -2205,7 +2205,7 @@ type ClustersApi_TestFailoverExecute_Call struct {
 
 // TestFailoverExecute is a helper method to define mock.On call
 //   - r admin.TestFailoverApiRequest
-func (_e *ClustersApi_Expecter) TestFailoverExecute(r interface{}) *ClustersApi_TestFailoverExecute_Call {
+func (_e *ClustersApi_Expecter) TestFailoverExecute(r any) *ClustersApi_TestFailoverExecute_Call {
 	return &ClustersApi_TestFailoverExecute_Call{Call: _e.mock.On("TestFailoverExecute", r)}
 }
 
@@ -2252,7 +2252,7 @@ type ClustersApi_TestFailoverWithParams_Call struct {
 // TestFailoverWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.TestFailoverApiParams
-func (_e *ClustersApi_Expecter) TestFailoverWithParams(ctx interface{}, args interface{}) *ClustersApi_TestFailoverWithParams_Call {
+func (_e *ClustersApi_Expecter) TestFailoverWithParams(ctx any, args any) *ClustersApi_TestFailoverWithParams_Call {
 	return &ClustersApi_TestFailoverWithParams_Call{Call: _e.mock.On("TestFailoverWithParams", ctx, args)}
 }
 
@@ -2300,7 +2300,7 @@ type ClustersApi_UnpinFeatureCompatibilityVersion_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *ClustersApi_Expecter) UnpinFeatureCompatibilityVersion(ctx interface{}, groupId interface{}, clusterName interface{}) *ClustersApi_UnpinFeatureCompatibilityVersion_Call {
+func (_e *ClustersApi_Expecter) UnpinFeatureCompatibilityVersion(ctx any, groupId any, clusterName any) *ClustersApi_UnpinFeatureCompatibilityVersion_Call {
 	return &ClustersApi_UnpinFeatureCompatibilityVersion_Call{Call: _e.mock.On("UnpinFeatureCompatibilityVersion", ctx, groupId, clusterName)}
 }
 
@@ -2322,24 +2322,24 @@ func (_c *ClustersApi_UnpinFeatureCompatibilityVersion_Call) RunAndReturn(run fu
 }
 
 // UnpinFeatureCompatibilityVersionExecute provides a mock function with given fields: r
-func (_m *ClustersApi) UnpinFeatureCompatibilityVersionExecute(r admin.UnpinFeatureCompatibilityVersionApiRequest) (interface{}, *http.Response, error) {
+func (_m *ClustersApi) UnpinFeatureCompatibilityVersionExecute(r admin.UnpinFeatureCompatibilityVersionApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UnpinFeatureCompatibilityVersionExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.UnpinFeatureCompatibilityVersionApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.UnpinFeatureCompatibilityVersionApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.UnpinFeatureCompatibilityVersionApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.UnpinFeatureCompatibilityVersionApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -2367,7 +2367,7 @@ type ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call struct {
 
 // UnpinFeatureCompatibilityVersionExecute is a helper method to define mock.On call
 //   - r admin.UnpinFeatureCompatibilityVersionApiRequest
-func (_e *ClustersApi_Expecter) UnpinFeatureCompatibilityVersionExecute(r interface{}) *ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call {
+func (_e *ClustersApi_Expecter) UnpinFeatureCompatibilityVersionExecute(r any) *ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call {
 	return &ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call{Call: _e.mock.On("UnpinFeatureCompatibilityVersionExecute", r)}
 }
 
@@ -2378,12 +2378,12 @@ func (_c *ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call) Run(run func
 	return _c
 }
 
-func (_c *ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call {
+func (_c *ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call) RunAndReturn(run func(admin.UnpinFeatureCompatibilityVersionApiRequest) (interface{}, *http.Response, error)) *ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call {
+func (_c *ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call) RunAndReturn(run func(admin.UnpinFeatureCompatibilityVersionApiRequest) (any, *http.Response, error)) *ClustersApi_UnpinFeatureCompatibilityVersionExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2414,7 +2414,7 @@ type ClustersApi_UnpinFeatureCompatibilityVersionWithParams_Call struct {
 // UnpinFeatureCompatibilityVersionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UnpinFeatureCompatibilityVersionApiParams
-func (_e *ClustersApi_Expecter) UnpinFeatureCompatibilityVersionWithParams(ctx interface{}, args interface{}) *ClustersApi_UnpinFeatureCompatibilityVersionWithParams_Call {
+func (_e *ClustersApi_Expecter) UnpinFeatureCompatibilityVersionWithParams(ctx any, args any) *ClustersApi_UnpinFeatureCompatibilityVersionWithParams_Call {
 	return &ClustersApi_UnpinFeatureCompatibilityVersionWithParams_Call{Call: _e.mock.On("UnpinFeatureCompatibilityVersionWithParams", ctx, args)}
 }
 
@@ -2463,7 +2463,7 @@ type ClustersApi_UpdateCluster_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - clusterDescription20240805 *admin.ClusterDescription20240805
-func (_e *ClustersApi_Expecter) UpdateCluster(ctx interface{}, groupId interface{}, clusterName interface{}, clusterDescription20240805 interface{}) *ClustersApi_UpdateCluster_Call {
+func (_e *ClustersApi_Expecter) UpdateCluster(ctx any, groupId any, clusterName any, clusterDescription20240805 any) *ClustersApi_UpdateCluster_Call {
 	return &ClustersApi_UpdateCluster_Call{Call: _e.mock.On("UpdateCluster", ctx, groupId, clusterName, clusterDescription20240805)}
 }
 
@@ -2512,7 +2512,7 @@ type ClustersApi_UpdateClusterAdvancedConfiguration_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - clusterDescriptionProcessArgs20240805 *admin.ClusterDescriptionProcessArgs20240805
-func (_e *ClustersApi_Expecter) UpdateClusterAdvancedConfiguration(ctx interface{}, groupId interface{}, clusterName interface{}, clusterDescriptionProcessArgs20240805 interface{}) *ClustersApi_UpdateClusterAdvancedConfiguration_Call {
+func (_e *ClustersApi_Expecter) UpdateClusterAdvancedConfiguration(ctx any, groupId any, clusterName any, clusterDescriptionProcessArgs20240805 any) *ClustersApi_UpdateClusterAdvancedConfiguration_Call {
 	return &ClustersApi_UpdateClusterAdvancedConfiguration_Call{Call: _e.mock.On("UpdateClusterAdvancedConfiguration", ctx, groupId, clusterName, clusterDescriptionProcessArgs20240805)}
 }
 
@@ -2579,7 +2579,7 @@ type ClustersApi_UpdateClusterAdvancedConfigurationExecute_Call struct {
 
 // UpdateClusterAdvancedConfigurationExecute is a helper method to define mock.On call
 //   - r admin.UpdateClusterAdvancedConfigurationApiRequest
-func (_e *ClustersApi_Expecter) UpdateClusterAdvancedConfigurationExecute(r interface{}) *ClustersApi_UpdateClusterAdvancedConfigurationExecute_Call {
+func (_e *ClustersApi_Expecter) UpdateClusterAdvancedConfigurationExecute(r any) *ClustersApi_UpdateClusterAdvancedConfigurationExecute_Call {
 	return &ClustersApi_UpdateClusterAdvancedConfigurationExecute_Call{Call: _e.mock.On("UpdateClusterAdvancedConfigurationExecute", r)}
 }
 
@@ -2626,7 +2626,7 @@ type ClustersApi_UpdateClusterAdvancedConfigurationWithParams_Call struct {
 // UpdateClusterAdvancedConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateClusterAdvancedConfigurationApiParams
-func (_e *ClustersApi_Expecter) UpdateClusterAdvancedConfigurationWithParams(ctx interface{}, args interface{}) *ClustersApi_UpdateClusterAdvancedConfigurationWithParams_Call {
+func (_e *ClustersApi_Expecter) UpdateClusterAdvancedConfigurationWithParams(ctx any, args any) *ClustersApi_UpdateClusterAdvancedConfigurationWithParams_Call {
 	return &ClustersApi_UpdateClusterAdvancedConfigurationWithParams_Call{Call: _e.mock.On("UpdateClusterAdvancedConfigurationWithParams", ctx, args)}
 }
 
@@ -2693,7 +2693,7 @@ type ClustersApi_UpdateClusterExecute_Call struct {
 
 // UpdateClusterExecute is a helper method to define mock.On call
 //   - r admin.UpdateClusterApiRequest
-func (_e *ClustersApi_Expecter) UpdateClusterExecute(r interface{}) *ClustersApi_UpdateClusterExecute_Call {
+func (_e *ClustersApi_Expecter) UpdateClusterExecute(r any) *ClustersApi_UpdateClusterExecute_Call {
 	return &ClustersApi_UpdateClusterExecute_Call{Call: _e.mock.On("UpdateClusterExecute", r)}
 }
 
@@ -2740,7 +2740,7 @@ type ClustersApi_UpdateClusterWithParams_Call struct {
 // UpdateClusterWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateClusterApiParams
-func (_e *ClustersApi_Expecter) UpdateClusterWithParams(ctx interface{}, args interface{}) *ClustersApi_UpdateClusterWithParams_Call {
+func (_e *ClustersApi_Expecter) UpdateClusterWithParams(ctx any, args any) *ClustersApi_UpdateClusterWithParams_Call {
 	return &ClustersApi_UpdateClusterWithParams_Call{Call: _e.mock.On("UpdateClusterWithParams", ctx, args)}
 }
 
@@ -2788,7 +2788,7 @@ type ClustersApi_UpgradeSharedCluster_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - legacyAtlasTenantClusterUpgradeRequest *admin.LegacyAtlasTenantClusterUpgradeRequest
-func (_e *ClustersApi_Expecter) UpgradeSharedCluster(ctx interface{}, groupId interface{}, legacyAtlasTenantClusterUpgradeRequest interface{}) *ClustersApi_UpgradeSharedCluster_Call {
+func (_e *ClustersApi_Expecter) UpgradeSharedCluster(ctx any, groupId any, legacyAtlasTenantClusterUpgradeRequest any) *ClustersApi_UpgradeSharedCluster_Call {
 	return &ClustersApi_UpgradeSharedCluster_Call{Call: _e.mock.On("UpgradeSharedCluster", ctx, groupId, legacyAtlasTenantClusterUpgradeRequest)}
 }
 
@@ -2855,7 +2855,7 @@ type ClustersApi_UpgradeSharedClusterExecute_Call struct {
 
 // UpgradeSharedClusterExecute is a helper method to define mock.On call
 //   - r admin.UpgradeSharedClusterApiRequest
-func (_e *ClustersApi_Expecter) UpgradeSharedClusterExecute(r interface{}) *ClustersApi_UpgradeSharedClusterExecute_Call {
+func (_e *ClustersApi_Expecter) UpgradeSharedClusterExecute(r any) *ClustersApi_UpgradeSharedClusterExecute_Call {
 	return &ClustersApi_UpgradeSharedClusterExecute_Call{Call: _e.mock.On("UpgradeSharedClusterExecute", r)}
 }
 
@@ -2903,7 +2903,7 @@ type ClustersApi_UpgradeSharedClusterToServerless_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - serverlessInstanceDescription *admin.ServerlessInstanceDescription
-func (_e *ClustersApi_Expecter) UpgradeSharedClusterToServerless(ctx interface{}, groupId interface{}, serverlessInstanceDescription interface{}) *ClustersApi_UpgradeSharedClusterToServerless_Call {
+func (_e *ClustersApi_Expecter) UpgradeSharedClusterToServerless(ctx any, groupId any, serverlessInstanceDescription any) *ClustersApi_UpgradeSharedClusterToServerless_Call {
 	return &ClustersApi_UpgradeSharedClusterToServerless_Call{Call: _e.mock.On("UpgradeSharedClusterToServerless", ctx, groupId, serverlessInstanceDescription)}
 }
 
@@ -2970,7 +2970,7 @@ type ClustersApi_UpgradeSharedClusterToServerlessExecute_Call struct {
 
 // UpgradeSharedClusterToServerlessExecute is a helper method to define mock.On call
 //   - r admin.UpgradeSharedClusterToServerlessApiRequest
-func (_e *ClustersApi_Expecter) UpgradeSharedClusterToServerlessExecute(r interface{}) *ClustersApi_UpgradeSharedClusterToServerlessExecute_Call {
+func (_e *ClustersApi_Expecter) UpgradeSharedClusterToServerlessExecute(r any) *ClustersApi_UpgradeSharedClusterToServerlessExecute_Call {
 	return &ClustersApi_UpgradeSharedClusterToServerlessExecute_Call{Call: _e.mock.On("UpgradeSharedClusterToServerlessExecute", r)}
 }
 
@@ -3017,7 +3017,7 @@ type ClustersApi_UpgradeSharedClusterToServerlessWithParams_Call struct {
 // UpgradeSharedClusterToServerlessWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpgradeSharedClusterToServerlessApiParams
-func (_e *ClustersApi_Expecter) UpgradeSharedClusterToServerlessWithParams(ctx interface{}, args interface{}) *ClustersApi_UpgradeSharedClusterToServerlessWithParams_Call {
+func (_e *ClustersApi_Expecter) UpgradeSharedClusterToServerlessWithParams(ctx any, args any) *ClustersApi_UpgradeSharedClusterToServerlessWithParams_Call {
 	return &ClustersApi_UpgradeSharedClusterToServerlessWithParams_Call{Call: _e.mock.On("UpgradeSharedClusterToServerlessWithParams", ctx, args)}
 }
 
@@ -3064,7 +3064,7 @@ type ClustersApi_UpgradeSharedClusterWithParams_Call struct {
 // UpgradeSharedClusterWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpgradeSharedClusterApiParams
-func (_e *ClustersApi_Expecter) UpgradeSharedClusterWithParams(ctx interface{}, args interface{}) *ClustersApi_UpgradeSharedClusterWithParams_Call {
+func (_e *ClustersApi_Expecter) UpgradeSharedClusterWithParams(ctx any, args any) *ClustersApi_UpgradeSharedClusterWithParams_Call {
 	return &ClustersApi_UpgradeSharedClusterWithParams_Call{Call: _e.mock.On("UpgradeSharedClusterWithParams", ctx, args)}
 }
 

--- a/mockadmin/collection_level_metrics_api.go
+++ b/mockadmin/collection_level_metrics_api.go
@@ -55,7 +55,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceClusterMeasurements_C
 //   - clusterView string
 //   - databaseName string
 //   - collectionName string
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceClusterMeasurements(ctx interface{}, groupId interface{}, clusterName interface{}, clusterView interface{}, databaseName interface{}, collectionName interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceClusterMeasurements_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceClusterMeasurements(ctx any, groupId any, clusterName any, clusterView any, databaseName any, collectionName any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceClusterMeasurements_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceClusterMeasurements_Call{Call: _e.mock.On("GetCollStatsLatencyNamespaceClusterMeasurements", ctx, groupId, clusterName, clusterView, databaseName, collectionName)}
 }
 
@@ -122,7 +122,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceClusterMeasurementsEx
 
 // GetCollStatsLatencyNamespaceClusterMeasurementsExecute is a helper method to define mock.On call
 //   - r admin.GetCollStatsLatencyNamespaceClusterMeasurementsApiRequest
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceClusterMeasurementsExecute(r interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceClusterMeasurementsExecute_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceClusterMeasurementsExecute(r any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceClusterMeasurementsExecute_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceClusterMeasurementsExecute_Call{Call: _e.mock.On("GetCollStatsLatencyNamespaceClusterMeasurementsExecute", r)}
 }
 
@@ -169,7 +169,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceClusterMeasurementsWi
 // GetCollStatsLatencyNamespaceClusterMeasurementsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx interface{}, args interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceClusterMeasurementsWithParams_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx any, args any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceClusterMeasurementsWithParams_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceClusterMeasurementsWithParams_Call{Call: _e.mock.On("GetCollStatsLatencyNamespaceClusterMeasurementsWithParams", ctx, args)}
 }
 
@@ -219,7 +219,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceHostMeasurements_Call
 //   - processId string
 //   - databaseName string
 //   - collectionName string
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceHostMeasurements(ctx interface{}, groupId interface{}, processId interface{}, databaseName interface{}, collectionName interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceHostMeasurements_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceHostMeasurements(ctx any, groupId any, processId any, databaseName any, collectionName any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceHostMeasurements_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceHostMeasurements_Call{Call: _e.mock.On("GetCollStatsLatencyNamespaceHostMeasurements", ctx, groupId, processId, databaseName, collectionName)}
 }
 
@@ -286,7 +286,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceHostMeasurementsExecu
 
 // GetCollStatsLatencyNamespaceHostMeasurementsExecute is a helper method to define mock.On call
 //   - r admin.GetCollStatsLatencyNamespaceHostMeasurementsApiRequest
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceHostMeasurementsExecute(r interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceHostMeasurementsExecute_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceHostMeasurementsExecute(r any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceHostMeasurementsExecute_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceHostMeasurementsExecute_Call{Call: _e.mock.On("GetCollStatsLatencyNamespaceHostMeasurementsExecute", r)}
 }
 
@@ -333,7 +333,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceHostMeasurementsWithP
 // GetCollStatsLatencyNamespaceHostMeasurementsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetCollStatsLatencyNamespaceHostMeasurementsApiParams
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx interface{}, args interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceHostMeasurementsWithParams_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx any, args any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceHostMeasurementsWithParams_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceHostMeasurementsWithParams_Call{Call: _e.mock.On("GetCollStatsLatencyNamespaceHostMeasurementsWithParams", ctx, args)}
 }
 
@@ -380,7 +380,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetrics_Call struct {
 // GetCollStatsLatencyNamespaceMetrics is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceMetrics(ctx interface{}, groupId interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetrics_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceMetrics(ctx any, groupId any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetrics_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetrics_Call{Call: _e.mock.On("GetCollStatsLatencyNamespaceMetrics", ctx, groupId)}
 }
 
@@ -402,24 +402,24 @@ func (_c *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetrics_Call) Ru
 }
 
 // GetCollStatsLatencyNamespaceMetricsExecute provides a mock function with given fields: r
-func (_m *CollectionLevelMetricsApi) GetCollStatsLatencyNamespaceMetricsExecute(r admin.GetCollStatsLatencyNamespaceMetricsApiRequest) (interface{}, *http.Response, error) {
+func (_m *CollectionLevelMetricsApi) GetCollStatsLatencyNamespaceMetricsExecute(r admin.GetCollStatsLatencyNamespaceMetricsApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCollStatsLatencyNamespaceMetricsExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.GetCollStatsLatencyNamespaceMetricsApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.GetCollStatsLatencyNamespaceMetricsApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.GetCollStatsLatencyNamespaceMetricsApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.GetCollStatsLatencyNamespaceMetricsApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -447,7 +447,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_Call s
 
 // GetCollStatsLatencyNamespaceMetricsExecute is a helper method to define mock.On call
 //   - r admin.GetCollStatsLatencyNamespaceMetricsApiRequest
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceMetricsExecute(r interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceMetricsExecute(r any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_Call{Call: _e.mock.On("GetCollStatsLatencyNamespaceMetricsExecute", r)}
 }
 
@@ -458,12 +458,12 @@ func (_c *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_C
 	return _c
 }
 
-func (_c *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_Call {
+func (_c *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_Call) RunAndReturn(run func(admin.GetCollStatsLatencyNamespaceMetricsApiRequest) (interface{}, *http.Response, error)) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_Call {
+func (_c *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_Call) RunAndReturn(run func(admin.GetCollStatsLatencyNamespaceMetricsApiRequest) (any, *http.Response, error)) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -494,7 +494,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsWithParams_Cal
 // GetCollStatsLatencyNamespaceMetricsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetCollStatsLatencyNamespaceMetricsApiParams
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceMetricsWithParams(ctx interface{}, args interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsWithParams_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespaceMetricsWithParams(ctx any, args any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsWithParams_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespaceMetricsWithParams_Call{Call: _e.mock.On("GetCollStatsLatencyNamespaceMetricsWithParams", ctx, args)}
 }
 
@@ -543,7 +543,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForCluster_Call stru
 //   - groupId string
 //   - clusterName string
 //   - clusterView string
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespacesForCluster(ctx interface{}, groupId interface{}, clusterName interface{}, clusterView interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForCluster_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespacesForCluster(ctx any, groupId any, clusterName any, clusterView any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForCluster_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForCluster_Call{Call: _e.mock.On("GetCollStatsLatencyNamespacesForCluster", ctx, groupId, clusterName, clusterView)}
 }
 
@@ -610,7 +610,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForClusterExecute_Ca
 
 // GetCollStatsLatencyNamespacesForClusterExecute is a helper method to define mock.On call
 //   - r admin.GetCollStatsLatencyNamespacesForClusterApiRequest
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespacesForClusterExecute(r interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForClusterExecute_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespacesForClusterExecute(r any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForClusterExecute_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForClusterExecute_Call{Call: _e.mock.On("GetCollStatsLatencyNamespacesForClusterExecute", r)}
 }
 
@@ -657,7 +657,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForClusterWithParams
 // GetCollStatsLatencyNamespacesForClusterWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetCollStatsLatencyNamespacesForClusterApiParams
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespacesForClusterWithParams(ctx interface{}, args interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForClusterWithParams_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespacesForClusterWithParams(ctx any, args any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForClusterWithParams_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForClusterWithParams_Call{Call: _e.mock.On("GetCollStatsLatencyNamespacesForClusterWithParams", ctx, args)}
 }
 
@@ -705,7 +705,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForHost_Call struct 
 //   - ctx context.Context
 //   - groupId string
 //   - processId string
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespacesForHost(ctx interface{}, groupId interface{}, processId interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForHost_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespacesForHost(ctx any, groupId any, processId any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForHost_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForHost_Call{Call: _e.mock.On("GetCollStatsLatencyNamespacesForHost", ctx, groupId, processId)}
 }
 
@@ -772,7 +772,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForHostExecute_Call 
 
 // GetCollStatsLatencyNamespacesForHostExecute is a helper method to define mock.On call
 //   - r admin.GetCollStatsLatencyNamespacesForHostApiRequest
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespacesForHostExecute(r interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForHostExecute_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespacesForHostExecute(r any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForHostExecute_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForHostExecute_Call{Call: _e.mock.On("GetCollStatsLatencyNamespacesForHostExecute", r)}
 }
 
@@ -819,7 +819,7 @@ type CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForHostWithParams_Ca
 // GetCollStatsLatencyNamespacesForHostWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetCollStatsLatencyNamespacesForHostApiParams
-func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespacesForHostWithParams(ctx interface{}, args interface{}) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForHostWithParams_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetCollStatsLatencyNamespacesForHostWithParams(ctx any, args any) *CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForHostWithParams_Call {
 	return &CollectionLevelMetricsApi_GetCollStatsLatencyNamespacesForHostWithParams_Call{Call: _e.mock.On("GetCollStatsLatencyNamespacesForHostWithParams", ctx, args)}
 }
 
@@ -867,7 +867,7 @@ type CollectionLevelMetricsApi_GetPinnedNamespaces_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *CollectionLevelMetricsApi_Expecter) GetPinnedNamespaces(ctx interface{}, groupId interface{}, clusterName interface{}) *CollectionLevelMetricsApi_GetPinnedNamespaces_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetPinnedNamespaces(ctx any, groupId any, clusterName any) *CollectionLevelMetricsApi_GetPinnedNamespaces_Call {
 	return &CollectionLevelMetricsApi_GetPinnedNamespaces_Call{Call: _e.mock.On("GetPinnedNamespaces", ctx, groupId, clusterName)}
 }
 
@@ -934,7 +934,7 @@ type CollectionLevelMetricsApi_GetPinnedNamespacesExecute_Call struct {
 
 // GetPinnedNamespacesExecute is a helper method to define mock.On call
 //   - r admin.GetPinnedNamespacesApiRequest
-func (_e *CollectionLevelMetricsApi_Expecter) GetPinnedNamespacesExecute(r interface{}) *CollectionLevelMetricsApi_GetPinnedNamespacesExecute_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetPinnedNamespacesExecute(r any) *CollectionLevelMetricsApi_GetPinnedNamespacesExecute_Call {
 	return &CollectionLevelMetricsApi_GetPinnedNamespacesExecute_Call{Call: _e.mock.On("GetPinnedNamespacesExecute", r)}
 }
 
@@ -981,7 +981,7 @@ type CollectionLevelMetricsApi_GetPinnedNamespacesWithParams_Call struct {
 // GetPinnedNamespacesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetPinnedNamespacesApiParams
-func (_e *CollectionLevelMetricsApi_Expecter) GetPinnedNamespacesWithParams(ctx interface{}, args interface{}) *CollectionLevelMetricsApi_GetPinnedNamespacesWithParams_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) GetPinnedNamespacesWithParams(ctx any, args any) *CollectionLevelMetricsApi_GetPinnedNamespacesWithParams_Call {
 	return &CollectionLevelMetricsApi_GetPinnedNamespacesWithParams_Call{Call: _e.mock.On("GetPinnedNamespacesWithParams", ctx, args)}
 }
 
@@ -1030,7 +1030,7 @@ type CollectionLevelMetricsApi_PinNamespacesPatch_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - namespacesRequest *admin.NamespacesRequest
-func (_e *CollectionLevelMetricsApi_Expecter) PinNamespacesPatch(ctx interface{}, groupId interface{}, clusterName interface{}, namespacesRequest interface{}) *CollectionLevelMetricsApi_PinNamespacesPatch_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) PinNamespacesPatch(ctx any, groupId any, clusterName any, namespacesRequest any) *CollectionLevelMetricsApi_PinNamespacesPatch_Call {
 	return &CollectionLevelMetricsApi_PinNamespacesPatch_Call{Call: _e.mock.On("PinNamespacesPatch", ctx, groupId, clusterName, namespacesRequest)}
 }
 
@@ -1097,7 +1097,7 @@ type CollectionLevelMetricsApi_PinNamespacesPatchExecute_Call struct {
 
 // PinNamespacesPatchExecute is a helper method to define mock.On call
 //   - r admin.PinNamespacesPatchApiRequest
-func (_e *CollectionLevelMetricsApi_Expecter) PinNamespacesPatchExecute(r interface{}) *CollectionLevelMetricsApi_PinNamespacesPatchExecute_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) PinNamespacesPatchExecute(r any) *CollectionLevelMetricsApi_PinNamespacesPatchExecute_Call {
 	return &CollectionLevelMetricsApi_PinNamespacesPatchExecute_Call{Call: _e.mock.On("PinNamespacesPatchExecute", r)}
 }
 
@@ -1144,7 +1144,7 @@ type CollectionLevelMetricsApi_PinNamespacesPatchWithParams_Call struct {
 // PinNamespacesPatchWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.PinNamespacesPatchApiParams
-func (_e *CollectionLevelMetricsApi_Expecter) PinNamespacesPatchWithParams(ctx interface{}, args interface{}) *CollectionLevelMetricsApi_PinNamespacesPatchWithParams_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) PinNamespacesPatchWithParams(ctx any, args any) *CollectionLevelMetricsApi_PinNamespacesPatchWithParams_Call {
 	return &CollectionLevelMetricsApi_PinNamespacesPatchWithParams_Call{Call: _e.mock.On("PinNamespacesPatchWithParams", ctx, args)}
 }
 
@@ -1193,7 +1193,7 @@ type CollectionLevelMetricsApi_PinNamespacesPut_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - namespacesRequest *admin.NamespacesRequest
-func (_e *CollectionLevelMetricsApi_Expecter) PinNamespacesPut(ctx interface{}, groupId interface{}, clusterName interface{}, namespacesRequest interface{}) *CollectionLevelMetricsApi_PinNamespacesPut_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) PinNamespacesPut(ctx any, groupId any, clusterName any, namespacesRequest any) *CollectionLevelMetricsApi_PinNamespacesPut_Call {
 	return &CollectionLevelMetricsApi_PinNamespacesPut_Call{Call: _e.mock.On("PinNamespacesPut", ctx, groupId, clusterName, namespacesRequest)}
 }
 
@@ -1260,7 +1260,7 @@ type CollectionLevelMetricsApi_PinNamespacesPutExecute_Call struct {
 
 // PinNamespacesPutExecute is a helper method to define mock.On call
 //   - r admin.PinNamespacesPutApiRequest
-func (_e *CollectionLevelMetricsApi_Expecter) PinNamespacesPutExecute(r interface{}) *CollectionLevelMetricsApi_PinNamespacesPutExecute_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) PinNamespacesPutExecute(r any) *CollectionLevelMetricsApi_PinNamespacesPutExecute_Call {
 	return &CollectionLevelMetricsApi_PinNamespacesPutExecute_Call{Call: _e.mock.On("PinNamespacesPutExecute", r)}
 }
 
@@ -1307,7 +1307,7 @@ type CollectionLevelMetricsApi_PinNamespacesPutWithParams_Call struct {
 // PinNamespacesPutWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.PinNamespacesPutApiParams
-func (_e *CollectionLevelMetricsApi_Expecter) PinNamespacesPutWithParams(ctx interface{}, args interface{}) *CollectionLevelMetricsApi_PinNamespacesPutWithParams_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) PinNamespacesPutWithParams(ctx any, args any) *CollectionLevelMetricsApi_PinNamespacesPutWithParams_Call {
 	return &CollectionLevelMetricsApi_PinNamespacesPutWithParams_Call{Call: _e.mock.On("PinNamespacesPutWithParams", ctx, args)}
 }
 
@@ -1356,7 +1356,7 @@ type CollectionLevelMetricsApi_UnpinNamespaces_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - namespacesRequest *admin.NamespacesRequest
-func (_e *CollectionLevelMetricsApi_Expecter) UnpinNamespaces(ctx interface{}, groupId interface{}, clusterName interface{}, namespacesRequest interface{}) *CollectionLevelMetricsApi_UnpinNamespaces_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) UnpinNamespaces(ctx any, groupId any, clusterName any, namespacesRequest any) *CollectionLevelMetricsApi_UnpinNamespaces_Call {
 	return &CollectionLevelMetricsApi_UnpinNamespaces_Call{Call: _e.mock.On("UnpinNamespaces", ctx, groupId, clusterName, namespacesRequest)}
 }
 
@@ -1423,7 +1423,7 @@ type CollectionLevelMetricsApi_UnpinNamespacesExecute_Call struct {
 
 // UnpinNamespacesExecute is a helper method to define mock.On call
 //   - r admin.UnpinNamespacesApiRequest
-func (_e *CollectionLevelMetricsApi_Expecter) UnpinNamespacesExecute(r interface{}) *CollectionLevelMetricsApi_UnpinNamespacesExecute_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) UnpinNamespacesExecute(r any) *CollectionLevelMetricsApi_UnpinNamespacesExecute_Call {
 	return &CollectionLevelMetricsApi_UnpinNamespacesExecute_Call{Call: _e.mock.On("UnpinNamespacesExecute", r)}
 }
 
@@ -1470,7 +1470,7 @@ type CollectionLevelMetricsApi_UnpinNamespacesWithParams_Call struct {
 // UnpinNamespacesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UnpinNamespacesApiParams
-func (_e *CollectionLevelMetricsApi_Expecter) UnpinNamespacesWithParams(ctx interface{}, args interface{}) *CollectionLevelMetricsApi_UnpinNamespacesWithParams_Call {
+func (_e *CollectionLevelMetricsApi_Expecter) UnpinNamespacesWithParams(ctx any, args any) *CollectionLevelMetricsApi_UnpinNamespacesWithParams_Call {
 	return &CollectionLevelMetricsApi_UnpinNamespacesWithParams_Call{Call: _e.mock.On("UnpinNamespacesWithParams", ctx, args)}
 }
 

--- a/mockadmin/custom_database_roles_api.go
+++ b/mockadmin/custom_database_roles_api.go
@@ -52,7 +52,7 @@ type CustomDatabaseRolesApi_CreateCustomDatabaseRole_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - userCustomDBRole *admin.UserCustomDBRole
-func (_e *CustomDatabaseRolesApi_Expecter) CreateCustomDatabaseRole(ctx interface{}, groupId interface{}, userCustomDBRole interface{}) *CustomDatabaseRolesApi_CreateCustomDatabaseRole_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) CreateCustomDatabaseRole(ctx any, groupId any, userCustomDBRole any) *CustomDatabaseRolesApi_CreateCustomDatabaseRole_Call {
 	return &CustomDatabaseRolesApi_CreateCustomDatabaseRole_Call{Call: _e.mock.On("CreateCustomDatabaseRole", ctx, groupId, userCustomDBRole)}
 }
 
@@ -119,7 +119,7 @@ type CustomDatabaseRolesApi_CreateCustomDatabaseRoleExecute_Call struct {
 
 // CreateCustomDatabaseRoleExecute is a helper method to define mock.On call
 //   - r admin.CreateCustomDatabaseRoleApiRequest
-func (_e *CustomDatabaseRolesApi_Expecter) CreateCustomDatabaseRoleExecute(r interface{}) *CustomDatabaseRolesApi_CreateCustomDatabaseRoleExecute_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) CreateCustomDatabaseRoleExecute(r any) *CustomDatabaseRolesApi_CreateCustomDatabaseRoleExecute_Call {
 	return &CustomDatabaseRolesApi_CreateCustomDatabaseRoleExecute_Call{Call: _e.mock.On("CreateCustomDatabaseRoleExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type CustomDatabaseRolesApi_CreateCustomDatabaseRoleWithParams_Call struct {
 // CreateCustomDatabaseRoleWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateCustomDatabaseRoleApiParams
-func (_e *CustomDatabaseRolesApi_Expecter) CreateCustomDatabaseRoleWithParams(ctx interface{}, args interface{}) *CustomDatabaseRolesApi_CreateCustomDatabaseRoleWithParams_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) CreateCustomDatabaseRoleWithParams(ctx any, args any) *CustomDatabaseRolesApi_CreateCustomDatabaseRoleWithParams_Call {
 	return &CustomDatabaseRolesApi_CreateCustomDatabaseRoleWithParams_Call{Call: _e.mock.On("CreateCustomDatabaseRoleWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type CustomDatabaseRolesApi_DeleteCustomDatabaseRole_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - roleName string
-func (_e *CustomDatabaseRolesApi_Expecter) DeleteCustomDatabaseRole(ctx interface{}, groupId interface{}, roleName interface{}) *CustomDatabaseRolesApi_DeleteCustomDatabaseRole_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) DeleteCustomDatabaseRole(ctx any, groupId any, roleName any) *CustomDatabaseRolesApi_DeleteCustomDatabaseRole_Call {
 	return &CustomDatabaseRolesApi_DeleteCustomDatabaseRole_Call{Call: _e.mock.On("DeleteCustomDatabaseRole", ctx, groupId, roleName)}
 }
 
@@ -272,7 +272,7 @@ type CustomDatabaseRolesApi_DeleteCustomDatabaseRoleExecute_Call struct {
 
 // DeleteCustomDatabaseRoleExecute is a helper method to define mock.On call
 //   - r admin.DeleteCustomDatabaseRoleApiRequest
-func (_e *CustomDatabaseRolesApi_Expecter) DeleteCustomDatabaseRoleExecute(r interface{}) *CustomDatabaseRolesApi_DeleteCustomDatabaseRoleExecute_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) DeleteCustomDatabaseRoleExecute(r any) *CustomDatabaseRolesApi_DeleteCustomDatabaseRoleExecute_Call {
 	return &CustomDatabaseRolesApi_DeleteCustomDatabaseRoleExecute_Call{Call: _e.mock.On("DeleteCustomDatabaseRoleExecute", r)}
 }
 
@@ -319,7 +319,7 @@ type CustomDatabaseRolesApi_DeleteCustomDatabaseRoleWithParams_Call struct {
 // DeleteCustomDatabaseRoleWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteCustomDatabaseRoleApiParams
-func (_e *CustomDatabaseRolesApi_Expecter) DeleteCustomDatabaseRoleWithParams(ctx interface{}, args interface{}) *CustomDatabaseRolesApi_DeleteCustomDatabaseRoleWithParams_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) DeleteCustomDatabaseRoleWithParams(ctx any, args any) *CustomDatabaseRolesApi_DeleteCustomDatabaseRoleWithParams_Call {
 	return &CustomDatabaseRolesApi_DeleteCustomDatabaseRoleWithParams_Call{Call: _e.mock.On("DeleteCustomDatabaseRoleWithParams", ctx, args)}
 }
 
@@ -367,7 +367,7 @@ type CustomDatabaseRolesApi_GetCustomDatabaseRole_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - roleName string
-func (_e *CustomDatabaseRolesApi_Expecter) GetCustomDatabaseRole(ctx interface{}, groupId interface{}, roleName interface{}) *CustomDatabaseRolesApi_GetCustomDatabaseRole_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) GetCustomDatabaseRole(ctx any, groupId any, roleName any) *CustomDatabaseRolesApi_GetCustomDatabaseRole_Call {
 	return &CustomDatabaseRolesApi_GetCustomDatabaseRole_Call{Call: _e.mock.On("GetCustomDatabaseRole", ctx, groupId, roleName)}
 }
 
@@ -434,7 +434,7 @@ type CustomDatabaseRolesApi_GetCustomDatabaseRoleExecute_Call struct {
 
 // GetCustomDatabaseRoleExecute is a helper method to define mock.On call
 //   - r admin.GetCustomDatabaseRoleApiRequest
-func (_e *CustomDatabaseRolesApi_Expecter) GetCustomDatabaseRoleExecute(r interface{}) *CustomDatabaseRolesApi_GetCustomDatabaseRoleExecute_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) GetCustomDatabaseRoleExecute(r any) *CustomDatabaseRolesApi_GetCustomDatabaseRoleExecute_Call {
 	return &CustomDatabaseRolesApi_GetCustomDatabaseRoleExecute_Call{Call: _e.mock.On("GetCustomDatabaseRoleExecute", r)}
 }
 
@@ -481,7 +481,7 @@ type CustomDatabaseRolesApi_GetCustomDatabaseRoleWithParams_Call struct {
 // GetCustomDatabaseRoleWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetCustomDatabaseRoleApiParams
-func (_e *CustomDatabaseRolesApi_Expecter) GetCustomDatabaseRoleWithParams(ctx interface{}, args interface{}) *CustomDatabaseRolesApi_GetCustomDatabaseRoleWithParams_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) GetCustomDatabaseRoleWithParams(ctx any, args any) *CustomDatabaseRolesApi_GetCustomDatabaseRoleWithParams_Call {
 	return &CustomDatabaseRolesApi_GetCustomDatabaseRoleWithParams_Call{Call: _e.mock.On("GetCustomDatabaseRoleWithParams", ctx, args)}
 }
 
@@ -528,7 +528,7 @@ type CustomDatabaseRolesApi_ListCustomDatabaseRoles_Call struct {
 // ListCustomDatabaseRoles is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *CustomDatabaseRolesApi_Expecter) ListCustomDatabaseRoles(ctx interface{}, groupId interface{}) *CustomDatabaseRolesApi_ListCustomDatabaseRoles_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) ListCustomDatabaseRoles(ctx any, groupId any) *CustomDatabaseRolesApi_ListCustomDatabaseRoles_Call {
 	return &CustomDatabaseRolesApi_ListCustomDatabaseRoles_Call{Call: _e.mock.On("ListCustomDatabaseRoles", ctx, groupId)}
 }
 
@@ -595,7 +595,7 @@ type CustomDatabaseRolesApi_ListCustomDatabaseRolesExecute_Call struct {
 
 // ListCustomDatabaseRolesExecute is a helper method to define mock.On call
 //   - r admin.ListCustomDatabaseRolesApiRequest
-func (_e *CustomDatabaseRolesApi_Expecter) ListCustomDatabaseRolesExecute(r interface{}) *CustomDatabaseRolesApi_ListCustomDatabaseRolesExecute_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) ListCustomDatabaseRolesExecute(r any) *CustomDatabaseRolesApi_ListCustomDatabaseRolesExecute_Call {
 	return &CustomDatabaseRolesApi_ListCustomDatabaseRolesExecute_Call{Call: _e.mock.On("ListCustomDatabaseRolesExecute", r)}
 }
 
@@ -642,7 +642,7 @@ type CustomDatabaseRolesApi_ListCustomDatabaseRolesWithParams_Call struct {
 // ListCustomDatabaseRolesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListCustomDatabaseRolesApiParams
-func (_e *CustomDatabaseRolesApi_Expecter) ListCustomDatabaseRolesWithParams(ctx interface{}, args interface{}) *CustomDatabaseRolesApi_ListCustomDatabaseRolesWithParams_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) ListCustomDatabaseRolesWithParams(ctx any, args any) *CustomDatabaseRolesApi_ListCustomDatabaseRolesWithParams_Call {
 	return &CustomDatabaseRolesApi_ListCustomDatabaseRolesWithParams_Call{Call: _e.mock.On("ListCustomDatabaseRolesWithParams", ctx, args)}
 }
 
@@ -691,7 +691,7 @@ type CustomDatabaseRolesApi_UpdateCustomDatabaseRole_Call struct {
 //   - groupId string
 //   - roleName string
 //   - updateCustomDBRole *admin.UpdateCustomDBRole
-func (_e *CustomDatabaseRolesApi_Expecter) UpdateCustomDatabaseRole(ctx interface{}, groupId interface{}, roleName interface{}, updateCustomDBRole interface{}) *CustomDatabaseRolesApi_UpdateCustomDatabaseRole_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) UpdateCustomDatabaseRole(ctx any, groupId any, roleName any, updateCustomDBRole any) *CustomDatabaseRolesApi_UpdateCustomDatabaseRole_Call {
 	return &CustomDatabaseRolesApi_UpdateCustomDatabaseRole_Call{Call: _e.mock.On("UpdateCustomDatabaseRole", ctx, groupId, roleName, updateCustomDBRole)}
 }
 
@@ -758,7 +758,7 @@ type CustomDatabaseRolesApi_UpdateCustomDatabaseRoleExecute_Call struct {
 
 // UpdateCustomDatabaseRoleExecute is a helper method to define mock.On call
 //   - r admin.UpdateCustomDatabaseRoleApiRequest
-func (_e *CustomDatabaseRolesApi_Expecter) UpdateCustomDatabaseRoleExecute(r interface{}) *CustomDatabaseRolesApi_UpdateCustomDatabaseRoleExecute_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) UpdateCustomDatabaseRoleExecute(r any) *CustomDatabaseRolesApi_UpdateCustomDatabaseRoleExecute_Call {
 	return &CustomDatabaseRolesApi_UpdateCustomDatabaseRoleExecute_Call{Call: _e.mock.On("UpdateCustomDatabaseRoleExecute", r)}
 }
 
@@ -805,7 +805,7 @@ type CustomDatabaseRolesApi_UpdateCustomDatabaseRoleWithParams_Call struct {
 // UpdateCustomDatabaseRoleWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateCustomDatabaseRoleApiParams
-func (_e *CustomDatabaseRolesApi_Expecter) UpdateCustomDatabaseRoleWithParams(ctx interface{}, args interface{}) *CustomDatabaseRolesApi_UpdateCustomDatabaseRoleWithParams_Call {
+func (_e *CustomDatabaseRolesApi_Expecter) UpdateCustomDatabaseRoleWithParams(ctx any, args any) *CustomDatabaseRolesApi_UpdateCustomDatabaseRoleWithParams_Call {
 	return &CustomDatabaseRolesApi_UpdateCustomDatabaseRoleWithParams_Call{Call: _e.mock.On("UpdateCustomDatabaseRoleWithParams", ctx, args)}
 }
 

--- a/mockadmin/data_federation_api.go
+++ b/mockadmin/data_federation_api.go
@@ -54,7 +54,7 @@ type DataFederationApi_CreateDataFederationPrivateEndpoint_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - privateNetworkEndpointIdEntry *admin.PrivateNetworkEndpointIdEntry
-func (_e *DataFederationApi_Expecter) CreateDataFederationPrivateEndpoint(ctx interface{}, groupId interface{}, privateNetworkEndpointIdEntry interface{}) *DataFederationApi_CreateDataFederationPrivateEndpoint_Call {
+func (_e *DataFederationApi_Expecter) CreateDataFederationPrivateEndpoint(ctx any, groupId any, privateNetworkEndpointIdEntry any) *DataFederationApi_CreateDataFederationPrivateEndpoint_Call {
 	return &DataFederationApi_CreateDataFederationPrivateEndpoint_Call{Call: _e.mock.On("CreateDataFederationPrivateEndpoint", ctx, groupId, privateNetworkEndpointIdEntry)}
 }
 
@@ -121,7 +121,7 @@ type DataFederationApi_CreateDataFederationPrivateEndpointExecute_Call struct {
 
 // CreateDataFederationPrivateEndpointExecute is a helper method to define mock.On call
 //   - r admin.CreateDataFederationPrivateEndpointApiRequest
-func (_e *DataFederationApi_Expecter) CreateDataFederationPrivateEndpointExecute(r interface{}) *DataFederationApi_CreateDataFederationPrivateEndpointExecute_Call {
+func (_e *DataFederationApi_Expecter) CreateDataFederationPrivateEndpointExecute(r any) *DataFederationApi_CreateDataFederationPrivateEndpointExecute_Call {
 	return &DataFederationApi_CreateDataFederationPrivateEndpointExecute_Call{Call: _e.mock.On("CreateDataFederationPrivateEndpointExecute", r)}
 }
 
@@ -168,7 +168,7 @@ type DataFederationApi_CreateDataFederationPrivateEndpointWithParams_Call struct
 // CreateDataFederationPrivateEndpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateDataFederationPrivateEndpointApiParams
-func (_e *DataFederationApi_Expecter) CreateDataFederationPrivateEndpointWithParams(ctx interface{}, args interface{}) *DataFederationApi_CreateDataFederationPrivateEndpointWithParams_Call {
+func (_e *DataFederationApi_Expecter) CreateDataFederationPrivateEndpointWithParams(ctx any, args any) *DataFederationApi_CreateDataFederationPrivateEndpointWithParams_Call {
 	return &DataFederationApi_CreateDataFederationPrivateEndpointWithParams_Call{Call: _e.mock.On("CreateDataFederationPrivateEndpointWithParams", ctx, args)}
 }
 
@@ -216,7 +216,7 @@ type DataFederationApi_CreateFederatedDatabase_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - dataLakeTenant *admin.DataLakeTenant
-func (_e *DataFederationApi_Expecter) CreateFederatedDatabase(ctx interface{}, groupId interface{}, dataLakeTenant interface{}) *DataFederationApi_CreateFederatedDatabase_Call {
+func (_e *DataFederationApi_Expecter) CreateFederatedDatabase(ctx any, groupId any, dataLakeTenant any) *DataFederationApi_CreateFederatedDatabase_Call {
 	return &DataFederationApi_CreateFederatedDatabase_Call{Call: _e.mock.On("CreateFederatedDatabase", ctx, groupId, dataLakeTenant)}
 }
 
@@ -283,7 +283,7 @@ type DataFederationApi_CreateFederatedDatabaseExecute_Call struct {
 
 // CreateFederatedDatabaseExecute is a helper method to define mock.On call
 //   - r admin.CreateFederatedDatabaseApiRequest
-func (_e *DataFederationApi_Expecter) CreateFederatedDatabaseExecute(r interface{}) *DataFederationApi_CreateFederatedDatabaseExecute_Call {
+func (_e *DataFederationApi_Expecter) CreateFederatedDatabaseExecute(r any) *DataFederationApi_CreateFederatedDatabaseExecute_Call {
 	return &DataFederationApi_CreateFederatedDatabaseExecute_Call{Call: _e.mock.On("CreateFederatedDatabaseExecute", r)}
 }
 
@@ -330,7 +330,7 @@ type DataFederationApi_CreateFederatedDatabaseWithParams_Call struct {
 // CreateFederatedDatabaseWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateFederatedDatabaseApiParams
-func (_e *DataFederationApi_Expecter) CreateFederatedDatabaseWithParams(ctx interface{}, args interface{}) *DataFederationApi_CreateFederatedDatabaseWithParams_Call {
+func (_e *DataFederationApi_Expecter) CreateFederatedDatabaseWithParams(ctx any, args any) *DataFederationApi_CreateFederatedDatabaseWithParams_Call {
 	return &DataFederationApi_CreateFederatedDatabaseWithParams_Call{Call: _e.mock.On("CreateFederatedDatabaseWithParams", ctx, args)}
 }
 
@@ -380,7 +380,7 @@ type DataFederationApi_CreateOneDataFederationQueryLimit_Call struct {
 //   - tenantName string
 //   - limitName string
 //   - dataFederationTenantQueryLimit *admin.DataFederationTenantQueryLimit
-func (_e *DataFederationApi_Expecter) CreateOneDataFederationQueryLimit(ctx interface{}, groupId interface{}, tenantName interface{}, limitName interface{}, dataFederationTenantQueryLimit interface{}) *DataFederationApi_CreateOneDataFederationQueryLimit_Call {
+func (_e *DataFederationApi_Expecter) CreateOneDataFederationQueryLimit(ctx any, groupId any, tenantName any, limitName any, dataFederationTenantQueryLimit any) *DataFederationApi_CreateOneDataFederationQueryLimit_Call {
 	return &DataFederationApi_CreateOneDataFederationQueryLimit_Call{Call: _e.mock.On("CreateOneDataFederationQueryLimit", ctx, groupId, tenantName, limitName, dataFederationTenantQueryLimit)}
 }
 
@@ -447,7 +447,7 @@ type DataFederationApi_CreateOneDataFederationQueryLimitExecute_Call struct {
 
 // CreateOneDataFederationQueryLimitExecute is a helper method to define mock.On call
 //   - r admin.CreateOneDataFederationQueryLimitApiRequest
-func (_e *DataFederationApi_Expecter) CreateOneDataFederationQueryLimitExecute(r interface{}) *DataFederationApi_CreateOneDataFederationQueryLimitExecute_Call {
+func (_e *DataFederationApi_Expecter) CreateOneDataFederationQueryLimitExecute(r any) *DataFederationApi_CreateOneDataFederationQueryLimitExecute_Call {
 	return &DataFederationApi_CreateOneDataFederationQueryLimitExecute_Call{Call: _e.mock.On("CreateOneDataFederationQueryLimitExecute", r)}
 }
 
@@ -494,7 +494,7 @@ type DataFederationApi_CreateOneDataFederationQueryLimitWithParams_Call struct {
 // CreateOneDataFederationQueryLimitWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateOneDataFederationQueryLimitApiParams
-func (_e *DataFederationApi_Expecter) CreateOneDataFederationQueryLimitWithParams(ctx interface{}, args interface{}) *DataFederationApi_CreateOneDataFederationQueryLimitWithParams_Call {
+func (_e *DataFederationApi_Expecter) CreateOneDataFederationQueryLimitWithParams(ctx any, args any) *DataFederationApi_CreateOneDataFederationQueryLimitWithParams_Call {
 	return &DataFederationApi_CreateOneDataFederationQueryLimitWithParams_Call{Call: _e.mock.On("CreateOneDataFederationQueryLimitWithParams", ctx, args)}
 }
 
@@ -542,7 +542,7 @@ type DataFederationApi_DeleteDataFederationPrivateEndpoint_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - endpointId string
-func (_e *DataFederationApi_Expecter) DeleteDataFederationPrivateEndpoint(ctx interface{}, groupId interface{}, endpointId interface{}) *DataFederationApi_DeleteDataFederationPrivateEndpoint_Call {
+func (_e *DataFederationApi_Expecter) DeleteDataFederationPrivateEndpoint(ctx any, groupId any, endpointId any) *DataFederationApi_DeleteDataFederationPrivateEndpoint_Call {
 	return &DataFederationApi_DeleteDataFederationPrivateEndpoint_Call{Call: _e.mock.On("DeleteDataFederationPrivateEndpoint", ctx, groupId, endpointId)}
 }
 
@@ -564,24 +564,24 @@ func (_c *DataFederationApi_DeleteDataFederationPrivateEndpoint_Call) RunAndRetu
 }
 
 // DeleteDataFederationPrivateEndpointExecute provides a mock function with given fields: r
-func (_m *DataFederationApi) DeleteDataFederationPrivateEndpointExecute(r admin.DeleteDataFederationPrivateEndpointApiRequest) (interface{}, *http.Response, error) {
+func (_m *DataFederationApi) DeleteDataFederationPrivateEndpointExecute(r admin.DeleteDataFederationPrivateEndpointApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteDataFederationPrivateEndpointExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteDataFederationPrivateEndpointApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteDataFederationPrivateEndpointApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteDataFederationPrivateEndpointApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteDataFederationPrivateEndpointApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -609,7 +609,7 @@ type DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call struct {
 
 // DeleteDataFederationPrivateEndpointExecute is a helper method to define mock.On call
 //   - r admin.DeleteDataFederationPrivateEndpointApiRequest
-func (_e *DataFederationApi_Expecter) DeleteDataFederationPrivateEndpointExecute(r interface{}) *DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call {
+func (_e *DataFederationApi_Expecter) DeleteDataFederationPrivateEndpointExecute(r any) *DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call {
 	return &DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call{Call: _e.mock.On("DeleteDataFederationPrivateEndpointExecute", r)}
 }
 
@@ -620,12 +620,12 @@ func (_c *DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call) Run
 	return _c
 }
 
-func (_c *DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call {
+func (_c *DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call) RunAndReturn(run func(admin.DeleteDataFederationPrivateEndpointApiRequest) (interface{}, *http.Response, error)) *DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call {
+func (_c *DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call) RunAndReturn(run func(admin.DeleteDataFederationPrivateEndpointApiRequest) (any, *http.Response, error)) *DataFederationApi_DeleteDataFederationPrivateEndpointExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -656,7 +656,7 @@ type DataFederationApi_DeleteDataFederationPrivateEndpointWithParams_Call struct
 // DeleteDataFederationPrivateEndpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteDataFederationPrivateEndpointApiParams
-func (_e *DataFederationApi_Expecter) DeleteDataFederationPrivateEndpointWithParams(ctx interface{}, args interface{}) *DataFederationApi_DeleteDataFederationPrivateEndpointWithParams_Call {
+func (_e *DataFederationApi_Expecter) DeleteDataFederationPrivateEndpointWithParams(ctx any, args any) *DataFederationApi_DeleteDataFederationPrivateEndpointWithParams_Call {
 	return &DataFederationApi_DeleteDataFederationPrivateEndpointWithParams_Call{Call: _e.mock.On("DeleteDataFederationPrivateEndpointWithParams", ctx, args)}
 }
 
@@ -704,7 +704,7 @@ type DataFederationApi_DeleteFederatedDatabase_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - tenantName string
-func (_e *DataFederationApi_Expecter) DeleteFederatedDatabase(ctx interface{}, groupId interface{}, tenantName interface{}) *DataFederationApi_DeleteFederatedDatabase_Call {
+func (_e *DataFederationApi_Expecter) DeleteFederatedDatabase(ctx any, groupId any, tenantName any) *DataFederationApi_DeleteFederatedDatabase_Call {
 	return &DataFederationApi_DeleteFederatedDatabase_Call{Call: _e.mock.On("DeleteFederatedDatabase", ctx, groupId, tenantName)}
 }
 
@@ -726,24 +726,24 @@ func (_c *DataFederationApi_DeleteFederatedDatabase_Call) RunAndReturn(run func(
 }
 
 // DeleteFederatedDatabaseExecute provides a mock function with given fields: r
-func (_m *DataFederationApi) DeleteFederatedDatabaseExecute(r admin.DeleteFederatedDatabaseApiRequest) (interface{}, *http.Response, error) {
+func (_m *DataFederationApi) DeleteFederatedDatabaseExecute(r admin.DeleteFederatedDatabaseApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteFederatedDatabaseExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteFederatedDatabaseApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteFederatedDatabaseApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteFederatedDatabaseApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteFederatedDatabaseApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -771,7 +771,7 @@ type DataFederationApi_DeleteFederatedDatabaseExecute_Call struct {
 
 // DeleteFederatedDatabaseExecute is a helper method to define mock.On call
 //   - r admin.DeleteFederatedDatabaseApiRequest
-func (_e *DataFederationApi_Expecter) DeleteFederatedDatabaseExecute(r interface{}) *DataFederationApi_DeleteFederatedDatabaseExecute_Call {
+func (_e *DataFederationApi_Expecter) DeleteFederatedDatabaseExecute(r any) *DataFederationApi_DeleteFederatedDatabaseExecute_Call {
 	return &DataFederationApi_DeleteFederatedDatabaseExecute_Call{Call: _e.mock.On("DeleteFederatedDatabaseExecute", r)}
 }
 
@@ -782,12 +782,12 @@ func (_c *DataFederationApi_DeleteFederatedDatabaseExecute_Call) Run(run func(r 
 	return _c
 }
 
-func (_c *DataFederationApi_DeleteFederatedDatabaseExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *DataFederationApi_DeleteFederatedDatabaseExecute_Call {
+func (_c *DataFederationApi_DeleteFederatedDatabaseExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *DataFederationApi_DeleteFederatedDatabaseExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *DataFederationApi_DeleteFederatedDatabaseExecute_Call) RunAndReturn(run func(admin.DeleteFederatedDatabaseApiRequest) (interface{}, *http.Response, error)) *DataFederationApi_DeleteFederatedDatabaseExecute_Call {
+func (_c *DataFederationApi_DeleteFederatedDatabaseExecute_Call) RunAndReturn(run func(admin.DeleteFederatedDatabaseApiRequest) (any, *http.Response, error)) *DataFederationApi_DeleteFederatedDatabaseExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -818,7 +818,7 @@ type DataFederationApi_DeleteFederatedDatabaseWithParams_Call struct {
 // DeleteFederatedDatabaseWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteFederatedDatabaseApiParams
-func (_e *DataFederationApi_Expecter) DeleteFederatedDatabaseWithParams(ctx interface{}, args interface{}) *DataFederationApi_DeleteFederatedDatabaseWithParams_Call {
+func (_e *DataFederationApi_Expecter) DeleteFederatedDatabaseWithParams(ctx any, args any) *DataFederationApi_DeleteFederatedDatabaseWithParams_Call {
 	return &DataFederationApi_DeleteFederatedDatabaseWithParams_Call{Call: _e.mock.On("DeleteFederatedDatabaseWithParams", ctx, args)}
 }
 
@@ -867,7 +867,7 @@ type DataFederationApi_DeleteOneDataFederationInstanceQueryLimit_Call struct {
 //   - groupId string
 //   - tenantName string
 //   - limitName string
-func (_e *DataFederationApi_Expecter) DeleteOneDataFederationInstanceQueryLimit(ctx interface{}, groupId interface{}, tenantName interface{}, limitName interface{}) *DataFederationApi_DeleteOneDataFederationInstanceQueryLimit_Call {
+func (_e *DataFederationApi_Expecter) DeleteOneDataFederationInstanceQueryLimit(ctx any, groupId any, tenantName any, limitName any) *DataFederationApi_DeleteOneDataFederationInstanceQueryLimit_Call {
 	return &DataFederationApi_DeleteOneDataFederationInstanceQueryLimit_Call{Call: _e.mock.On("DeleteOneDataFederationInstanceQueryLimit", ctx, groupId, tenantName, limitName)}
 }
 
@@ -889,24 +889,24 @@ func (_c *DataFederationApi_DeleteOneDataFederationInstanceQueryLimit_Call) RunA
 }
 
 // DeleteOneDataFederationInstanceQueryLimitExecute provides a mock function with given fields: r
-func (_m *DataFederationApi) DeleteOneDataFederationInstanceQueryLimitExecute(r admin.DeleteOneDataFederationInstanceQueryLimitApiRequest) (interface{}, *http.Response, error) {
+func (_m *DataFederationApi) DeleteOneDataFederationInstanceQueryLimitExecute(r admin.DeleteOneDataFederationInstanceQueryLimitApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteOneDataFederationInstanceQueryLimitExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteOneDataFederationInstanceQueryLimitApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteOneDataFederationInstanceQueryLimitApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteOneDataFederationInstanceQueryLimitApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteOneDataFederationInstanceQueryLimitApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -934,7 +934,7 @@ type DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Call str
 
 // DeleteOneDataFederationInstanceQueryLimitExecute is a helper method to define mock.On call
 //   - r admin.DeleteOneDataFederationInstanceQueryLimitApiRequest
-func (_e *DataFederationApi_Expecter) DeleteOneDataFederationInstanceQueryLimitExecute(r interface{}) *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Call {
+func (_e *DataFederationApi_Expecter) DeleteOneDataFederationInstanceQueryLimitExecute(r any) *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Call {
 	return &DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Call{Call: _e.mock.On("DeleteOneDataFederationInstanceQueryLimitExecute", r)}
 }
 
@@ -945,12 +945,12 @@ func (_c *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Cal
 	return _c
 }
 
-func (_c *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Call {
+func (_c *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Call) RunAndReturn(run func(admin.DeleteOneDataFederationInstanceQueryLimitApiRequest) (interface{}, *http.Response, error)) *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Call {
+func (_c *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Call) RunAndReturn(run func(admin.DeleteOneDataFederationInstanceQueryLimitApiRequest) (any, *http.Response, error)) *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -981,7 +981,7 @@ type DataFederationApi_DeleteOneDataFederationInstanceQueryLimitWithParams_Call 
 // DeleteOneDataFederationInstanceQueryLimitWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteOneDataFederationInstanceQueryLimitApiParams
-func (_e *DataFederationApi_Expecter) DeleteOneDataFederationInstanceQueryLimitWithParams(ctx interface{}, args interface{}) *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitWithParams_Call {
+func (_e *DataFederationApi_Expecter) DeleteOneDataFederationInstanceQueryLimitWithParams(ctx any, args any) *DataFederationApi_DeleteOneDataFederationInstanceQueryLimitWithParams_Call {
 	return &DataFederationApi_DeleteOneDataFederationInstanceQueryLimitWithParams_Call{Call: _e.mock.On("DeleteOneDataFederationInstanceQueryLimitWithParams", ctx, args)}
 }
 
@@ -1029,7 +1029,7 @@ type DataFederationApi_DownloadFederatedDatabaseQueryLogs_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - tenantName string
-func (_e *DataFederationApi_Expecter) DownloadFederatedDatabaseQueryLogs(ctx interface{}, groupId interface{}, tenantName interface{}) *DataFederationApi_DownloadFederatedDatabaseQueryLogs_Call {
+func (_e *DataFederationApi_Expecter) DownloadFederatedDatabaseQueryLogs(ctx any, groupId any, tenantName any) *DataFederationApi_DownloadFederatedDatabaseQueryLogs_Call {
 	return &DataFederationApi_DownloadFederatedDatabaseQueryLogs_Call{Call: _e.mock.On("DownloadFederatedDatabaseQueryLogs", ctx, groupId, tenantName)}
 }
 
@@ -1096,7 +1096,7 @@ type DataFederationApi_DownloadFederatedDatabaseQueryLogsExecute_Call struct {
 
 // DownloadFederatedDatabaseQueryLogsExecute is a helper method to define mock.On call
 //   - r admin.DownloadFederatedDatabaseQueryLogsApiRequest
-func (_e *DataFederationApi_Expecter) DownloadFederatedDatabaseQueryLogsExecute(r interface{}) *DataFederationApi_DownloadFederatedDatabaseQueryLogsExecute_Call {
+func (_e *DataFederationApi_Expecter) DownloadFederatedDatabaseQueryLogsExecute(r any) *DataFederationApi_DownloadFederatedDatabaseQueryLogsExecute_Call {
 	return &DataFederationApi_DownloadFederatedDatabaseQueryLogsExecute_Call{Call: _e.mock.On("DownloadFederatedDatabaseQueryLogsExecute", r)}
 }
 
@@ -1143,7 +1143,7 @@ type DataFederationApi_DownloadFederatedDatabaseQueryLogsWithParams_Call struct 
 // DownloadFederatedDatabaseQueryLogsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DownloadFederatedDatabaseQueryLogsApiParams
-func (_e *DataFederationApi_Expecter) DownloadFederatedDatabaseQueryLogsWithParams(ctx interface{}, args interface{}) *DataFederationApi_DownloadFederatedDatabaseQueryLogsWithParams_Call {
+func (_e *DataFederationApi_Expecter) DownloadFederatedDatabaseQueryLogsWithParams(ctx any, args any) *DataFederationApi_DownloadFederatedDatabaseQueryLogsWithParams_Call {
 	return &DataFederationApi_DownloadFederatedDatabaseQueryLogsWithParams_Call{Call: _e.mock.On("DownloadFederatedDatabaseQueryLogsWithParams", ctx, args)}
 }
 
@@ -1191,7 +1191,7 @@ type DataFederationApi_GetDataFederationPrivateEndpoint_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - endpointId string
-func (_e *DataFederationApi_Expecter) GetDataFederationPrivateEndpoint(ctx interface{}, groupId interface{}, endpointId interface{}) *DataFederationApi_GetDataFederationPrivateEndpoint_Call {
+func (_e *DataFederationApi_Expecter) GetDataFederationPrivateEndpoint(ctx any, groupId any, endpointId any) *DataFederationApi_GetDataFederationPrivateEndpoint_Call {
 	return &DataFederationApi_GetDataFederationPrivateEndpoint_Call{Call: _e.mock.On("GetDataFederationPrivateEndpoint", ctx, groupId, endpointId)}
 }
 
@@ -1258,7 +1258,7 @@ type DataFederationApi_GetDataFederationPrivateEndpointExecute_Call struct {
 
 // GetDataFederationPrivateEndpointExecute is a helper method to define mock.On call
 //   - r admin.GetDataFederationPrivateEndpointApiRequest
-func (_e *DataFederationApi_Expecter) GetDataFederationPrivateEndpointExecute(r interface{}) *DataFederationApi_GetDataFederationPrivateEndpointExecute_Call {
+func (_e *DataFederationApi_Expecter) GetDataFederationPrivateEndpointExecute(r any) *DataFederationApi_GetDataFederationPrivateEndpointExecute_Call {
 	return &DataFederationApi_GetDataFederationPrivateEndpointExecute_Call{Call: _e.mock.On("GetDataFederationPrivateEndpointExecute", r)}
 }
 
@@ -1305,7 +1305,7 @@ type DataFederationApi_GetDataFederationPrivateEndpointWithParams_Call struct {
 // GetDataFederationPrivateEndpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetDataFederationPrivateEndpointApiParams
-func (_e *DataFederationApi_Expecter) GetDataFederationPrivateEndpointWithParams(ctx interface{}, args interface{}) *DataFederationApi_GetDataFederationPrivateEndpointWithParams_Call {
+func (_e *DataFederationApi_Expecter) GetDataFederationPrivateEndpointWithParams(ctx any, args any) *DataFederationApi_GetDataFederationPrivateEndpointWithParams_Call {
 	return &DataFederationApi_GetDataFederationPrivateEndpointWithParams_Call{Call: _e.mock.On("GetDataFederationPrivateEndpointWithParams", ctx, args)}
 }
 
@@ -1353,7 +1353,7 @@ type DataFederationApi_GetFederatedDatabase_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - tenantName string
-func (_e *DataFederationApi_Expecter) GetFederatedDatabase(ctx interface{}, groupId interface{}, tenantName interface{}) *DataFederationApi_GetFederatedDatabase_Call {
+func (_e *DataFederationApi_Expecter) GetFederatedDatabase(ctx any, groupId any, tenantName any) *DataFederationApi_GetFederatedDatabase_Call {
 	return &DataFederationApi_GetFederatedDatabase_Call{Call: _e.mock.On("GetFederatedDatabase", ctx, groupId, tenantName)}
 }
 
@@ -1420,7 +1420,7 @@ type DataFederationApi_GetFederatedDatabaseExecute_Call struct {
 
 // GetFederatedDatabaseExecute is a helper method to define mock.On call
 //   - r admin.GetFederatedDatabaseApiRequest
-func (_e *DataFederationApi_Expecter) GetFederatedDatabaseExecute(r interface{}) *DataFederationApi_GetFederatedDatabaseExecute_Call {
+func (_e *DataFederationApi_Expecter) GetFederatedDatabaseExecute(r any) *DataFederationApi_GetFederatedDatabaseExecute_Call {
 	return &DataFederationApi_GetFederatedDatabaseExecute_Call{Call: _e.mock.On("GetFederatedDatabaseExecute", r)}
 }
 
@@ -1467,7 +1467,7 @@ type DataFederationApi_GetFederatedDatabaseWithParams_Call struct {
 // GetFederatedDatabaseWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetFederatedDatabaseApiParams
-func (_e *DataFederationApi_Expecter) GetFederatedDatabaseWithParams(ctx interface{}, args interface{}) *DataFederationApi_GetFederatedDatabaseWithParams_Call {
+func (_e *DataFederationApi_Expecter) GetFederatedDatabaseWithParams(ctx any, args any) *DataFederationApi_GetFederatedDatabaseWithParams_Call {
 	return &DataFederationApi_GetFederatedDatabaseWithParams_Call{Call: _e.mock.On("GetFederatedDatabaseWithParams", ctx, args)}
 }
 
@@ -1514,7 +1514,7 @@ type DataFederationApi_ListDataFederationPrivateEndpoints_Call struct {
 // ListDataFederationPrivateEndpoints is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *DataFederationApi_Expecter) ListDataFederationPrivateEndpoints(ctx interface{}, groupId interface{}) *DataFederationApi_ListDataFederationPrivateEndpoints_Call {
+func (_e *DataFederationApi_Expecter) ListDataFederationPrivateEndpoints(ctx any, groupId any) *DataFederationApi_ListDataFederationPrivateEndpoints_Call {
 	return &DataFederationApi_ListDataFederationPrivateEndpoints_Call{Call: _e.mock.On("ListDataFederationPrivateEndpoints", ctx, groupId)}
 }
 
@@ -1581,7 +1581,7 @@ type DataFederationApi_ListDataFederationPrivateEndpointsExecute_Call struct {
 
 // ListDataFederationPrivateEndpointsExecute is a helper method to define mock.On call
 //   - r admin.ListDataFederationPrivateEndpointsApiRequest
-func (_e *DataFederationApi_Expecter) ListDataFederationPrivateEndpointsExecute(r interface{}) *DataFederationApi_ListDataFederationPrivateEndpointsExecute_Call {
+func (_e *DataFederationApi_Expecter) ListDataFederationPrivateEndpointsExecute(r any) *DataFederationApi_ListDataFederationPrivateEndpointsExecute_Call {
 	return &DataFederationApi_ListDataFederationPrivateEndpointsExecute_Call{Call: _e.mock.On("ListDataFederationPrivateEndpointsExecute", r)}
 }
 
@@ -1628,7 +1628,7 @@ type DataFederationApi_ListDataFederationPrivateEndpointsWithParams_Call struct 
 // ListDataFederationPrivateEndpointsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListDataFederationPrivateEndpointsApiParams
-func (_e *DataFederationApi_Expecter) ListDataFederationPrivateEndpointsWithParams(ctx interface{}, args interface{}) *DataFederationApi_ListDataFederationPrivateEndpointsWithParams_Call {
+func (_e *DataFederationApi_Expecter) ListDataFederationPrivateEndpointsWithParams(ctx any, args any) *DataFederationApi_ListDataFederationPrivateEndpointsWithParams_Call {
 	return &DataFederationApi_ListDataFederationPrivateEndpointsWithParams_Call{Call: _e.mock.On("ListDataFederationPrivateEndpointsWithParams", ctx, args)}
 }
 
@@ -1675,7 +1675,7 @@ type DataFederationApi_ListFederatedDatabases_Call struct {
 // ListFederatedDatabases is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *DataFederationApi_Expecter) ListFederatedDatabases(ctx interface{}, groupId interface{}) *DataFederationApi_ListFederatedDatabases_Call {
+func (_e *DataFederationApi_Expecter) ListFederatedDatabases(ctx any, groupId any) *DataFederationApi_ListFederatedDatabases_Call {
 	return &DataFederationApi_ListFederatedDatabases_Call{Call: _e.mock.On("ListFederatedDatabases", ctx, groupId)}
 }
 
@@ -1742,7 +1742,7 @@ type DataFederationApi_ListFederatedDatabasesExecute_Call struct {
 
 // ListFederatedDatabasesExecute is a helper method to define mock.On call
 //   - r admin.ListFederatedDatabasesApiRequest
-func (_e *DataFederationApi_Expecter) ListFederatedDatabasesExecute(r interface{}) *DataFederationApi_ListFederatedDatabasesExecute_Call {
+func (_e *DataFederationApi_Expecter) ListFederatedDatabasesExecute(r any) *DataFederationApi_ListFederatedDatabasesExecute_Call {
 	return &DataFederationApi_ListFederatedDatabasesExecute_Call{Call: _e.mock.On("ListFederatedDatabasesExecute", r)}
 }
 
@@ -1789,7 +1789,7 @@ type DataFederationApi_ListFederatedDatabasesWithParams_Call struct {
 // ListFederatedDatabasesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListFederatedDatabasesApiParams
-func (_e *DataFederationApi_Expecter) ListFederatedDatabasesWithParams(ctx interface{}, args interface{}) *DataFederationApi_ListFederatedDatabasesWithParams_Call {
+func (_e *DataFederationApi_Expecter) ListFederatedDatabasesWithParams(ctx any, args any) *DataFederationApi_ListFederatedDatabasesWithParams_Call {
 	return &DataFederationApi_ListFederatedDatabasesWithParams_Call{Call: _e.mock.On("ListFederatedDatabasesWithParams", ctx, args)}
 }
 
@@ -1838,7 +1838,7 @@ type DataFederationApi_ReturnFederatedDatabaseQueryLimit_Call struct {
 //   - groupId string
 //   - tenantName string
 //   - limitName string
-func (_e *DataFederationApi_Expecter) ReturnFederatedDatabaseQueryLimit(ctx interface{}, groupId interface{}, tenantName interface{}, limitName interface{}) *DataFederationApi_ReturnFederatedDatabaseQueryLimit_Call {
+func (_e *DataFederationApi_Expecter) ReturnFederatedDatabaseQueryLimit(ctx any, groupId any, tenantName any, limitName any) *DataFederationApi_ReturnFederatedDatabaseQueryLimit_Call {
 	return &DataFederationApi_ReturnFederatedDatabaseQueryLimit_Call{Call: _e.mock.On("ReturnFederatedDatabaseQueryLimit", ctx, groupId, tenantName, limitName)}
 }
 
@@ -1905,7 +1905,7 @@ type DataFederationApi_ReturnFederatedDatabaseQueryLimitExecute_Call struct {
 
 // ReturnFederatedDatabaseQueryLimitExecute is a helper method to define mock.On call
 //   - r admin.ReturnFederatedDatabaseQueryLimitApiRequest
-func (_e *DataFederationApi_Expecter) ReturnFederatedDatabaseQueryLimitExecute(r interface{}) *DataFederationApi_ReturnFederatedDatabaseQueryLimitExecute_Call {
+func (_e *DataFederationApi_Expecter) ReturnFederatedDatabaseQueryLimitExecute(r any) *DataFederationApi_ReturnFederatedDatabaseQueryLimitExecute_Call {
 	return &DataFederationApi_ReturnFederatedDatabaseQueryLimitExecute_Call{Call: _e.mock.On("ReturnFederatedDatabaseQueryLimitExecute", r)}
 }
 
@@ -1952,7 +1952,7 @@ type DataFederationApi_ReturnFederatedDatabaseQueryLimitWithParams_Call struct {
 // ReturnFederatedDatabaseQueryLimitWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ReturnFederatedDatabaseQueryLimitApiParams
-func (_e *DataFederationApi_Expecter) ReturnFederatedDatabaseQueryLimitWithParams(ctx interface{}, args interface{}) *DataFederationApi_ReturnFederatedDatabaseQueryLimitWithParams_Call {
+func (_e *DataFederationApi_Expecter) ReturnFederatedDatabaseQueryLimitWithParams(ctx any, args any) *DataFederationApi_ReturnFederatedDatabaseQueryLimitWithParams_Call {
 	return &DataFederationApi_ReturnFederatedDatabaseQueryLimitWithParams_Call{Call: _e.mock.On("ReturnFederatedDatabaseQueryLimitWithParams", ctx, args)}
 }
 
@@ -2000,7 +2000,7 @@ type DataFederationApi_ReturnFederatedDatabaseQueryLimits_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - tenantName string
-func (_e *DataFederationApi_Expecter) ReturnFederatedDatabaseQueryLimits(ctx interface{}, groupId interface{}, tenantName interface{}) *DataFederationApi_ReturnFederatedDatabaseQueryLimits_Call {
+func (_e *DataFederationApi_Expecter) ReturnFederatedDatabaseQueryLimits(ctx any, groupId any, tenantName any) *DataFederationApi_ReturnFederatedDatabaseQueryLimits_Call {
 	return &DataFederationApi_ReturnFederatedDatabaseQueryLimits_Call{Call: _e.mock.On("ReturnFederatedDatabaseQueryLimits", ctx, groupId, tenantName)}
 }
 
@@ -2067,7 +2067,7 @@ type DataFederationApi_ReturnFederatedDatabaseQueryLimitsExecute_Call struct {
 
 // ReturnFederatedDatabaseQueryLimitsExecute is a helper method to define mock.On call
 //   - r admin.ReturnFederatedDatabaseQueryLimitsApiRequest
-func (_e *DataFederationApi_Expecter) ReturnFederatedDatabaseQueryLimitsExecute(r interface{}) *DataFederationApi_ReturnFederatedDatabaseQueryLimitsExecute_Call {
+func (_e *DataFederationApi_Expecter) ReturnFederatedDatabaseQueryLimitsExecute(r any) *DataFederationApi_ReturnFederatedDatabaseQueryLimitsExecute_Call {
 	return &DataFederationApi_ReturnFederatedDatabaseQueryLimitsExecute_Call{Call: _e.mock.On("ReturnFederatedDatabaseQueryLimitsExecute", r)}
 }
 
@@ -2114,7 +2114,7 @@ type DataFederationApi_ReturnFederatedDatabaseQueryLimitsWithParams_Call struct 
 // ReturnFederatedDatabaseQueryLimitsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ReturnFederatedDatabaseQueryLimitsApiParams
-func (_e *DataFederationApi_Expecter) ReturnFederatedDatabaseQueryLimitsWithParams(ctx interface{}, args interface{}) *DataFederationApi_ReturnFederatedDatabaseQueryLimitsWithParams_Call {
+func (_e *DataFederationApi_Expecter) ReturnFederatedDatabaseQueryLimitsWithParams(ctx any, args any) *DataFederationApi_ReturnFederatedDatabaseQueryLimitsWithParams_Call {
 	return &DataFederationApi_ReturnFederatedDatabaseQueryLimitsWithParams_Call{Call: _e.mock.On("ReturnFederatedDatabaseQueryLimitsWithParams", ctx, args)}
 }
 
@@ -2163,7 +2163,7 @@ type DataFederationApi_UpdateFederatedDatabase_Call struct {
 //   - groupId string
 //   - tenantName string
 //   - dataLakeTenant *admin.DataLakeTenant
-func (_e *DataFederationApi_Expecter) UpdateFederatedDatabase(ctx interface{}, groupId interface{}, tenantName interface{}, dataLakeTenant interface{}) *DataFederationApi_UpdateFederatedDatabase_Call {
+func (_e *DataFederationApi_Expecter) UpdateFederatedDatabase(ctx any, groupId any, tenantName any, dataLakeTenant any) *DataFederationApi_UpdateFederatedDatabase_Call {
 	return &DataFederationApi_UpdateFederatedDatabase_Call{Call: _e.mock.On("UpdateFederatedDatabase", ctx, groupId, tenantName, dataLakeTenant)}
 }
 
@@ -2230,7 +2230,7 @@ type DataFederationApi_UpdateFederatedDatabaseExecute_Call struct {
 
 // UpdateFederatedDatabaseExecute is a helper method to define mock.On call
 //   - r admin.UpdateFederatedDatabaseApiRequest
-func (_e *DataFederationApi_Expecter) UpdateFederatedDatabaseExecute(r interface{}) *DataFederationApi_UpdateFederatedDatabaseExecute_Call {
+func (_e *DataFederationApi_Expecter) UpdateFederatedDatabaseExecute(r any) *DataFederationApi_UpdateFederatedDatabaseExecute_Call {
 	return &DataFederationApi_UpdateFederatedDatabaseExecute_Call{Call: _e.mock.On("UpdateFederatedDatabaseExecute", r)}
 }
 
@@ -2277,7 +2277,7 @@ type DataFederationApi_UpdateFederatedDatabaseWithParams_Call struct {
 // UpdateFederatedDatabaseWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateFederatedDatabaseApiParams
-func (_e *DataFederationApi_Expecter) UpdateFederatedDatabaseWithParams(ctx interface{}, args interface{}) *DataFederationApi_UpdateFederatedDatabaseWithParams_Call {
+func (_e *DataFederationApi_Expecter) UpdateFederatedDatabaseWithParams(ctx any, args any) *DataFederationApi_UpdateFederatedDatabaseWithParams_Call {
 	return &DataFederationApi_UpdateFederatedDatabaseWithParams_Call{Call: _e.mock.On("UpdateFederatedDatabaseWithParams", ctx, args)}
 }
 

--- a/mockadmin/data_lake_pipelines_api.go
+++ b/mockadmin/data_lake_pipelines_api.go
@@ -52,7 +52,7 @@ type DataLakePipelinesApi_CreatePipeline_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - dataLakeIngestionPipeline *admin.DataLakeIngestionPipeline
-func (_e *DataLakePipelinesApi_Expecter) CreatePipeline(ctx interface{}, groupId interface{}, dataLakeIngestionPipeline interface{}) *DataLakePipelinesApi_CreatePipeline_Call {
+func (_e *DataLakePipelinesApi_Expecter) CreatePipeline(ctx any, groupId any, dataLakeIngestionPipeline any) *DataLakePipelinesApi_CreatePipeline_Call {
 	return &DataLakePipelinesApi_CreatePipeline_Call{Call: _e.mock.On("CreatePipeline", ctx, groupId, dataLakeIngestionPipeline)}
 }
 
@@ -119,7 +119,7 @@ type DataLakePipelinesApi_CreatePipelineExecute_Call struct {
 
 // CreatePipelineExecute is a helper method to define mock.On call
 //   - r admin.CreatePipelineApiRequest
-func (_e *DataLakePipelinesApi_Expecter) CreatePipelineExecute(r interface{}) *DataLakePipelinesApi_CreatePipelineExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) CreatePipelineExecute(r any) *DataLakePipelinesApi_CreatePipelineExecute_Call {
 	return &DataLakePipelinesApi_CreatePipelineExecute_Call{Call: _e.mock.On("CreatePipelineExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type DataLakePipelinesApi_CreatePipelineWithParams_Call struct {
 // CreatePipelineWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreatePipelineApiParams
-func (_e *DataLakePipelinesApi_Expecter) CreatePipelineWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_CreatePipelineWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) CreatePipelineWithParams(ctx any, args any) *DataLakePipelinesApi_CreatePipelineWithParams_Call {
 	return &DataLakePipelinesApi_CreatePipelineWithParams_Call{Call: _e.mock.On("CreatePipelineWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type DataLakePipelinesApi_DeletePipeline_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - pipelineName string
-func (_e *DataLakePipelinesApi_Expecter) DeletePipeline(ctx interface{}, groupId interface{}, pipelineName interface{}) *DataLakePipelinesApi_DeletePipeline_Call {
+func (_e *DataLakePipelinesApi_Expecter) DeletePipeline(ctx any, groupId any, pipelineName any) *DataLakePipelinesApi_DeletePipeline_Call {
 	return &DataLakePipelinesApi_DeletePipeline_Call{Call: _e.mock.On("DeletePipeline", ctx, groupId, pipelineName)}
 }
 
@@ -236,24 +236,24 @@ func (_c *DataLakePipelinesApi_DeletePipeline_Call) RunAndReturn(run func(contex
 }
 
 // DeletePipelineExecute provides a mock function with given fields: r
-func (_m *DataLakePipelinesApi) DeletePipelineExecute(r admin.DeletePipelineApiRequest) (interface{}, *http.Response, error) {
+func (_m *DataLakePipelinesApi) DeletePipelineExecute(r admin.DeletePipelineApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeletePipelineExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeletePipelineApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeletePipelineApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeletePipelineApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeletePipelineApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -281,7 +281,7 @@ type DataLakePipelinesApi_DeletePipelineExecute_Call struct {
 
 // DeletePipelineExecute is a helper method to define mock.On call
 //   - r admin.DeletePipelineApiRequest
-func (_e *DataLakePipelinesApi_Expecter) DeletePipelineExecute(r interface{}) *DataLakePipelinesApi_DeletePipelineExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) DeletePipelineExecute(r any) *DataLakePipelinesApi_DeletePipelineExecute_Call {
 	return &DataLakePipelinesApi_DeletePipelineExecute_Call{Call: _e.mock.On("DeletePipelineExecute", r)}
 }
 
@@ -292,12 +292,12 @@ func (_c *DataLakePipelinesApi_DeletePipelineExecute_Call) Run(run func(r admin.
 	return _c
 }
 
-func (_c *DataLakePipelinesApi_DeletePipelineExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *DataLakePipelinesApi_DeletePipelineExecute_Call {
+func (_c *DataLakePipelinesApi_DeletePipelineExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *DataLakePipelinesApi_DeletePipelineExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *DataLakePipelinesApi_DeletePipelineExecute_Call) RunAndReturn(run func(admin.DeletePipelineApiRequest) (interface{}, *http.Response, error)) *DataLakePipelinesApi_DeletePipelineExecute_Call {
+func (_c *DataLakePipelinesApi_DeletePipelineExecute_Call) RunAndReturn(run func(admin.DeletePipelineApiRequest) (any, *http.Response, error)) *DataLakePipelinesApi_DeletePipelineExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -330,7 +330,7 @@ type DataLakePipelinesApi_DeletePipelineRunDataset_Call struct {
 //   - groupId string
 //   - pipelineName string
 //   - pipelineRunId string
-func (_e *DataLakePipelinesApi_Expecter) DeletePipelineRunDataset(ctx interface{}, groupId interface{}, pipelineName interface{}, pipelineRunId interface{}) *DataLakePipelinesApi_DeletePipelineRunDataset_Call {
+func (_e *DataLakePipelinesApi_Expecter) DeletePipelineRunDataset(ctx any, groupId any, pipelineName any, pipelineRunId any) *DataLakePipelinesApi_DeletePipelineRunDataset_Call {
 	return &DataLakePipelinesApi_DeletePipelineRunDataset_Call{Call: _e.mock.On("DeletePipelineRunDataset", ctx, groupId, pipelineName, pipelineRunId)}
 }
 
@@ -352,24 +352,24 @@ func (_c *DataLakePipelinesApi_DeletePipelineRunDataset_Call) RunAndReturn(run f
 }
 
 // DeletePipelineRunDatasetExecute provides a mock function with given fields: r
-func (_m *DataLakePipelinesApi) DeletePipelineRunDatasetExecute(r admin.DeletePipelineRunDatasetApiRequest) (interface{}, *http.Response, error) {
+func (_m *DataLakePipelinesApi) DeletePipelineRunDatasetExecute(r admin.DeletePipelineRunDatasetApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeletePipelineRunDatasetExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeletePipelineRunDatasetApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeletePipelineRunDatasetApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeletePipelineRunDatasetApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeletePipelineRunDatasetApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -397,7 +397,7 @@ type DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call struct {
 
 // DeletePipelineRunDatasetExecute is a helper method to define mock.On call
 //   - r admin.DeletePipelineRunDatasetApiRequest
-func (_e *DataLakePipelinesApi_Expecter) DeletePipelineRunDatasetExecute(r interface{}) *DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) DeletePipelineRunDatasetExecute(r any) *DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call {
 	return &DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call{Call: _e.mock.On("DeletePipelineRunDatasetExecute", r)}
 }
 
@@ -408,12 +408,12 @@ func (_c *DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call) Run(run fun
 	return _c
 }
 
-func (_c *DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call {
+func (_c *DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call) RunAndReturn(run func(admin.DeletePipelineRunDatasetApiRequest) (interface{}, *http.Response, error)) *DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call {
+func (_c *DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call) RunAndReturn(run func(admin.DeletePipelineRunDatasetApiRequest) (any, *http.Response, error)) *DataLakePipelinesApi_DeletePipelineRunDatasetExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -444,7 +444,7 @@ type DataLakePipelinesApi_DeletePipelineRunDatasetWithParams_Call struct {
 // DeletePipelineRunDatasetWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeletePipelineRunDatasetApiParams
-func (_e *DataLakePipelinesApi_Expecter) DeletePipelineRunDatasetWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_DeletePipelineRunDatasetWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) DeletePipelineRunDatasetWithParams(ctx any, args any) *DataLakePipelinesApi_DeletePipelineRunDatasetWithParams_Call {
 	return &DataLakePipelinesApi_DeletePipelineRunDatasetWithParams_Call{Call: _e.mock.On("DeletePipelineRunDatasetWithParams", ctx, args)}
 }
 
@@ -491,7 +491,7 @@ type DataLakePipelinesApi_DeletePipelineWithParams_Call struct {
 // DeletePipelineWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeletePipelineApiParams
-func (_e *DataLakePipelinesApi_Expecter) DeletePipelineWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_DeletePipelineWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) DeletePipelineWithParams(ctx any, args any) *DataLakePipelinesApi_DeletePipelineWithParams_Call {
 	return &DataLakePipelinesApi_DeletePipelineWithParams_Call{Call: _e.mock.On("DeletePipelineWithParams", ctx, args)}
 }
 
@@ -539,7 +539,7 @@ type DataLakePipelinesApi_GetPipeline_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - pipelineName string
-func (_e *DataLakePipelinesApi_Expecter) GetPipeline(ctx interface{}, groupId interface{}, pipelineName interface{}) *DataLakePipelinesApi_GetPipeline_Call {
+func (_e *DataLakePipelinesApi_Expecter) GetPipeline(ctx any, groupId any, pipelineName any) *DataLakePipelinesApi_GetPipeline_Call {
 	return &DataLakePipelinesApi_GetPipeline_Call{Call: _e.mock.On("GetPipeline", ctx, groupId, pipelineName)}
 }
 
@@ -606,7 +606,7 @@ type DataLakePipelinesApi_GetPipelineExecute_Call struct {
 
 // GetPipelineExecute is a helper method to define mock.On call
 //   - r admin.GetPipelineApiRequest
-func (_e *DataLakePipelinesApi_Expecter) GetPipelineExecute(r interface{}) *DataLakePipelinesApi_GetPipelineExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) GetPipelineExecute(r any) *DataLakePipelinesApi_GetPipelineExecute_Call {
 	return &DataLakePipelinesApi_GetPipelineExecute_Call{Call: _e.mock.On("GetPipelineExecute", r)}
 }
 
@@ -655,7 +655,7 @@ type DataLakePipelinesApi_GetPipelineRun_Call struct {
 //   - groupId string
 //   - pipelineName string
 //   - pipelineRunId string
-func (_e *DataLakePipelinesApi_Expecter) GetPipelineRun(ctx interface{}, groupId interface{}, pipelineName interface{}, pipelineRunId interface{}) *DataLakePipelinesApi_GetPipelineRun_Call {
+func (_e *DataLakePipelinesApi_Expecter) GetPipelineRun(ctx any, groupId any, pipelineName any, pipelineRunId any) *DataLakePipelinesApi_GetPipelineRun_Call {
 	return &DataLakePipelinesApi_GetPipelineRun_Call{Call: _e.mock.On("GetPipelineRun", ctx, groupId, pipelineName, pipelineRunId)}
 }
 
@@ -722,7 +722,7 @@ type DataLakePipelinesApi_GetPipelineRunExecute_Call struct {
 
 // GetPipelineRunExecute is a helper method to define mock.On call
 //   - r admin.GetPipelineRunApiRequest
-func (_e *DataLakePipelinesApi_Expecter) GetPipelineRunExecute(r interface{}) *DataLakePipelinesApi_GetPipelineRunExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) GetPipelineRunExecute(r any) *DataLakePipelinesApi_GetPipelineRunExecute_Call {
 	return &DataLakePipelinesApi_GetPipelineRunExecute_Call{Call: _e.mock.On("GetPipelineRunExecute", r)}
 }
 
@@ -769,7 +769,7 @@ type DataLakePipelinesApi_GetPipelineRunWithParams_Call struct {
 // GetPipelineRunWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetPipelineRunApiParams
-func (_e *DataLakePipelinesApi_Expecter) GetPipelineRunWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_GetPipelineRunWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) GetPipelineRunWithParams(ctx any, args any) *DataLakePipelinesApi_GetPipelineRunWithParams_Call {
 	return &DataLakePipelinesApi_GetPipelineRunWithParams_Call{Call: _e.mock.On("GetPipelineRunWithParams", ctx, args)}
 }
 
@@ -816,7 +816,7 @@ type DataLakePipelinesApi_GetPipelineWithParams_Call struct {
 // GetPipelineWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetPipelineApiParams
-func (_e *DataLakePipelinesApi_Expecter) GetPipelineWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_GetPipelineWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) GetPipelineWithParams(ctx any, args any) *DataLakePipelinesApi_GetPipelineWithParams_Call {
 	return &DataLakePipelinesApi_GetPipelineWithParams_Call{Call: _e.mock.On("GetPipelineWithParams", ctx, args)}
 }
 
@@ -864,7 +864,7 @@ type DataLakePipelinesApi_ListPipelineRuns_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - pipelineName string
-func (_e *DataLakePipelinesApi_Expecter) ListPipelineRuns(ctx interface{}, groupId interface{}, pipelineName interface{}) *DataLakePipelinesApi_ListPipelineRuns_Call {
+func (_e *DataLakePipelinesApi_Expecter) ListPipelineRuns(ctx any, groupId any, pipelineName any) *DataLakePipelinesApi_ListPipelineRuns_Call {
 	return &DataLakePipelinesApi_ListPipelineRuns_Call{Call: _e.mock.On("ListPipelineRuns", ctx, groupId, pipelineName)}
 }
 
@@ -931,7 +931,7 @@ type DataLakePipelinesApi_ListPipelineRunsExecute_Call struct {
 
 // ListPipelineRunsExecute is a helper method to define mock.On call
 //   - r admin.ListPipelineRunsApiRequest
-func (_e *DataLakePipelinesApi_Expecter) ListPipelineRunsExecute(r interface{}) *DataLakePipelinesApi_ListPipelineRunsExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) ListPipelineRunsExecute(r any) *DataLakePipelinesApi_ListPipelineRunsExecute_Call {
 	return &DataLakePipelinesApi_ListPipelineRunsExecute_Call{Call: _e.mock.On("ListPipelineRunsExecute", r)}
 }
 
@@ -978,7 +978,7 @@ type DataLakePipelinesApi_ListPipelineRunsWithParams_Call struct {
 // ListPipelineRunsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListPipelineRunsApiParams
-func (_e *DataLakePipelinesApi_Expecter) ListPipelineRunsWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_ListPipelineRunsWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) ListPipelineRunsWithParams(ctx any, args any) *DataLakePipelinesApi_ListPipelineRunsWithParams_Call {
 	return &DataLakePipelinesApi_ListPipelineRunsWithParams_Call{Call: _e.mock.On("ListPipelineRunsWithParams", ctx, args)}
 }
 
@@ -1026,7 +1026,7 @@ type DataLakePipelinesApi_ListPipelineSchedules_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - pipelineName string
-func (_e *DataLakePipelinesApi_Expecter) ListPipelineSchedules(ctx interface{}, groupId interface{}, pipelineName interface{}) *DataLakePipelinesApi_ListPipelineSchedules_Call {
+func (_e *DataLakePipelinesApi_Expecter) ListPipelineSchedules(ctx any, groupId any, pipelineName any) *DataLakePipelinesApi_ListPipelineSchedules_Call {
 	return &DataLakePipelinesApi_ListPipelineSchedules_Call{Call: _e.mock.On("ListPipelineSchedules", ctx, groupId, pipelineName)}
 }
 
@@ -1093,7 +1093,7 @@ type DataLakePipelinesApi_ListPipelineSchedulesExecute_Call struct {
 
 // ListPipelineSchedulesExecute is a helper method to define mock.On call
 //   - r admin.ListPipelineSchedulesApiRequest
-func (_e *DataLakePipelinesApi_Expecter) ListPipelineSchedulesExecute(r interface{}) *DataLakePipelinesApi_ListPipelineSchedulesExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) ListPipelineSchedulesExecute(r any) *DataLakePipelinesApi_ListPipelineSchedulesExecute_Call {
 	return &DataLakePipelinesApi_ListPipelineSchedulesExecute_Call{Call: _e.mock.On("ListPipelineSchedulesExecute", r)}
 }
 
@@ -1140,7 +1140,7 @@ type DataLakePipelinesApi_ListPipelineSchedulesWithParams_Call struct {
 // ListPipelineSchedulesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListPipelineSchedulesApiParams
-func (_e *DataLakePipelinesApi_Expecter) ListPipelineSchedulesWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_ListPipelineSchedulesWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) ListPipelineSchedulesWithParams(ctx any, args any) *DataLakePipelinesApi_ListPipelineSchedulesWithParams_Call {
 	return &DataLakePipelinesApi_ListPipelineSchedulesWithParams_Call{Call: _e.mock.On("ListPipelineSchedulesWithParams", ctx, args)}
 }
 
@@ -1188,7 +1188,7 @@ type DataLakePipelinesApi_ListPipelineSnapshots_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - pipelineName string
-func (_e *DataLakePipelinesApi_Expecter) ListPipelineSnapshots(ctx interface{}, groupId interface{}, pipelineName interface{}) *DataLakePipelinesApi_ListPipelineSnapshots_Call {
+func (_e *DataLakePipelinesApi_Expecter) ListPipelineSnapshots(ctx any, groupId any, pipelineName any) *DataLakePipelinesApi_ListPipelineSnapshots_Call {
 	return &DataLakePipelinesApi_ListPipelineSnapshots_Call{Call: _e.mock.On("ListPipelineSnapshots", ctx, groupId, pipelineName)}
 }
 
@@ -1255,7 +1255,7 @@ type DataLakePipelinesApi_ListPipelineSnapshotsExecute_Call struct {
 
 // ListPipelineSnapshotsExecute is a helper method to define mock.On call
 //   - r admin.ListPipelineSnapshotsApiRequest
-func (_e *DataLakePipelinesApi_Expecter) ListPipelineSnapshotsExecute(r interface{}) *DataLakePipelinesApi_ListPipelineSnapshotsExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) ListPipelineSnapshotsExecute(r any) *DataLakePipelinesApi_ListPipelineSnapshotsExecute_Call {
 	return &DataLakePipelinesApi_ListPipelineSnapshotsExecute_Call{Call: _e.mock.On("ListPipelineSnapshotsExecute", r)}
 }
 
@@ -1302,7 +1302,7 @@ type DataLakePipelinesApi_ListPipelineSnapshotsWithParams_Call struct {
 // ListPipelineSnapshotsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListPipelineSnapshotsApiParams
-func (_e *DataLakePipelinesApi_Expecter) ListPipelineSnapshotsWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_ListPipelineSnapshotsWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) ListPipelineSnapshotsWithParams(ctx any, args any) *DataLakePipelinesApi_ListPipelineSnapshotsWithParams_Call {
 	return &DataLakePipelinesApi_ListPipelineSnapshotsWithParams_Call{Call: _e.mock.On("ListPipelineSnapshotsWithParams", ctx, args)}
 }
 
@@ -1349,7 +1349,7 @@ type DataLakePipelinesApi_ListPipelines_Call struct {
 // ListPipelines is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *DataLakePipelinesApi_Expecter) ListPipelines(ctx interface{}, groupId interface{}) *DataLakePipelinesApi_ListPipelines_Call {
+func (_e *DataLakePipelinesApi_Expecter) ListPipelines(ctx any, groupId any) *DataLakePipelinesApi_ListPipelines_Call {
 	return &DataLakePipelinesApi_ListPipelines_Call{Call: _e.mock.On("ListPipelines", ctx, groupId)}
 }
 
@@ -1416,7 +1416,7 @@ type DataLakePipelinesApi_ListPipelinesExecute_Call struct {
 
 // ListPipelinesExecute is a helper method to define mock.On call
 //   - r admin.ListPipelinesApiRequest
-func (_e *DataLakePipelinesApi_Expecter) ListPipelinesExecute(r interface{}) *DataLakePipelinesApi_ListPipelinesExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) ListPipelinesExecute(r any) *DataLakePipelinesApi_ListPipelinesExecute_Call {
 	return &DataLakePipelinesApi_ListPipelinesExecute_Call{Call: _e.mock.On("ListPipelinesExecute", r)}
 }
 
@@ -1463,7 +1463,7 @@ type DataLakePipelinesApi_ListPipelinesWithParams_Call struct {
 // ListPipelinesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListPipelinesApiParams
-func (_e *DataLakePipelinesApi_Expecter) ListPipelinesWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_ListPipelinesWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) ListPipelinesWithParams(ctx any, args any) *DataLakePipelinesApi_ListPipelinesWithParams_Call {
 	return &DataLakePipelinesApi_ListPipelinesWithParams_Call{Call: _e.mock.On("ListPipelinesWithParams", ctx, args)}
 }
 
@@ -1511,7 +1511,7 @@ type DataLakePipelinesApi_PausePipeline_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - pipelineName string
-func (_e *DataLakePipelinesApi_Expecter) PausePipeline(ctx interface{}, groupId interface{}, pipelineName interface{}) *DataLakePipelinesApi_PausePipeline_Call {
+func (_e *DataLakePipelinesApi_Expecter) PausePipeline(ctx any, groupId any, pipelineName any) *DataLakePipelinesApi_PausePipeline_Call {
 	return &DataLakePipelinesApi_PausePipeline_Call{Call: _e.mock.On("PausePipeline", ctx, groupId, pipelineName)}
 }
 
@@ -1578,7 +1578,7 @@ type DataLakePipelinesApi_PausePipelineExecute_Call struct {
 
 // PausePipelineExecute is a helper method to define mock.On call
 //   - r admin.PausePipelineApiRequest
-func (_e *DataLakePipelinesApi_Expecter) PausePipelineExecute(r interface{}) *DataLakePipelinesApi_PausePipelineExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) PausePipelineExecute(r any) *DataLakePipelinesApi_PausePipelineExecute_Call {
 	return &DataLakePipelinesApi_PausePipelineExecute_Call{Call: _e.mock.On("PausePipelineExecute", r)}
 }
 
@@ -1625,7 +1625,7 @@ type DataLakePipelinesApi_PausePipelineWithParams_Call struct {
 // PausePipelineWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.PausePipelineApiParams
-func (_e *DataLakePipelinesApi_Expecter) PausePipelineWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_PausePipelineWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) PausePipelineWithParams(ctx any, args any) *DataLakePipelinesApi_PausePipelineWithParams_Call {
 	return &DataLakePipelinesApi_PausePipelineWithParams_Call{Call: _e.mock.On("PausePipelineWithParams", ctx, args)}
 }
 
@@ -1673,7 +1673,7 @@ type DataLakePipelinesApi_ResumePipeline_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - pipelineName string
-func (_e *DataLakePipelinesApi_Expecter) ResumePipeline(ctx interface{}, groupId interface{}, pipelineName interface{}) *DataLakePipelinesApi_ResumePipeline_Call {
+func (_e *DataLakePipelinesApi_Expecter) ResumePipeline(ctx any, groupId any, pipelineName any) *DataLakePipelinesApi_ResumePipeline_Call {
 	return &DataLakePipelinesApi_ResumePipeline_Call{Call: _e.mock.On("ResumePipeline", ctx, groupId, pipelineName)}
 }
 
@@ -1740,7 +1740,7 @@ type DataLakePipelinesApi_ResumePipelineExecute_Call struct {
 
 // ResumePipelineExecute is a helper method to define mock.On call
 //   - r admin.ResumePipelineApiRequest
-func (_e *DataLakePipelinesApi_Expecter) ResumePipelineExecute(r interface{}) *DataLakePipelinesApi_ResumePipelineExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) ResumePipelineExecute(r any) *DataLakePipelinesApi_ResumePipelineExecute_Call {
 	return &DataLakePipelinesApi_ResumePipelineExecute_Call{Call: _e.mock.On("ResumePipelineExecute", r)}
 }
 
@@ -1787,7 +1787,7 @@ type DataLakePipelinesApi_ResumePipelineWithParams_Call struct {
 // ResumePipelineWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ResumePipelineApiParams
-func (_e *DataLakePipelinesApi_Expecter) ResumePipelineWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_ResumePipelineWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) ResumePipelineWithParams(ctx any, args any) *DataLakePipelinesApi_ResumePipelineWithParams_Call {
 	return &DataLakePipelinesApi_ResumePipelineWithParams_Call{Call: _e.mock.On("ResumePipelineWithParams", ctx, args)}
 }
 
@@ -1836,7 +1836,7 @@ type DataLakePipelinesApi_TriggerSnapshotIngestion_Call struct {
 //   - groupId string
 //   - pipelineName string
 //   - triggerIngestionPipelineRequest *admin.TriggerIngestionPipelineRequest
-func (_e *DataLakePipelinesApi_Expecter) TriggerSnapshotIngestion(ctx interface{}, groupId interface{}, pipelineName interface{}, triggerIngestionPipelineRequest interface{}) *DataLakePipelinesApi_TriggerSnapshotIngestion_Call {
+func (_e *DataLakePipelinesApi_Expecter) TriggerSnapshotIngestion(ctx any, groupId any, pipelineName any, triggerIngestionPipelineRequest any) *DataLakePipelinesApi_TriggerSnapshotIngestion_Call {
 	return &DataLakePipelinesApi_TriggerSnapshotIngestion_Call{Call: _e.mock.On("TriggerSnapshotIngestion", ctx, groupId, pipelineName, triggerIngestionPipelineRequest)}
 }
 
@@ -1903,7 +1903,7 @@ type DataLakePipelinesApi_TriggerSnapshotIngestionExecute_Call struct {
 
 // TriggerSnapshotIngestionExecute is a helper method to define mock.On call
 //   - r admin.TriggerSnapshotIngestionApiRequest
-func (_e *DataLakePipelinesApi_Expecter) TriggerSnapshotIngestionExecute(r interface{}) *DataLakePipelinesApi_TriggerSnapshotIngestionExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) TriggerSnapshotIngestionExecute(r any) *DataLakePipelinesApi_TriggerSnapshotIngestionExecute_Call {
 	return &DataLakePipelinesApi_TriggerSnapshotIngestionExecute_Call{Call: _e.mock.On("TriggerSnapshotIngestionExecute", r)}
 }
 
@@ -1950,7 +1950,7 @@ type DataLakePipelinesApi_TriggerSnapshotIngestionWithParams_Call struct {
 // TriggerSnapshotIngestionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.TriggerSnapshotIngestionApiParams
-func (_e *DataLakePipelinesApi_Expecter) TriggerSnapshotIngestionWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_TriggerSnapshotIngestionWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) TriggerSnapshotIngestionWithParams(ctx any, args any) *DataLakePipelinesApi_TriggerSnapshotIngestionWithParams_Call {
 	return &DataLakePipelinesApi_TriggerSnapshotIngestionWithParams_Call{Call: _e.mock.On("TriggerSnapshotIngestionWithParams", ctx, args)}
 }
 
@@ -1999,7 +1999,7 @@ type DataLakePipelinesApi_UpdatePipeline_Call struct {
 //   - groupId string
 //   - pipelineName string
 //   - dataLakeIngestionPipeline *admin.DataLakeIngestionPipeline
-func (_e *DataLakePipelinesApi_Expecter) UpdatePipeline(ctx interface{}, groupId interface{}, pipelineName interface{}, dataLakeIngestionPipeline interface{}) *DataLakePipelinesApi_UpdatePipeline_Call {
+func (_e *DataLakePipelinesApi_Expecter) UpdatePipeline(ctx any, groupId any, pipelineName any, dataLakeIngestionPipeline any) *DataLakePipelinesApi_UpdatePipeline_Call {
 	return &DataLakePipelinesApi_UpdatePipeline_Call{Call: _e.mock.On("UpdatePipeline", ctx, groupId, pipelineName, dataLakeIngestionPipeline)}
 }
 
@@ -2066,7 +2066,7 @@ type DataLakePipelinesApi_UpdatePipelineExecute_Call struct {
 
 // UpdatePipelineExecute is a helper method to define mock.On call
 //   - r admin.UpdatePipelineApiRequest
-func (_e *DataLakePipelinesApi_Expecter) UpdatePipelineExecute(r interface{}) *DataLakePipelinesApi_UpdatePipelineExecute_Call {
+func (_e *DataLakePipelinesApi_Expecter) UpdatePipelineExecute(r any) *DataLakePipelinesApi_UpdatePipelineExecute_Call {
 	return &DataLakePipelinesApi_UpdatePipelineExecute_Call{Call: _e.mock.On("UpdatePipelineExecute", r)}
 }
 
@@ -2113,7 +2113,7 @@ type DataLakePipelinesApi_UpdatePipelineWithParams_Call struct {
 // UpdatePipelineWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdatePipelineApiParams
-func (_e *DataLakePipelinesApi_Expecter) UpdatePipelineWithParams(ctx interface{}, args interface{}) *DataLakePipelinesApi_UpdatePipelineWithParams_Call {
+func (_e *DataLakePipelinesApi_Expecter) UpdatePipelineWithParams(ctx any, args any) *DataLakePipelinesApi_UpdatePipelineWithParams_Call {
 	return &DataLakePipelinesApi_UpdatePipelineWithParams_Call{Call: _e.mock.On("UpdatePipelineWithParams", ctx, args)}
 }
 

--- a/mockadmin/database_users_api.go
+++ b/mockadmin/database_users_api.go
@@ -52,7 +52,7 @@ type DatabaseUsersApi_CreateDatabaseUser_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - cloudDatabaseUser *admin.CloudDatabaseUser
-func (_e *DatabaseUsersApi_Expecter) CreateDatabaseUser(ctx interface{}, groupId interface{}, cloudDatabaseUser interface{}) *DatabaseUsersApi_CreateDatabaseUser_Call {
+func (_e *DatabaseUsersApi_Expecter) CreateDatabaseUser(ctx any, groupId any, cloudDatabaseUser any) *DatabaseUsersApi_CreateDatabaseUser_Call {
 	return &DatabaseUsersApi_CreateDatabaseUser_Call{Call: _e.mock.On("CreateDatabaseUser", ctx, groupId, cloudDatabaseUser)}
 }
 
@@ -119,7 +119,7 @@ type DatabaseUsersApi_CreateDatabaseUserExecute_Call struct {
 
 // CreateDatabaseUserExecute is a helper method to define mock.On call
 //   - r admin.CreateDatabaseUserApiRequest
-func (_e *DatabaseUsersApi_Expecter) CreateDatabaseUserExecute(r interface{}) *DatabaseUsersApi_CreateDatabaseUserExecute_Call {
+func (_e *DatabaseUsersApi_Expecter) CreateDatabaseUserExecute(r any) *DatabaseUsersApi_CreateDatabaseUserExecute_Call {
 	return &DatabaseUsersApi_CreateDatabaseUserExecute_Call{Call: _e.mock.On("CreateDatabaseUserExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type DatabaseUsersApi_CreateDatabaseUserWithParams_Call struct {
 // CreateDatabaseUserWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateDatabaseUserApiParams
-func (_e *DatabaseUsersApi_Expecter) CreateDatabaseUserWithParams(ctx interface{}, args interface{}) *DatabaseUsersApi_CreateDatabaseUserWithParams_Call {
+func (_e *DatabaseUsersApi_Expecter) CreateDatabaseUserWithParams(ctx any, args any) *DatabaseUsersApi_CreateDatabaseUserWithParams_Call {
 	return &DatabaseUsersApi_CreateDatabaseUserWithParams_Call{Call: _e.mock.On("CreateDatabaseUserWithParams", ctx, args)}
 }
 
@@ -215,7 +215,7 @@ type DatabaseUsersApi_DeleteDatabaseUser_Call struct {
 //   - groupId string
 //   - databaseName string
 //   - username string
-func (_e *DatabaseUsersApi_Expecter) DeleteDatabaseUser(ctx interface{}, groupId interface{}, databaseName interface{}, username interface{}) *DatabaseUsersApi_DeleteDatabaseUser_Call {
+func (_e *DatabaseUsersApi_Expecter) DeleteDatabaseUser(ctx any, groupId any, databaseName any, username any) *DatabaseUsersApi_DeleteDatabaseUser_Call {
 	return &DatabaseUsersApi_DeleteDatabaseUser_Call{Call: _e.mock.On("DeleteDatabaseUser", ctx, groupId, databaseName, username)}
 }
 
@@ -237,24 +237,24 @@ func (_c *DatabaseUsersApi_DeleteDatabaseUser_Call) RunAndReturn(run func(contex
 }
 
 // DeleteDatabaseUserExecute provides a mock function with given fields: r
-func (_m *DatabaseUsersApi) DeleteDatabaseUserExecute(r admin.DeleteDatabaseUserApiRequest) (interface{}, *http.Response, error) {
+func (_m *DatabaseUsersApi) DeleteDatabaseUserExecute(r admin.DeleteDatabaseUserApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteDatabaseUserExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteDatabaseUserApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteDatabaseUserApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteDatabaseUserApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteDatabaseUserApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -282,7 +282,7 @@ type DatabaseUsersApi_DeleteDatabaseUserExecute_Call struct {
 
 // DeleteDatabaseUserExecute is a helper method to define mock.On call
 //   - r admin.DeleteDatabaseUserApiRequest
-func (_e *DatabaseUsersApi_Expecter) DeleteDatabaseUserExecute(r interface{}) *DatabaseUsersApi_DeleteDatabaseUserExecute_Call {
+func (_e *DatabaseUsersApi_Expecter) DeleteDatabaseUserExecute(r any) *DatabaseUsersApi_DeleteDatabaseUserExecute_Call {
 	return &DatabaseUsersApi_DeleteDatabaseUserExecute_Call{Call: _e.mock.On("DeleteDatabaseUserExecute", r)}
 }
 
@@ -293,12 +293,12 @@ func (_c *DatabaseUsersApi_DeleteDatabaseUserExecute_Call) Run(run func(r admin.
 	return _c
 }
 
-func (_c *DatabaseUsersApi_DeleteDatabaseUserExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *DatabaseUsersApi_DeleteDatabaseUserExecute_Call {
+func (_c *DatabaseUsersApi_DeleteDatabaseUserExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *DatabaseUsersApi_DeleteDatabaseUserExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *DatabaseUsersApi_DeleteDatabaseUserExecute_Call) RunAndReturn(run func(admin.DeleteDatabaseUserApiRequest) (interface{}, *http.Response, error)) *DatabaseUsersApi_DeleteDatabaseUserExecute_Call {
+func (_c *DatabaseUsersApi_DeleteDatabaseUserExecute_Call) RunAndReturn(run func(admin.DeleteDatabaseUserApiRequest) (any, *http.Response, error)) *DatabaseUsersApi_DeleteDatabaseUserExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -329,7 +329,7 @@ type DatabaseUsersApi_DeleteDatabaseUserWithParams_Call struct {
 // DeleteDatabaseUserWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteDatabaseUserApiParams
-func (_e *DatabaseUsersApi_Expecter) DeleteDatabaseUserWithParams(ctx interface{}, args interface{}) *DatabaseUsersApi_DeleteDatabaseUserWithParams_Call {
+func (_e *DatabaseUsersApi_Expecter) DeleteDatabaseUserWithParams(ctx any, args any) *DatabaseUsersApi_DeleteDatabaseUserWithParams_Call {
 	return &DatabaseUsersApi_DeleteDatabaseUserWithParams_Call{Call: _e.mock.On("DeleteDatabaseUserWithParams", ctx, args)}
 }
 
@@ -378,7 +378,7 @@ type DatabaseUsersApi_GetDatabaseUser_Call struct {
 //   - groupId string
 //   - databaseName string
 //   - username string
-func (_e *DatabaseUsersApi_Expecter) GetDatabaseUser(ctx interface{}, groupId interface{}, databaseName interface{}, username interface{}) *DatabaseUsersApi_GetDatabaseUser_Call {
+func (_e *DatabaseUsersApi_Expecter) GetDatabaseUser(ctx any, groupId any, databaseName any, username any) *DatabaseUsersApi_GetDatabaseUser_Call {
 	return &DatabaseUsersApi_GetDatabaseUser_Call{Call: _e.mock.On("GetDatabaseUser", ctx, groupId, databaseName, username)}
 }
 
@@ -445,7 +445,7 @@ type DatabaseUsersApi_GetDatabaseUserExecute_Call struct {
 
 // GetDatabaseUserExecute is a helper method to define mock.On call
 //   - r admin.GetDatabaseUserApiRequest
-func (_e *DatabaseUsersApi_Expecter) GetDatabaseUserExecute(r interface{}) *DatabaseUsersApi_GetDatabaseUserExecute_Call {
+func (_e *DatabaseUsersApi_Expecter) GetDatabaseUserExecute(r any) *DatabaseUsersApi_GetDatabaseUserExecute_Call {
 	return &DatabaseUsersApi_GetDatabaseUserExecute_Call{Call: _e.mock.On("GetDatabaseUserExecute", r)}
 }
 
@@ -492,7 +492,7 @@ type DatabaseUsersApi_GetDatabaseUserWithParams_Call struct {
 // GetDatabaseUserWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetDatabaseUserApiParams
-func (_e *DatabaseUsersApi_Expecter) GetDatabaseUserWithParams(ctx interface{}, args interface{}) *DatabaseUsersApi_GetDatabaseUserWithParams_Call {
+func (_e *DatabaseUsersApi_Expecter) GetDatabaseUserWithParams(ctx any, args any) *DatabaseUsersApi_GetDatabaseUserWithParams_Call {
 	return &DatabaseUsersApi_GetDatabaseUserWithParams_Call{Call: _e.mock.On("GetDatabaseUserWithParams", ctx, args)}
 }
 
@@ -539,7 +539,7 @@ type DatabaseUsersApi_ListDatabaseUsers_Call struct {
 // ListDatabaseUsers is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *DatabaseUsersApi_Expecter) ListDatabaseUsers(ctx interface{}, groupId interface{}) *DatabaseUsersApi_ListDatabaseUsers_Call {
+func (_e *DatabaseUsersApi_Expecter) ListDatabaseUsers(ctx any, groupId any) *DatabaseUsersApi_ListDatabaseUsers_Call {
 	return &DatabaseUsersApi_ListDatabaseUsers_Call{Call: _e.mock.On("ListDatabaseUsers", ctx, groupId)}
 }
 
@@ -606,7 +606,7 @@ type DatabaseUsersApi_ListDatabaseUsersExecute_Call struct {
 
 // ListDatabaseUsersExecute is a helper method to define mock.On call
 //   - r admin.ListDatabaseUsersApiRequest
-func (_e *DatabaseUsersApi_Expecter) ListDatabaseUsersExecute(r interface{}) *DatabaseUsersApi_ListDatabaseUsersExecute_Call {
+func (_e *DatabaseUsersApi_Expecter) ListDatabaseUsersExecute(r any) *DatabaseUsersApi_ListDatabaseUsersExecute_Call {
 	return &DatabaseUsersApi_ListDatabaseUsersExecute_Call{Call: _e.mock.On("ListDatabaseUsersExecute", r)}
 }
 
@@ -653,7 +653,7 @@ type DatabaseUsersApi_ListDatabaseUsersWithParams_Call struct {
 // ListDatabaseUsersWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListDatabaseUsersApiParams
-func (_e *DatabaseUsersApi_Expecter) ListDatabaseUsersWithParams(ctx interface{}, args interface{}) *DatabaseUsersApi_ListDatabaseUsersWithParams_Call {
+func (_e *DatabaseUsersApi_Expecter) ListDatabaseUsersWithParams(ctx any, args any) *DatabaseUsersApi_ListDatabaseUsersWithParams_Call {
 	return &DatabaseUsersApi_ListDatabaseUsersWithParams_Call{Call: _e.mock.On("ListDatabaseUsersWithParams", ctx, args)}
 }
 
@@ -703,7 +703,7 @@ type DatabaseUsersApi_UpdateDatabaseUser_Call struct {
 //   - databaseName string
 //   - username string
 //   - cloudDatabaseUser *admin.CloudDatabaseUser
-func (_e *DatabaseUsersApi_Expecter) UpdateDatabaseUser(ctx interface{}, groupId interface{}, databaseName interface{}, username interface{}, cloudDatabaseUser interface{}) *DatabaseUsersApi_UpdateDatabaseUser_Call {
+func (_e *DatabaseUsersApi_Expecter) UpdateDatabaseUser(ctx any, groupId any, databaseName any, username any, cloudDatabaseUser any) *DatabaseUsersApi_UpdateDatabaseUser_Call {
 	return &DatabaseUsersApi_UpdateDatabaseUser_Call{Call: _e.mock.On("UpdateDatabaseUser", ctx, groupId, databaseName, username, cloudDatabaseUser)}
 }
 
@@ -770,7 +770,7 @@ type DatabaseUsersApi_UpdateDatabaseUserExecute_Call struct {
 
 // UpdateDatabaseUserExecute is a helper method to define mock.On call
 //   - r admin.UpdateDatabaseUserApiRequest
-func (_e *DatabaseUsersApi_Expecter) UpdateDatabaseUserExecute(r interface{}) *DatabaseUsersApi_UpdateDatabaseUserExecute_Call {
+func (_e *DatabaseUsersApi_Expecter) UpdateDatabaseUserExecute(r any) *DatabaseUsersApi_UpdateDatabaseUserExecute_Call {
 	return &DatabaseUsersApi_UpdateDatabaseUserExecute_Call{Call: _e.mock.On("UpdateDatabaseUserExecute", r)}
 }
 
@@ -817,7 +817,7 @@ type DatabaseUsersApi_UpdateDatabaseUserWithParams_Call struct {
 // UpdateDatabaseUserWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateDatabaseUserApiParams
-func (_e *DatabaseUsersApi_Expecter) UpdateDatabaseUserWithParams(ctx interface{}, args interface{}) *DatabaseUsersApi_UpdateDatabaseUserWithParams_Call {
+func (_e *DatabaseUsersApi_Expecter) UpdateDatabaseUserWithParams(ctx any, args any) *DatabaseUsersApi_UpdateDatabaseUserWithParams_Call {
 	return &DatabaseUsersApi_UpdateDatabaseUserWithParams_Call{Call: _e.mock.On("UpdateDatabaseUserWithParams", ctx, args)}
 }
 

--- a/mockadmin/encryption_at_rest_using_customer_key_management_api.go
+++ b/mockadmin/encryption_at_rest_using_customer_key_management_api.go
@@ -53,7 +53,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_CreateEncryptionAtRestPrivate
 //   - groupId string
 //   - cloudProvider string
 //   - eARPrivateEndpoint *admin.EARPrivateEndpoint
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) CreateEncryptionAtRestPrivateEndpoint(ctx interface{}, groupId interface{}, cloudProvider interface{}, eARPrivateEndpoint interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_CreateEncryptionAtRestPrivateEndpoint_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) CreateEncryptionAtRestPrivateEndpoint(ctx any, groupId any, cloudProvider any, eARPrivateEndpoint any) *EncryptionAtRestUsingCustomerKeyManagementApi_CreateEncryptionAtRestPrivateEndpoint_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_CreateEncryptionAtRestPrivateEndpoint_Call{Call: _e.mock.On("CreateEncryptionAtRestPrivateEndpoint", ctx, groupId, cloudProvider, eARPrivateEndpoint)}
 }
 
@@ -120,7 +120,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_CreateEncryptionAtRestPrivate
 
 // CreateEncryptionAtRestPrivateEndpointExecute is a helper method to define mock.On call
 //   - r admin.CreateEncryptionAtRestPrivateEndpointApiRequest
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) CreateEncryptionAtRestPrivateEndpointExecute(r interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_CreateEncryptionAtRestPrivateEndpointExecute_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) CreateEncryptionAtRestPrivateEndpointExecute(r any) *EncryptionAtRestUsingCustomerKeyManagementApi_CreateEncryptionAtRestPrivateEndpointExecute_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_CreateEncryptionAtRestPrivateEndpointExecute_Call{Call: _e.mock.On("CreateEncryptionAtRestPrivateEndpointExecute", r)}
 }
 
@@ -167,7 +167,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_CreateEncryptionAtRestPrivate
 // CreateEncryptionAtRestPrivateEndpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateEncryptionAtRestPrivateEndpointApiParams
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) CreateEncryptionAtRestPrivateEndpointWithParams(ctx interface{}, args interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_CreateEncryptionAtRestPrivateEndpointWithParams_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) CreateEncryptionAtRestPrivateEndpointWithParams(ctx any, args any) *EncryptionAtRestUsingCustomerKeyManagementApi_CreateEncryptionAtRestPrivateEndpointWithParams_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_CreateEncryptionAtRestPrivateEndpointWithParams_Call{Call: _e.mock.On("CreateEncryptionAtRestPrivateEndpointWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRest_Call stru
 // GetEncryptionAtRest is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRest(ctx interface{}, groupId interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRest_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRest(ctx any, groupId any) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRest_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRest_Call{Call: _e.mock.On("GetEncryptionAtRest", ctx, groupId)}
 }
 
@@ -281,7 +281,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestExecute_Ca
 
 // GetEncryptionAtRestExecute is a helper method to define mock.On call
 //   - r admin.GetEncryptionAtRestApiRequest
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestExecute(r interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestExecute_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestExecute(r any) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestExecute_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestExecute_Call{Call: _e.mock.On("GetEncryptionAtRestExecute", r)}
 }
 
@@ -330,7 +330,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEnd
 //   - groupId string
 //   - cloudProvider string
 //   - endpointId string
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestPrivateEndpoint(ctx interface{}, groupId interface{}, cloudProvider interface{}, endpointId interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpoint_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestPrivateEndpoint(ctx any, groupId any, cloudProvider any, endpointId any) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpoint_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpoint_Call{Call: _e.mock.On("GetEncryptionAtRestPrivateEndpoint", ctx, groupId, cloudProvider, endpointId)}
 }
 
@@ -397,7 +397,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEnd
 
 // GetEncryptionAtRestPrivateEndpointExecute is a helper method to define mock.On call
 //   - r admin.GetEncryptionAtRestPrivateEndpointApiRequest
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestPrivateEndpointExecute(r interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointExecute_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestPrivateEndpointExecute(r any) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointExecute_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointExecute_Call{Call: _e.mock.On("GetEncryptionAtRestPrivateEndpointExecute", r)}
 }
 
@@ -444,7 +444,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEnd
 // GetEncryptionAtRestPrivateEndpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetEncryptionAtRestPrivateEndpointApiParams
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestPrivateEndpointWithParams(ctx interface{}, args interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointWithParams_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestPrivateEndpointWithParams(ctx any, args any) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointWithParams_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointWithParams_Call{Call: _e.mock.On("GetEncryptionAtRestPrivateEndpointWithParams", ctx, args)}
 }
 
@@ -492,7 +492,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEnd
 //   - ctx context.Context
 //   - groupId string
 //   - cloudProvider string
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestPrivateEndpointsForCloudProvider(ctx interface{}, groupId interface{}, cloudProvider interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointsForCloudProvider_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestPrivateEndpointsForCloudProvider(ctx any, groupId any, cloudProvider any) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointsForCloudProvider_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointsForCloudProvider_Call{Call: _e.mock.On("GetEncryptionAtRestPrivateEndpointsForCloudProvider", ctx, groupId, cloudProvider)}
 }
 
@@ -559,7 +559,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEnd
 
 // GetEncryptionAtRestPrivateEndpointsForCloudProviderExecute is a helper method to define mock.On call
 //   - r admin.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiRequest
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestPrivateEndpointsForCloudProviderExecute(r interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointsForCloudProviderExecute_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestPrivateEndpointsForCloudProviderExecute(r any) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointsForCloudProviderExecute_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointsForCloudProviderExecute_Call{Call: _e.mock.On("GetEncryptionAtRestPrivateEndpointsForCloudProviderExecute", r)}
 }
 
@@ -606,7 +606,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEnd
 // GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx interface{}, args interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx any, args any) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams_Call{Call: _e.mock.On("GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams", ctx, args)}
 }
 
@@ -653,7 +653,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestWithParams
 // GetEncryptionAtRestWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetEncryptionAtRestApiParams
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestWithParams(ctx interface{}, args interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestWithParams_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) GetEncryptionAtRestWithParams(ctx any, args any) *EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestWithParams_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_GetEncryptionAtRestWithParams_Call{Call: _e.mock.On("GetEncryptionAtRestWithParams", ctx, args)}
 }
 
@@ -702,7 +702,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivat
 //   - groupId string
 //   - cloudProvider string
 //   - endpointId string
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) RequestEncryptionAtRestPrivateEndpointDeletion(ctx interface{}, groupId interface{}, cloudProvider interface{}, endpointId interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletion_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) RequestEncryptionAtRestPrivateEndpointDeletion(ctx any, groupId any, cloudProvider any, endpointId any) *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletion_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletion_Call{Call: _e.mock.On("RequestEncryptionAtRestPrivateEndpointDeletion", ctx, groupId, cloudProvider, endpointId)}
 }
 
@@ -724,24 +724,24 @@ func (_c *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestP
 }
 
 // RequestEncryptionAtRestPrivateEndpointDeletionExecute provides a mock function with given fields: r
-func (_m *EncryptionAtRestUsingCustomerKeyManagementApi) RequestEncryptionAtRestPrivateEndpointDeletionExecute(r admin.RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) (interface{}, *http.Response, error) {
+func (_m *EncryptionAtRestUsingCustomerKeyManagementApi) RequestEncryptionAtRestPrivateEndpointDeletionExecute(r admin.RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestEncryptionAtRestPrivateEndpointDeletionExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -769,7 +769,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivat
 
 // RequestEncryptionAtRestPrivateEndpointDeletionExecute is a helper method to define mock.On call
 //   - r admin.RequestEncryptionAtRestPrivateEndpointDeletionApiRequest
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) RequestEncryptionAtRestPrivateEndpointDeletionExecute(r interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionExecute_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) RequestEncryptionAtRestPrivateEndpointDeletionExecute(r any) *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionExecute_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionExecute_Call{Call: _e.mock.On("RequestEncryptionAtRestPrivateEndpointDeletionExecute", r)}
 }
 
@@ -780,12 +780,12 @@ func (_c *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestP
 	return _c
 }
 
-func (_c *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionExecute_Call {
+func (_c *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionExecute_Call) RunAndReturn(run func(admin.RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) (interface{}, *http.Response, error)) *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionExecute_Call {
+func (_c *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionExecute_Call) RunAndReturn(run func(admin.RequestEncryptionAtRestPrivateEndpointDeletionApiRequest) (any, *http.Response, error)) *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -816,7 +816,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivat
 // RequestEncryptionAtRestPrivateEndpointDeletionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.RequestEncryptionAtRestPrivateEndpointDeletionApiParams
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) RequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx interface{}, args interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionWithParams_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) RequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx any, args any) *EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionWithParams_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_RequestEncryptionAtRestPrivateEndpointDeletionWithParams_Call{Call: _e.mock.On("RequestEncryptionAtRestPrivateEndpointDeletionWithParams", ctx, args)}
 }
 
@@ -864,7 +864,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_UpdateEncryptionAtRest_Call s
 //   - ctx context.Context
 //   - groupId string
 //   - encryptionAtRest *admin.EncryptionAtRest
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) UpdateEncryptionAtRest(ctx interface{}, groupId interface{}, encryptionAtRest interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_UpdateEncryptionAtRest_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) UpdateEncryptionAtRest(ctx any, groupId any, encryptionAtRest any) *EncryptionAtRestUsingCustomerKeyManagementApi_UpdateEncryptionAtRest_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_UpdateEncryptionAtRest_Call{Call: _e.mock.On("UpdateEncryptionAtRest", ctx, groupId, encryptionAtRest)}
 }
 
@@ -931,7 +931,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_UpdateEncryptionAtRestExecute
 
 // UpdateEncryptionAtRestExecute is a helper method to define mock.On call
 //   - r admin.UpdateEncryptionAtRestApiRequest
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) UpdateEncryptionAtRestExecute(r interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_UpdateEncryptionAtRestExecute_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) UpdateEncryptionAtRestExecute(r any) *EncryptionAtRestUsingCustomerKeyManagementApi_UpdateEncryptionAtRestExecute_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_UpdateEncryptionAtRestExecute_Call{Call: _e.mock.On("UpdateEncryptionAtRestExecute", r)}
 }
 
@@ -978,7 +978,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi_UpdateEncryptionAtRestWithPar
 // UpdateEncryptionAtRestWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateEncryptionAtRestApiParams
-func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) UpdateEncryptionAtRestWithParams(ctx interface{}, args interface{}) *EncryptionAtRestUsingCustomerKeyManagementApi_UpdateEncryptionAtRestWithParams_Call {
+func (_e *EncryptionAtRestUsingCustomerKeyManagementApi_Expecter) UpdateEncryptionAtRestWithParams(ctx any, args any) *EncryptionAtRestUsingCustomerKeyManagementApi_UpdateEncryptionAtRestWithParams_Call {
 	return &EncryptionAtRestUsingCustomerKeyManagementApi_UpdateEncryptionAtRestWithParams_Call{Call: _e.mock.On("UpdateEncryptionAtRestWithParams", ctx, args)}
 }
 

--- a/mockadmin/events_api.go
+++ b/mockadmin/events_api.go
@@ -52,7 +52,7 @@ type EventsApi_GetOrganizationEvent_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - eventId string
-func (_e *EventsApi_Expecter) GetOrganizationEvent(ctx interface{}, orgId interface{}, eventId interface{}) *EventsApi_GetOrganizationEvent_Call {
+func (_e *EventsApi_Expecter) GetOrganizationEvent(ctx any, orgId any, eventId any) *EventsApi_GetOrganizationEvent_Call {
 	return &EventsApi_GetOrganizationEvent_Call{Call: _e.mock.On("GetOrganizationEvent", ctx, orgId, eventId)}
 }
 
@@ -119,7 +119,7 @@ type EventsApi_GetOrganizationEventExecute_Call struct {
 
 // GetOrganizationEventExecute is a helper method to define mock.On call
 //   - r admin.GetOrganizationEventApiRequest
-func (_e *EventsApi_Expecter) GetOrganizationEventExecute(r interface{}) *EventsApi_GetOrganizationEventExecute_Call {
+func (_e *EventsApi_Expecter) GetOrganizationEventExecute(r any) *EventsApi_GetOrganizationEventExecute_Call {
 	return &EventsApi_GetOrganizationEventExecute_Call{Call: _e.mock.On("GetOrganizationEventExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type EventsApi_GetOrganizationEventWithParams_Call struct {
 // GetOrganizationEventWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetOrganizationEventApiParams
-func (_e *EventsApi_Expecter) GetOrganizationEventWithParams(ctx interface{}, args interface{}) *EventsApi_GetOrganizationEventWithParams_Call {
+func (_e *EventsApi_Expecter) GetOrganizationEventWithParams(ctx any, args any) *EventsApi_GetOrganizationEventWithParams_Call {
 	return &EventsApi_GetOrganizationEventWithParams_Call{Call: _e.mock.On("GetOrganizationEventWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type EventsApi_GetProjectEvent_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - eventId string
-func (_e *EventsApi_Expecter) GetProjectEvent(ctx interface{}, groupId interface{}, eventId interface{}) *EventsApi_GetProjectEvent_Call {
+func (_e *EventsApi_Expecter) GetProjectEvent(ctx any, groupId any, eventId any) *EventsApi_GetProjectEvent_Call {
 	return &EventsApi_GetProjectEvent_Call{Call: _e.mock.On("GetProjectEvent", ctx, groupId, eventId)}
 }
 
@@ -281,7 +281,7 @@ type EventsApi_GetProjectEventExecute_Call struct {
 
 // GetProjectEventExecute is a helper method to define mock.On call
 //   - r admin.GetProjectEventApiRequest
-func (_e *EventsApi_Expecter) GetProjectEventExecute(r interface{}) *EventsApi_GetProjectEventExecute_Call {
+func (_e *EventsApi_Expecter) GetProjectEventExecute(r any) *EventsApi_GetProjectEventExecute_Call {
 	return &EventsApi_GetProjectEventExecute_Call{Call: _e.mock.On("GetProjectEventExecute", r)}
 }
 
@@ -328,7 +328,7 @@ type EventsApi_GetProjectEventWithParams_Call struct {
 // GetProjectEventWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetProjectEventApiParams
-func (_e *EventsApi_Expecter) GetProjectEventWithParams(ctx interface{}, args interface{}) *EventsApi_GetProjectEventWithParams_Call {
+func (_e *EventsApi_Expecter) GetProjectEventWithParams(ctx any, args any) *EventsApi_GetProjectEventWithParams_Call {
 	return &EventsApi_GetProjectEventWithParams_Call{Call: _e.mock.On("GetProjectEventWithParams", ctx, args)}
 }
 
@@ -374,7 +374,7 @@ type EventsApi_ListEventTypes_Call struct {
 
 // ListEventTypes is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *EventsApi_Expecter) ListEventTypes(ctx interface{}) *EventsApi_ListEventTypes_Call {
+func (_e *EventsApi_Expecter) ListEventTypes(ctx any) *EventsApi_ListEventTypes_Call {
 	return &EventsApi_ListEventTypes_Call{Call: _e.mock.On("ListEventTypes", ctx)}
 }
 
@@ -441,7 +441,7 @@ type EventsApi_ListEventTypesExecute_Call struct {
 
 // ListEventTypesExecute is a helper method to define mock.On call
 //   - r admin.ListEventTypesApiRequest
-func (_e *EventsApi_Expecter) ListEventTypesExecute(r interface{}) *EventsApi_ListEventTypesExecute_Call {
+func (_e *EventsApi_Expecter) ListEventTypesExecute(r any) *EventsApi_ListEventTypesExecute_Call {
 	return &EventsApi_ListEventTypesExecute_Call{Call: _e.mock.On("ListEventTypesExecute", r)}
 }
 
@@ -488,7 +488,7 @@ type EventsApi_ListEventTypesWithParams_Call struct {
 // ListEventTypesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListEventTypesApiParams
-func (_e *EventsApi_Expecter) ListEventTypesWithParams(ctx interface{}, args interface{}) *EventsApi_ListEventTypesWithParams_Call {
+func (_e *EventsApi_Expecter) ListEventTypesWithParams(ctx any, args any) *EventsApi_ListEventTypesWithParams_Call {
 	return &EventsApi_ListEventTypesWithParams_Call{Call: _e.mock.On("ListEventTypesWithParams", ctx, args)}
 }
 
@@ -535,7 +535,7 @@ type EventsApi_ListOrganizationEvents_Call struct {
 // ListOrganizationEvents is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *EventsApi_Expecter) ListOrganizationEvents(ctx interface{}, orgId interface{}) *EventsApi_ListOrganizationEvents_Call {
+func (_e *EventsApi_Expecter) ListOrganizationEvents(ctx any, orgId any) *EventsApi_ListOrganizationEvents_Call {
 	return &EventsApi_ListOrganizationEvents_Call{Call: _e.mock.On("ListOrganizationEvents", ctx, orgId)}
 }
 
@@ -602,7 +602,7 @@ type EventsApi_ListOrganizationEventsExecute_Call struct {
 
 // ListOrganizationEventsExecute is a helper method to define mock.On call
 //   - r admin.ListOrganizationEventsApiRequest
-func (_e *EventsApi_Expecter) ListOrganizationEventsExecute(r interface{}) *EventsApi_ListOrganizationEventsExecute_Call {
+func (_e *EventsApi_Expecter) ListOrganizationEventsExecute(r any) *EventsApi_ListOrganizationEventsExecute_Call {
 	return &EventsApi_ListOrganizationEventsExecute_Call{Call: _e.mock.On("ListOrganizationEventsExecute", r)}
 }
 
@@ -649,7 +649,7 @@ type EventsApi_ListOrganizationEventsWithParams_Call struct {
 // ListOrganizationEventsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListOrganizationEventsApiParams
-func (_e *EventsApi_Expecter) ListOrganizationEventsWithParams(ctx interface{}, args interface{}) *EventsApi_ListOrganizationEventsWithParams_Call {
+func (_e *EventsApi_Expecter) ListOrganizationEventsWithParams(ctx any, args any) *EventsApi_ListOrganizationEventsWithParams_Call {
 	return &EventsApi_ListOrganizationEventsWithParams_Call{Call: _e.mock.On("ListOrganizationEventsWithParams", ctx, args)}
 }
 
@@ -696,7 +696,7 @@ type EventsApi_ListProjectEvents_Call struct {
 // ListProjectEvents is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *EventsApi_Expecter) ListProjectEvents(ctx interface{}, groupId interface{}) *EventsApi_ListProjectEvents_Call {
+func (_e *EventsApi_Expecter) ListProjectEvents(ctx any, groupId any) *EventsApi_ListProjectEvents_Call {
 	return &EventsApi_ListProjectEvents_Call{Call: _e.mock.On("ListProjectEvents", ctx, groupId)}
 }
 
@@ -763,7 +763,7 @@ type EventsApi_ListProjectEventsExecute_Call struct {
 
 // ListProjectEventsExecute is a helper method to define mock.On call
 //   - r admin.ListProjectEventsApiRequest
-func (_e *EventsApi_Expecter) ListProjectEventsExecute(r interface{}) *EventsApi_ListProjectEventsExecute_Call {
+func (_e *EventsApi_Expecter) ListProjectEventsExecute(r any) *EventsApi_ListProjectEventsExecute_Call {
 	return &EventsApi_ListProjectEventsExecute_Call{Call: _e.mock.On("ListProjectEventsExecute", r)}
 }
 
@@ -810,7 +810,7 @@ type EventsApi_ListProjectEventsWithParams_Call struct {
 // ListProjectEventsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListProjectEventsApiParams
-func (_e *EventsApi_Expecter) ListProjectEventsWithParams(ctx interface{}, args interface{}) *EventsApi_ListProjectEventsWithParams_Call {
+func (_e *EventsApi_Expecter) ListProjectEventsWithParams(ctx any, args any) *EventsApi_ListProjectEventsWithParams_Call {
 	return &EventsApi_ListProjectEventsWithParams_Call{Call: _e.mock.On("ListProjectEventsWithParams", ctx, args)}
 }
 

--- a/mockadmin/federated_authentication_api.go
+++ b/mockadmin/federated_authentication_api.go
@@ -52,7 +52,7 @@ type FederatedAuthenticationApi_CreateIdentityProvider_Call struct {
 //   - ctx context.Context
 //   - federationSettingsId string
 //   - federationOidcIdentityProviderUpdate *admin.FederationOidcIdentityProviderUpdate
-func (_e *FederatedAuthenticationApi_Expecter) CreateIdentityProvider(ctx interface{}, federationSettingsId interface{}, federationOidcIdentityProviderUpdate interface{}) *FederatedAuthenticationApi_CreateIdentityProvider_Call {
+func (_e *FederatedAuthenticationApi_Expecter) CreateIdentityProvider(ctx any, federationSettingsId any, federationOidcIdentityProviderUpdate any) *FederatedAuthenticationApi_CreateIdentityProvider_Call {
 	return &FederatedAuthenticationApi_CreateIdentityProvider_Call{Call: _e.mock.On("CreateIdentityProvider", ctx, federationSettingsId, federationOidcIdentityProviderUpdate)}
 }
 
@@ -119,7 +119,7 @@ type FederatedAuthenticationApi_CreateIdentityProviderExecute_Call struct {
 
 // CreateIdentityProviderExecute is a helper method to define mock.On call
 //   - r admin.CreateIdentityProviderApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) CreateIdentityProviderExecute(r interface{}) *FederatedAuthenticationApi_CreateIdentityProviderExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) CreateIdentityProviderExecute(r any) *FederatedAuthenticationApi_CreateIdentityProviderExecute_Call {
 	return &FederatedAuthenticationApi_CreateIdentityProviderExecute_Call{Call: _e.mock.On("CreateIdentityProviderExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type FederatedAuthenticationApi_CreateIdentityProviderWithParams_Call struct {
 // CreateIdentityProviderWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateIdentityProviderApiParams
-func (_e *FederatedAuthenticationApi_Expecter) CreateIdentityProviderWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_CreateIdentityProviderWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) CreateIdentityProviderWithParams(ctx any, args any) *FederatedAuthenticationApi_CreateIdentityProviderWithParams_Call {
 	return &FederatedAuthenticationApi_CreateIdentityProviderWithParams_Call{Call: _e.mock.On("CreateIdentityProviderWithParams", ctx, args)}
 }
 
@@ -215,7 +215,7 @@ type FederatedAuthenticationApi_CreateRoleMapping_Call struct {
 //   - federationSettingsId string
 //   - orgId string
 //   - authFederationRoleMapping *admin.AuthFederationRoleMapping
-func (_e *FederatedAuthenticationApi_Expecter) CreateRoleMapping(ctx interface{}, federationSettingsId interface{}, orgId interface{}, authFederationRoleMapping interface{}) *FederatedAuthenticationApi_CreateRoleMapping_Call {
+func (_e *FederatedAuthenticationApi_Expecter) CreateRoleMapping(ctx any, federationSettingsId any, orgId any, authFederationRoleMapping any) *FederatedAuthenticationApi_CreateRoleMapping_Call {
 	return &FederatedAuthenticationApi_CreateRoleMapping_Call{Call: _e.mock.On("CreateRoleMapping", ctx, federationSettingsId, orgId, authFederationRoleMapping)}
 }
 
@@ -282,7 +282,7 @@ type FederatedAuthenticationApi_CreateRoleMappingExecute_Call struct {
 
 // CreateRoleMappingExecute is a helper method to define mock.On call
 //   - r admin.CreateRoleMappingApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) CreateRoleMappingExecute(r interface{}) *FederatedAuthenticationApi_CreateRoleMappingExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) CreateRoleMappingExecute(r any) *FederatedAuthenticationApi_CreateRoleMappingExecute_Call {
 	return &FederatedAuthenticationApi_CreateRoleMappingExecute_Call{Call: _e.mock.On("CreateRoleMappingExecute", r)}
 }
 
@@ -329,7 +329,7 @@ type FederatedAuthenticationApi_CreateRoleMappingWithParams_Call struct {
 // CreateRoleMappingWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateRoleMappingApiParams
-func (_e *FederatedAuthenticationApi_Expecter) CreateRoleMappingWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_CreateRoleMappingWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) CreateRoleMappingWithParams(ctx any, args any) *FederatedAuthenticationApi_CreateRoleMappingWithParams_Call {
 	return &FederatedAuthenticationApi_CreateRoleMappingWithParams_Call{Call: _e.mock.On("CreateRoleMappingWithParams", ctx, args)}
 }
 
@@ -376,7 +376,7 @@ type FederatedAuthenticationApi_DeleteFederationApp_Call struct {
 // DeleteFederationApp is a helper method to define mock.On call
 //   - ctx context.Context
 //   - federationSettingsId string
-func (_e *FederatedAuthenticationApi_Expecter) DeleteFederationApp(ctx interface{}, federationSettingsId interface{}) *FederatedAuthenticationApi_DeleteFederationApp_Call {
+func (_e *FederatedAuthenticationApi_Expecter) DeleteFederationApp(ctx any, federationSettingsId any) *FederatedAuthenticationApi_DeleteFederationApp_Call {
 	return &FederatedAuthenticationApi_DeleteFederationApp_Call{Call: _e.mock.On("DeleteFederationApp", ctx, federationSettingsId)}
 }
 
@@ -434,7 +434,7 @@ type FederatedAuthenticationApi_DeleteFederationAppExecute_Call struct {
 
 // DeleteFederationAppExecute is a helper method to define mock.On call
 //   - r admin.DeleteFederationAppApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) DeleteFederationAppExecute(r interface{}) *FederatedAuthenticationApi_DeleteFederationAppExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) DeleteFederationAppExecute(r any) *FederatedAuthenticationApi_DeleteFederationAppExecute_Call {
 	return &FederatedAuthenticationApi_DeleteFederationAppExecute_Call{Call: _e.mock.On("DeleteFederationAppExecute", r)}
 }
 
@@ -481,7 +481,7 @@ type FederatedAuthenticationApi_DeleteFederationAppWithParams_Call struct {
 // DeleteFederationAppWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteFederationAppApiParams
-func (_e *FederatedAuthenticationApi_Expecter) DeleteFederationAppWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_DeleteFederationAppWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) DeleteFederationAppWithParams(ctx any, args any) *FederatedAuthenticationApi_DeleteFederationAppWithParams_Call {
 	return &FederatedAuthenticationApi_DeleteFederationAppWithParams_Call{Call: _e.mock.On("DeleteFederationAppWithParams", ctx, args)}
 }
 
@@ -529,7 +529,7 @@ type FederatedAuthenticationApi_DeleteIdentityProvider_Call struct {
 //   - ctx context.Context
 //   - federationSettingsId string
 //   - identityProviderId string
-func (_e *FederatedAuthenticationApi_Expecter) DeleteIdentityProvider(ctx interface{}, federationSettingsId interface{}, identityProviderId interface{}) *FederatedAuthenticationApi_DeleteIdentityProvider_Call {
+func (_e *FederatedAuthenticationApi_Expecter) DeleteIdentityProvider(ctx any, federationSettingsId any, identityProviderId any) *FederatedAuthenticationApi_DeleteIdentityProvider_Call {
 	return &FederatedAuthenticationApi_DeleteIdentityProvider_Call{Call: _e.mock.On("DeleteIdentityProvider", ctx, federationSettingsId, identityProviderId)}
 }
 
@@ -587,7 +587,7 @@ type FederatedAuthenticationApi_DeleteIdentityProviderExecute_Call struct {
 
 // DeleteIdentityProviderExecute is a helper method to define mock.On call
 //   - r admin.DeleteIdentityProviderApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) DeleteIdentityProviderExecute(r interface{}) *FederatedAuthenticationApi_DeleteIdentityProviderExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) DeleteIdentityProviderExecute(r any) *FederatedAuthenticationApi_DeleteIdentityProviderExecute_Call {
 	return &FederatedAuthenticationApi_DeleteIdentityProviderExecute_Call{Call: _e.mock.On("DeleteIdentityProviderExecute", r)}
 }
 
@@ -634,7 +634,7 @@ type FederatedAuthenticationApi_DeleteIdentityProviderWithParams_Call struct {
 // DeleteIdentityProviderWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteIdentityProviderApiParams
-func (_e *FederatedAuthenticationApi_Expecter) DeleteIdentityProviderWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_DeleteIdentityProviderWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) DeleteIdentityProviderWithParams(ctx any, args any) *FederatedAuthenticationApi_DeleteIdentityProviderWithParams_Call {
 	return &FederatedAuthenticationApi_DeleteIdentityProviderWithParams_Call{Call: _e.mock.On("DeleteIdentityProviderWithParams", ctx, args)}
 }
 
@@ -683,7 +683,7 @@ type FederatedAuthenticationApi_DeleteRoleMapping_Call struct {
 //   - federationSettingsId string
 //   - id string
 //   - orgId string
-func (_e *FederatedAuthenticationApi_Expecter) DeleteRoleMapping(ctx interface{}, federationSettingsId interface{}, id interface{}, orgId interface{}) *FederatedAuthenticationApi_DeleteRoleMapping_Call {
+func (_e *FederatedAuthenticationApi_Expecter) DeleteRoleMapping(ctx any, federationSettingsId any, id any, orgId any) *FederatedAuthenticationApi_DeleteRoleMapping_Call {
 	return &FederatedAuthenticationApi_DeleteRoleMapping_Call{Call: _e.mock.On("DeleteRoleMapping", ctx, federationSettingsId, id, orgId)}
 }
 
@@ -741,7 +741,7 @@ type FederatedAuthenticationApi_DeleteRoleMappingExecute_Call struct {
 
 // DeleteRoleMappingExecute is a helper method to define mock.On call
 //   - r admin.DeleteRoleMappingApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) DeleteRoleMappingExecute(r interface{}) *FederatedAuthenticationApi_DeleteRoleMappingExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) DeleteRoleMappingExecute(r any) *FederatedAuthenticationApi_DeleteRoleMappingExecute_Call {
 	return &FederatedAuthenticationApi_DeleteRoleMappingExecute_Call{Call: _e.mock.On("DeleteRoleMappingExecute", r)}
 }
 
@@ -788,7 +788,7 @@ type FederatedAuthenticationApi_DeleteRoleMappingWithParams_Call struct {
 // DeleteRoleMappingWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteRoleMappingApiParams
-func (_e *FederatedAuthenticationApi_Expecter) DeleteRoleMappingWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_DeleteRoleMappingWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) DeleteRoleMappingWithParams(ctx any, args any) *FederatedAuthenticationApi_DeleteRoleMappingWithParams_Call {
 	return &FederatedAuthenticationApi_DeleteRoleMappingWithParams_Call{Call: _e.mock.On("DeleteRoleMappingWithParams", ctx, args)}
 }
 
@@ -836,7 +836,7 @@ type FederatedAuthenticationApi_GetConnectedOrgConfig_Call struct {
 //   - ctx context.Context
 //   - federationSettingsId string
 //   - orgId string
-func (_e *FederatedAuthenticationApi_Expecter) GetConnectedOrgConfig(ctx interface{}, federationSettingsId interface{}, orgId interface{}) *FederatedAuthenticationApi_GetConnectedOrgConfig_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetConnectedOrgConfig(ctx any, federationSettingsId any, orgId any) *FederatedAuthenticationApi_GetConnectedOrgConfig_Call {
 	return &FederatedAuthenticationApi_GetConnectedOrgConfig_Call{Call: _e.mock.On("GetConnectedOrgConfig", ctx, federationSettingsId, orgId)}
 }
 
@@ -903,7 +903,7 @@ type FederatedAuthenticationApi_GetConnectedOrgConfigExecute_Call struct {
 
 // GetConnectedOrgConfigExecute is a helper method to define mock.On call
 //   - r admin.GetConnectedOrgConfigApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) GetConnectedOrgConfigExecute(r interface{}) *FederatedAuthenticationApi_GetConnectedOrgConfigExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetConnectedOrgConfigExecute(r any) *FederatedAuthenticationApi_GetConnectedOrgConfigExecute_Call {
 	return &FederatedAuthenticationApi_GetConnectedOrgConfigExecute_Call{Call: _e.mock.On("GetConnectedOrgConfigExecute", r)}
 }
 
@@ -950,7 +950,7 @@ type FederatedAuthenticationApi_GetConnectedOrgConfigWithParams_Call struct {
 // GetConnectedOrgConfigWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetConnectedOrgConfigApiParams
-func (_e *FederatedAuthenticationApi_Expecter) GetConnectedOrgConfigWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_GetConnectedOrgConfigWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetConnectedOrgConfigWithParams(ctx any, args any) *FederatedAuthenticationApi_GetConnectedOrgConfigWithParams_Call {
 	return &FederatedAuthenticationApi_GetConnectedOrgConfigWithParams_Call{Call: _e.mock.On("GetConnectedOrgConfigWithParams", ctx, args)}
 }
 
@@ -997,7 +997,7 @@ type FederatedAuthenticationApi_GetFederationSettings_Call struct {
 // GetFederationSettings is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *FederatedAuthenticationApi_Expecter) GetFederationSettings(ctx interface{}, orgId interface{}) *FederatedAuthenticationApi_GetFederationSettings_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetFederationSettings(ctx any, orgId any) *FederatedAuthenticationApi_GetFederationSettings_Call {
 	return &FederatedAuthenticationApi_GetFederationSettings_Call{Call: _e.mock.On("GetFederationSettings", ctx, orgId)}
 }
 
@@ -1064,7 +1064,7 @@ type FederatedAuthenticationApi_GetFederationSettingsExecute_Call struct {
 
 // GetFederationSettingsExecute is a helper method to define mock.On call
 //   - r admin.GetFederationSettingsApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) GetFederationSettingsExecute(r interface{}) *FederatedAuthenticationApi_GetFederationSettingsExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetFederationSettingsExecute(r any) *FederatedAuthenticationApi_GetFederationSettingsExecute_Call {
 	return &FederatedAuthenticationApi_GetFederationSettingsExecute_Call{Call: _e.mock.On("GetFederationSettingsExecute", r)}
 }
 
@@ -1111,7 +1111,7 @@ type FederatedAuthenticationApi_GetFederationSettingsWithParams_Call struct {
 // GetFederationSettingsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetFederationSettingsApiParams
-func (_e *FederatedAuthenticationApi_Expecter) GetFederationSettingsWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_GetFederationSettingsWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetFederationSettingsWithParams(ctx any, args any) *FederatedAuthenticationApi_GetFederationSettingsWithParams_Call {
 	return &FederatedAuthenticationApi_GetFederationSettingsWithParams_Call{Call: _e.mock.On("GetFederationSettingsWithParams", ctx, args)}
 }
 
@@ -1159,7 +1159,7 @@ type FederatedAuthenticationApi_GetIdentityProvider_Call struct {
 //   - ctx context.Context
 //   - federationSettingsId string
 //   - identityProviderId string
-func (_e *FederatedAuthenticationApi_Expecter) GetIdentityProvider(ctx interface{}, federationSettingsId interface{}, identityProviderId interface{}) *FederatedAuthenticationApi_GetIdentityProvider_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetIdentityProvider(ctx any, federationSettingsId any, identityProviderId any) *FederatedAuthenticationApi_GetIdentityProvider_Call {
 	return &FederatedAuthenticationApi_GetIdentityProvider_Call{Call: _e.mock.On("GetIdentityProvider", ctx, federationSettingsId, identityProviderId)}
 }
 
@@ -1226,7 +1226,7 @@ type FederatedAuthenticationApi_GetIdentityProviderExecute_Call struct {
 
 // GetIdentityProviderExecute is a helper method to define mock.On call
 //   - r admin.GetIdentityProviderApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) GetIdentityProviderExecute(r interface{}) *FederatedAuthenticationApi_GetIdentityProviderExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetIdentityProviderExecute(r any) *FederatedAuthenticationApi_GetIdentityProviderExecute_Call {
 	return &FederatedAuthenticationApi_GetIdentityProviderExecute_Call{Call: _e.mock.On("GetIdentityProviderExecute", r)}
 }
 
@@ -1274,7 +1274,7 @@ type FederatedAuthenticationApi_GetIdentityProviderMetadata_Call struct {
 //   - ctx context.Context
 //   - federationSettingsId string
 //   - identityProviderId string
-func (_e *FederatedAuthenticationApi_Expecter) GetIdentityProviderMetadata(ctx interface{}, federationSettingsId interface{}, identityProviderId interface{}) *FederatedAuthenticationApi_GetIdentityProviderMetadata_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetIdentityProviderMetadata(ctx any, federationSettingsId any, identityProviderId any) *FederatedAuthenticationApi_GetIdentityProviderMetadata_Call {
 	return &FederatedAuthenticationApi_GetIdentityProviderMetadata_Call{Call: _e.mock.On("GetIdentityProviderMetadata", ctx, federationSettingsId, identityProviderId)}
 }
 
@@ -1339,7 +1339,7 @@ type FederatedAuthenticationApi_GetIdentityProviderMetadataExecute_Call struct {
 
 // GetIdentityProviderMetadataExecute is a helper method to define mock.On call
 //   - r admin.GetIdentityProviderMetadataApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) GetIdentityProviderMetadataExecute(r interface{}) *FederatedAuthenticationApi_GetIdentityProviderMetadataExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetIdentityProviderMetadataExecute(r any) *FederatedAuthenticationApi_GetIdentityProviderMetadataExecute_Call {
 	return &FederatedAuthenticationApi_GetIdentityProviderMetadataExecute_Call{Call: _e.mock.On("GetIdentityProviderMetadataExecute", r)}
 }
 
@@ -1386,7 +1386,7 @@ type FederatedAuthenticationApi_GetIdentityProviderMetadataWithParams_Call struc
 // GetIdentityProviderMetadataWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetIdentityProviderMetadataApiParams
-func (_e *FederatedAuthenticationApi_Expecter) GetIdentityProviderMetadataWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_GetIdentityProviderMetadataWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetIdentityProviderMetadataWithParams(ctx any, args any) *FederatedAuthenticationApi_GetIdentityProviderMetadataWithParams_Call {
 	return &FederatedAuthenticationApi_GetIdentityProviderMetadataWithParams_Call{Call: _e.mock.On("GetIdentityProviderMetadataWithParams", ctx, args)}
 }
 
@@ -1433,7 +1433,7 @@ type FederatedAuthenticationApi_GetIdentityProviderWithParams_Call struct {
 // GetIdentityProviderWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetIdentityProviderApiParams
-func (_e *FederatedAuthenticationApi_Expecter) GetIdentityProviderWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_GetIdentityProviderWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetIdentityProviderWithParams(ctx any, args any) *FederatedAuthenticationApi_GetIdentityProviderWithParams_Call {
 	return &FederatedAuthenticationApi_GetIdentityProviderWithParams_Call{Call: _e.mock.On("GetIdentityProviderWithParams", ctx, args)}
 }
 
@@ -1482,7 +1482,7 @@ type FederatedAuthenticationApi_GetRoleMapping_Call struct {
 //   - federationSettingsId string
 //   - id string
 //   - orgId string
-func (_e *FederatedAuthenticationApi_Expecter) GetRoleMapping(ctx interface{}, federationSettingsId interface{}, id interface{}, orgId interface{}) *FederatedAuthenticationApi_GetRoleMapping_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetRoleMapping(ctx any, federationSettingsId any, id any, orgId any) *FederatedAuthenticationApi_GetRoleMapping_Call {
 	return &FederatedAuthenticationApi_GetRoleMapping_Call{Call: _e.mock.On("GetRoleMapping", ctx, federationSettingsId, id, orgId)}
 }
 
@@ -1549,7 +1549,7 @@ type FederatedAuthenticationApi_GetRoleMappingExecute_Call struct {
 
 // GetRoleMappingExecute is a helper method to define mock.On call
 //   - r admin.GetRoleMappingApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) GetRoleMappingExecute(r interface{}) *FederatedAuthenticationApi_GetRoleMappingExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetRoleMappingExecute(r any) *FederatedAuthenticationApi_GetRoleMappingExecute_Call {
 	return &FederatedAuthenticationApi_GetRoleMappingExecute_Call{Call: _e.mock.On("GetRoleMappingExecute", r)}
 }
 
@@ -1596,7 +1596,7 @@ type FederatedAuthenticationApi_GetRoleMappingWithParams_Call struct {
 // GetRoleMappingWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetRoleMappingApiParams
-func (_e *FederatedAuthenticationApi_Expecter) GetRoleMappingWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_GetRoleMappingWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) GetRoleMappingWithParams(ctx any, args any) *FederatedAuthenticationApi_GetRoleMappingWithParams_Call {
 	return &FederatedAuthenticationApi_GetRoleMappingWithParams_Call{Call: _e.mock.On("GetRoleMappingWithParams", ctx, args)}
 }
 
@@ -1643,7 +1643,7 @@ type FederatedAuthenticationApi_ListConnectedOrgConfigs_Call struct {
 // ListConnectedOrgConfigs is a helper method to define mock.On call
 //   - ctx context.Context
 //   - federationSettingsId string
-func (_e *FederatedAuthenticationApi_Expecter) ListConnectedOrgConfigs(ctx interface{}, federationSettingsId interface{}) *FederatedAuthenticationApi_ListConnectedOrgConfigs_Call {
+func (_e *FederatedAuthenticationApi_Expecter) ListConnectedOrgConfigs(ctx any, federationSettingsId any) *FederatedAuthenticationApi_ListConnectedOrgConfigs_Call {
 	return &FederatedAuthenticationApi_ListConnectedOrgConfigs_Call{Call: _e.mock.On("ListConnectedOrgConfigs", ctx, federationSettingsId)}
 }
 
@@ -1710,7 +1710,7 @@ type FederatedAuthenticationApi_ListConnectedOrgConfigsExecute_Call struct {
 
 // ListConnectedOrgConfigsExecute is a helper method to define mock.On call
 //   - r admin.ListConnectedOrgConfigsApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) ListConnectedOrgConfigsExecute(r interface{}) *FederatedAuthenticationApi_ListConnectedOrgConfigsExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) ListConnectedOrgConfigsExecute(r any) *FederatedAuthenticationApi_ListConnectedOrgConfigsExecute_Call {
 	return &FederatedAuthenticationApi_ListConnectedOrgConfigsExecute_Call{Call: _e.mock.On("ListConnectedOrgConfigsExecute", r)}
 }
 
@@ -1757,7 +1757,7 @@ type FederatedAuthenticationApi_ListConnectedOrgConfigsWithParams_Call struct {
 // ListConnectedOrgConfigsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListConnectedOrgConfigsApiParams
-func (_e *FederatedAuthenticationApi_Expecter) ListConnectedOrgConfigsWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_ListConnectedOrgConfigsWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) ListConnectedOrgConfigsWithParams(ctx any, args any) *FederatedAuthenticationApi_ListConnectedOrgConfigsWithParams_Call {
 	return &FederatedAuthenticationApi_ListConnectedOrgConfigsWithParams_Call{Call: _e.mock.On("ListConnectedOrgConfigsWithParams", ctx, args)}
 }
 
@@ -1804,7 +1804,7 @@ type FederatedAuthenticationApi_ListIdentityProviders_Call struct {
 // ListIdentityProviders is a helper method to define mock.On call
 //   - ctx context.Context
 //   - federationSettingsId string
-func (_e *FederatedAuthenticationApi_Expecter) ListIdentityProviders(ctx interface{}, federationSettingsId interface{}) *FederatedAuthenticationApi_ListIdentityProviders_Call {
+func (_e *FederatedAuthenticationApi_Expecter) ListIdentityProviders(ctx any, federationSettingsId any) *FederatedAuthenticationApi_ListIdentityProviders_Call {
 	return &FederatedAuthenticationApi_ListIdentityProviders_Call{Call: _e.mock.On("ListIdentityProviders", ctx, federationSettingsId)}
 }
 
@@ -1871,7 +1871,7 @@ type FederatedAuthenticationApi_ListIdentityProvidersExecute_Call struct {
 
 // ListIdentityProvidersExecute is a helper method to define mock.On call
 //   - r admin.ListIdentityProvidersApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) ListIdentityProvidersExecute(r interface{}) *FederatedAuthenticationApi_ListIdentityProvidersExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) ListIdentityProvidersExecute(r any) *FederatedAuthenticationApi_ListIdentityProvidersExecute_Call {
 	return &FederatedAuthenticationApi_ListIdentityProvidersExecute_Call{Call: _e.mock.On("ListIdentityProvidersExecute", r)}
 }
 
@@ -1918,7 +1918,7 @@ type FederatedAuthenticationApi_ListIdentityProvidersWithParams_Call struct {
 // ListIdentityProvidersWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListIdentityProvidersApiParams
-func (_e *FederatedAuthenticationApi_Expecter) ListIdentityProvidersWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_ListIdentityProvidersWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) ListIdentityProvidersWithParams(ctx any, args any) *FederatedAuthenticationApi_ListIdentityProvidersWithParams_Call {
 	return &FederatedAuthenticationApi_ListIdentityProvidersWithParams_Call{Call: _e.mock.On("ListIdentityProvidersWithParams", ctx, args)}
 }
 
@@ -1966,7 +1966,7 @@ type FederatedAuthenticationApi_ListRoleMappings_Call struct {
 //   - ctx context.Context
 //   - federationSettingsId string
 //   - orgId string
-func (_e *FederatedAuthenticationApi_Expecter) ListRoleMappings(ctx interface{}, federationSettingsId interface{}, orgId interface{}) *FederatedAuthenticationApi_ListRoleMappings_Call {
+func (_e *FederatedAuthenticationApi_Expecter) ListRoleMappings(ctx any, federationSettingsId any, orgId any) *FederatedAuthenticationApi_ListRoleMappings_Call {
 	return &FederatedAuthenticationApi_ListRoleMappings_Call{Call: _e.mock.On("ListRoleMappings", ctx, federationSettingsId, orgId)}
 }
 
@@ -2033,7 +2033,7 @@ type FederatedAuthenticationApi_ListRoleMappingsExecute_Call struct {
 
 // ListRoleMappingsExecute is a helper method to define mock.On call
 //   - r admin.ListRoleMappingsApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) ListRoleMappingsExecute(r interface{}) *FederatedAuthenticationApi_ListRoleMappingsExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) ListRoleMappingsExecute(r any) *FederatedAuthenticationApi_ListRoleMappingsExecute_Call {
 	return &FederatedAuthenticationApi_ListRoleMappingsExecute_Call{Call: _e.mock.On("ListRoleMappingsExecute", r)}
 }
 
@@ -2080,7 +2080,7 @@ type FederatedAuthenticationApi_ListRoleMappingsWithParams_Call struct {
 // ListRoleMappingsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListRoleMappingsApiParams
-func (_e *FederatedAuthenticationApi_Expecter) ListRoleMappingsWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_ListRoleMappingsWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) ListRoleMappingsWithParams(ctx any, args any) *FederatedAuthenticationApi_ListRoleMappingsWithParams_Call {
 	return &FederatedAuthenticationApi_ListRoleMappingsWithParams_Call{Call: _e.mock.On("ListRoleMappingsWithParams", ctx, args)}
 }
 
@@ -2128,7 +2128,7 @@ type FederatedAuthenticationApi_RemoveConnectedOrgConfig_Call struct {
 //   - ctx context.Context
 //   - federationSettingsId string
 //   - orgId string
-func (_e *FederatedAuthenticationApi_Expecter) RemoveConnectedOrgConfig(ctx interface{}, federationSettingsId interface{}, orgId interface{}) *FederatedAuthenticationApi_RemoveConnectedOrgConfig_Call {
+func (_e *FederatedAuthenticationApi_Expecter) RemoveConnectedOrgConfig(ctx any, federationSettingsId any, orgId any) *FederatedAuthenticationApi_RemoveConnectedOrgConfig_Call {
 	return &FederatedAuthenticationApi_RemoveConnectedOrgConfig_Call{Call: _e.mock.On("RemoveConnectedOrgConfig", ctx, federationSettingsId, orgId)}
 }
 
@@ -2150,24 +2150,24 @@ func (_c *FederatedAuthenticationApi_RemoveConnectedOrgConfig_Call) RunAndReturn
 }
 
 // RemoveConnectedOrgConfigExecute provides a mock function with given fields: r
-func (_m *FederatedAuthenticationApi) RemoveConnectedOrgConfigExecute(r admin.RemoveConnectedOrgConfigApiRequest) (interface{}, *http.Response, error) {
+func (_m *FederatedAuthenticationApi) RemoveConnectedOrgConfigExecute(r admin.RemoveConnectedOrgConfigApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RemoveConnectedOrgConfigExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.RemoveConnectedOrgConfigApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.RemoveConnectedOrgConfigApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.RemoveConnectedOrgConfigApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.RemoveConnectedOrgConfigApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -2195,7 +2195,7 @@ type FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call struct {
 
 // RemoveConnectedOrgConfigExecute is a helper method to define mock.On call
 //   - r admin.RemoveConnectedOrgConfigApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) RemoveConnectedOrgConfigExecute(r interface{}) *FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) RemoveConnectedOrgConfigExecute(r any) *FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call {
 	return &FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call{Call: _e.mock.On("RemoveConnectedOrgConfigExecute", r)}
 }
 
@@ -2206,12 +2206,12 @@ func (_c *FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call) Run(r
 	return _c
 }
 
-func (_c *FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call {
+func (_c *FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call) RunAndReturn(run func(admin.RemoveConnectedOrgConfigApiRequest) (interface{}, *http.Response, error)) *FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call {
+func (_c *FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call) RunAndReturn(run func(admin.RemoveConnectedOrgConfigApiRequest) (any, *http.Response, error)) *FederatedAuthenticationApi_RemoveConnectedOrgConfigExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2242,7 +2242,7 @@ type FederatedAuthenticationApi_RemoveConnectedOrgConfigWithParams_Call struct {
 // RemoveConnectedOrgConfigWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.RemoveConnectedOrgConfigApiParams
-func (_e *FederatedAuthenticationApi_Expecter) RemoveConnectedOrgConfigWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_RemoveConnectedOrgConfigWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) RemoveConnectedOrgConfigWithParams(ctx any, args any) *FederatedAuthenticationApi_RemoveConnectedOrgConfigWithParams_Call {
 	return &FederatedAuthenticationApi_RemoveConnectedOrgConfigWithParams_Call{Call: _e.mock.On("RemoveConnectedOrgConfigWithParams", ctx, args)}
 }
 
@@ -2290,7 +2290,7 @@ type FederatedAuthenticationApi_RevokeJwksFromIdentityProvider_Call struct {
 //   - ctx context.Context
 //   - federationSettingsId string
 //   - identityProviderId string
-func (_e *FederatedAuthenticationApi_Expecter) RevokeJwksFromIdentityProvider(ctx interface{}, federationSettingsId interface{}, identityProviderId interface{}) *FederatedAuthenticationApi_RevokeJwksFromIdentityProvider_Call {
+func (_e *FederatedAuthenticationApi_Expecter) RevokeJwksFromIdentityProvider(ctx any, federationSettingsId any, identityProviderId any) *FederatedAuthenticationApi_RevokeJwksFromIdentityProvider_Call {
 	return &FederatedAuthenticationApi_RevokeJwksFromIdentityProvider_Call{Call: _e.mock.On("RevokeJwksFromIdentityProvider", ctx, federationSettingsId, identityProviderId)}
 }
 
@@ -2348,7 +2348,7 @@ type FederatedAuthenticationApi_RevokeJwksFromIdentityProviderExecute_Call struc
 
 // RevokeJwksFromIdentityProviderExecute is a helper method to define mock.On call
 //   - r admin.RevokeJwksFromIdentityProviderApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) RevokeJwksFromIdentityProviderExecute(r interface{}) *FederatedAuthenticationApi_RevokeJwksFromIdentityProviderExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) RevokeJwksFromIdentityProviderExecute(r any) *FederatedAuthenticationApi_RevokeJwksFromIdentityProviderExecute_Call {
 	return &FederatedAuthenticationApi_RevokeJwksFromIdentityProviderExecute_Call{Call: _e.mock.On("RevokeJwksFromIdentityProviderExecute", r)}
 }
 
@@ -2395,7 +2395,7 @@ type FederatedAuthenticationApi_RevokeJwksFromIdentityProviderWithParams_Call st
 // RevokeJwksFromIdentityProviderWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.RevokeJwksFromIdentityProviderApiParams
-func (_e *FederatedAuthenticationApi_Expecter) RevokeJwksFromIdentityProviderWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_RevokeJwksFromIdentityProviderWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) RevokeJwksFromIdentityProviderWithParams(ctx any, args any) *FederatedAuthenticationApi_RevokeJwksFromIdentityProviderWithParams_Call {
 	return &FederatedAuthenticationApi_RevokeJwksFromIdentityProviderWithParams_Call{Call: _e.mock.On("RevokeJwksFromIdentityProviderWithParams", ctx, args)}
 }
 
@@ -2444,7 +2444,7 @@ type FederatedAuthenticationApi_UpdateConnectedOrgConfig_Call struct {
 //   - federationSettingsId string
 //   - orgId string
 //   - connectedOrgConfig *admin.ConnectedOrgConfig
-func (_e *FederatedAuthenticationApi_Expecter) UpdateConnectedOrgConfig(ctx interface{}, federationSettingsId interface{}, orgId interface{}, connectedOrgConfig interface{}) *FederatedAuthenticationApi_UpdateConnectedOrgConfig_Call {
+func (_e *FederatedAuthenticationApi_Expecter) UpdateConnectedOrgConfig(ctx any, federationSettingsId any, orgId any, connectedOrgConfig any) *FederatedAuthenticationApi_UpdateConnectedOrgConfig_Call {
 	return &FederatedAuthenticationApi_UpdateConnectedOrgConfig_Call{Call: _e.mock.On("UpdateConnectedOrgConfig", ctx, federationSettingsId, orgId, connectedOrgConfig)}
 }
 
@@ -2511,7 +2511,7 @@ type FederatedAuthenticationApi_UpdateConnectedOrgConfigExecute_Call struct {
 
 // UpdateConnectedOrgConfigExecute is a helper method to define mock.On call
 //   - r admin.UpdateConnectedOrgConfigApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) UpdateConnectedOrgConfigExecute(r interface{}) *FederatedAuthenticationApi_UpdateConnectedOrgConfigExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) UpdateConnectedOrgConfigExecute(r any) *FederatedAuthenticationApi_UpdateConnectedOrgConfigExecute_Call {
 	return &FederatedAuthenticationApi_UpdateConnectedOrgConfigExecute_Call{Call: _e.mock.On("UpdateConnectedOrgConfigExecute", r)}
 }
 
@@ -2558,7 +2558,7 @@ type FederatedAuthenticationApi_UpdateConnectedOrgConfigWithParams_Call struct {
 // UpdateConnectedOrgConfigWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateConnectedOrgConfigApiParams
-func (_e *FederatedAuthenticationApi_Expecter) UpdateConnectedOrgConfigWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_UpdateConnectedOrgConfigWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) UpdateConnectedOrgConfigWithParams(ctx any, args any) *FederatedAuthenticationApi_UpdateConnectedOrgConfigWithParams_Call {
 	return &FederatedAuthenticationApi_UpdateConnectedOrgConfigWithParams_Call{Call: _e.mock.On("UpdateConnectedOrgConfigWithParams", ctx, args)}
 }
 
@@ -2607,7 +2607,7 @@ type FederatedAuthenticationApi_UpdateIdentityProvider_Call struct {
 //   - federationSettingsId string
 //   - identityProviderId string
 //   - federationIdentityProviderUpdate *admin.FederationIdentityProviderUpdate
-func (_e *FederatedAuthenticationApi_Expecter) UpdateIdentityProvider(ctx interface{}, federationSettingsId interface{}, identityProviderId interface{}, federationIdentityProviderUpdate interface{}) *FederatedAuthenticationApi_UpdateIdentityProvider_Call {
+func (_e *FederatedAuthenticationApi_Expecter) UpdateIdentityProvider(ctx any, federationSettingsId any, identityProviderId any, federationIdentityProviderUpdate any) *FederatedAuthenticationApi_UpdateIdentityProvider_Call {
 	return &FederatedAuthenticationApi_UpdateIdentityProvider_Call{Call: _e.mock.On("UpdateIdentityProvider", ctx, federationSettingsId, identityProviderId, federationIdentityProviderUpdate)}
 }
 
@@ -2674,7 +2674,7 @@ type FederatedAuthenticationApi_UpdateIdentityProviderExecute_Call struct {
 
 // UpdateIdentityProviderExecute is a helper method to define mock.On call
 //   - r admin.UpdateIdentityProviderApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) UpdateIdentityProviderExecute(r interface{}) *FederatedAuthenticationApi_UpdateIdentityProviderExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) UpdateIdentityProviderExecute(r any) *FederatedAuthenticationApi_UpdateIdentityProviderExecute_Call {
 	return &FederatedAuthenticationApi_UpdateIdentityProviderExecute_Call{Call: _e.mock.On("UpdateIdentityProviderExecute", r)}
 }
 
@@ -2721,7 +2721,7 @@ type FederatedAuthenticationApi_UpdateIdentityProviderWithParams_Call struct {
 // UpdateIdentityProviderWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateIdentityProviderApiParams
-func (_e *FederatedAuthenticationApi_Expecter) UpdateIdentityProviderWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_UpdateIdentityProviderWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) UpdateIdentityProviderWithParams(ctx any, args any) *FederatedAuthenticationApi_UpdateIdentityProviderWithParams_Call {
 	return &FederatedAuthenticationApi_UpdateIdentityProviderWithParams_Call{Call: _e.mock.On("UpdateIdentityProviderWithParams", ctx, args)}
 }
 
@@ -2771,7 +2771,7 @@ type FederatedAuthenticationApi_UpdateRoleMapping_Call struct {
 //   - id string
 //   - orgId string
 //   - authFederationRoleMapping *admin.AuthFederationRoleMapping
-func (_e *FederatedAuthenticationApi_Expecter) UpdateRoleMapping(ctx interface{}, federationSettingsId interface{}, id interface{}, orgId interface{}, authFederationRoleMapping interface{}) *FederatedAuthenticationApi_UpdateRoleMapping_Call {
+func (_e *FederatedAuthenticationApi_Expecter) UpdateRoleMapping(ctx any, federationSettingsId any, id any, orgId any, authFederationRoleMapping any) *FederatedAuthenticationApi_UpdateRoleMapping_Call {
 	return &FederatedAuthenticationApi_UpdateRoleMapping_Call{Call: _e.mock.On("UpdateRoleMapping", ctx, federationSettingsId, id, orgId, authFederationRoleMapping)}
 }
 
@@ -2838,7 +2838,7 @@ type FederatedAuthenticationApi_UpdateRoleMappingExecute_Call struct {
 
 // UpdateRoleMappingExecute is a helper method to define mock.On call
 //   - r admin.UpdateRoleMappingApiRequest
-func (_e *FederatedAuthenticationApi_Expecter) UpdateRoleMappingExecute(r interface{}) *FederatedAuthenticationApi_UpdateRoleMappingExecute_Call {
+func (_e *FederatedAuthenticationApi_Expecter) UpdateRoleMappingExecute(r any) *FederatedAuthenticationApi_UpdateRoleMappingExecute_Call {
 	return &FederatedAuthenticationApi_UpdateRoleMappingExecute_Call{Call: _e.mock.On("UpdateRoleMappingExecute", r)}
 }
 
@@ -2885,7 +2885,7 @@ type FederatedAuthenticationApi_UpdateRoleMappingWithParams_Call struct {
 // UpdateRoleMappingWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateRoleMappingApiParams
-func (_e *FederatedAuthenticationApi_Expecter) UpdateRoleMappingWithParams(ctx interface{}, args interface{}) *FederatedAuthenticationApi_UpdateRoleMappingWithParams_Call {
+func (_e *FederatedAuthenticationApi_Expecter) UpdateRoleMappingWithParams(ctx any, args any) *FederatedAuthenticationApi_UpdateRoleMappingWithParams_Call {
 	return &FederatedAuthenticationApi_UpdateRoleMappingWithParams_Call{Call: _e.mock.On("UpdateRoleMappingWithParams", ctx, args)}
 }
 

--- a/mockadmin/global_clusters_api.go
+++ b/mockadmin/global_clusters_api.go
@@ -53,7 +53,7 @@ type GlobalClustersApi_CreateCustomZoneMapping_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - customZoneMappings *admin.CustomZoneMappings
-func (_e *GlobalClustersApi_Expecter) CreateCustomZoneMapping(ctx interface{}, groupId interface{}, clusterName interface{}, customZoneMappings interface{}) *GlobalClustersApi_CreateCustomZoneMapping_Call {
+func (_e *GlobalClustersApi_Expecter) CreateCustomZoneMapping(ctx any, groupId any, clusterName any, customZoneMappings any) *GlobalClustersApi_CreateCustomZoneMapping_Call {
 	return &GlobalClustersApi_CreateCustomZoneMapping_Call{Call: _e.mock.On("CreateCustomZoneMapping", ctx, groupId, clusterName, customZoneMappings)}
 }
 
@@ -120,7 +120,7 @@ type GlobalClustersApi_CreateCustomZoneMappingExecute_Call struct {
 
 // CreateCustomZoneMappingExecute is a helper method to define mock.On call
 //   - r admin.CreateCustomZoneMappingApiRequest
-func (_e *GlobalClustersApi_Expecter) CreateCustomZoneMappingExecute(r interface{}) *GlobalClustersApi_CreateCustomZoneMappingExecute_Call {
+func (_e *GlobalClustersApi_Expecter) CreateCustomZoneMappingExecute(r any) *GlobalClustersApi_CreateCustomZoneMappingExecute_Call {
 	return &GlobalClustersApi_CreateCustomZoneMappingExecute_Call{Call: _e.mock.On("CreateCustomZoneMappingExecute", r)}
 }
 
@@ -167,7 +167,7 @@ type GlobalClustersApi_CreateCustomZoneMappingWithParams_Call struct {
 // CreateCustomZoneMappingWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateCustomZoneMappingApiParams
-func (_e *GlobalClustersApi_Expecter) CreateCustomZoneMappingWithParams(ctx interface{}, args interface{}) *GlobalClustersApi_CreateCustomZoneMappingWithParams_Call {
+func (_e *GlobalClustersApi_Expecter) CreateCustomZoneMappingWithParams(ctx any, args any) *GlobalClustersApi_CreateCustomZoneMappingWithParams_Call {
 	return &GlobalClustersApi_CreateCustomZoneMappingWithParams_Call{Call: _e.mock.On("CreateCustomZoneMappingWithParams", ctx, args)}
 }
 
@@ -216,7 +216,7 @@ type GlobalClustersApi_CreateManagedNamespace_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - managedNamespaces *admin.ManagedNamespaces
-func (_e *GlobalClustersApi_Expecter) CreateManagedNamespace(ctx interface{}, groupId interface{}, clusterName interface{}, managedNamespaces interface{}) *GlobalClustersApi_CreateManagedNamespace_Call {
+func (_e *GlobalClustersApi_Expecter) CreateManagedNamespace(ctx any, groupId any, clusterName any, managedNamespaces any) *GlobalClustersApi_CreateManagedNamespace_Call {
 	return &GlobalClustersApi_CreateManagedNamespace_Call{Call: _e.mock.On("CreateManagedNamespace", ctx, groupId, clusterName, managedNamespaces)}
 }
 
@@ -283,7 +283,7 @@ type GlobalClustersApi_CreateManagedNamespaceExecute_Call struct {
 
 // CreateManagedNamespaceExecute is a helper method to define mock.On call
 //   - r admin.CreateManagedNamespaceApiRequest
-func (_e *GlobalClustersApi_Expecter) CreateManagedNamespaceExecute(r interface{}) *GlobalClustersApi_CreateManagedNamespaceExecute_Call {
+func (_e *GlobalClustersApi_Expecter) CreateManagedNamespaceExecute(r any) *GlobalClustersApi_CreateManagedNamespaceExecute_Call {
 	return &GlobalClustersApi_CreateManagedNamespaceExecute_Call{Call: _e.mock.On("CreateManagedNamespaceExecute", r)}
 }
 
@@ -330,7 +330,7 @@ type GlobalClustersApi_CreateManagedNamespaceWithParams_Call struct {
 // CreateManagedNamespaceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateManagedNamespaceApiParams
-func (_e *GlobalClustersApi_Expecter) CreateManagedNamespaceWithParams(ctx interface{}, args interface{}) *GlobalClustersApi_CreateManagedNamespaceWithParams_Call {
+func (_e *GlobalClustersApi_Expecter) CreateManagedNamespaceWithParams(ctx any, args any) *GlobalClustersApi_CreateManagedNamespaceWithParams_Call {
 	return &GlobalClustersApi_CreateManagedNamespaceWithParams_Call{Call: _e.mock.On("CreateManagedNamespaceWithParams", ctx, args)}
 }
 
@@ -378,7 +378,7 @@ type GlobalClustersApi_DeleteAllCustomZoneMappings_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *GlobalClustersApi_Expecter) DeleteAllCustomZoneMappings(ctx interface{}, groupId interface{}, clusterName interface{}) *GlobalClustersApi_DeleteAllCustomZoneMappings_Call {
+func (_e *GlobalClustersApi_Expecter) DeleteAllCustomZoneMappings(ctx any, groupId any, clusterName any) *GlobalClustersApi_DeleteAllCustomZoneMappings_Call {
 	return &GlobalClustersApi_DeleteAllCustomZoneMappings_Call{Call: _e.mock.On("DeleteAllCustomZoneMappings", ctx, groupId, clusterName)}
 }
 
@@ -445,7 +445,7 @@ type GlobalClustersApi_DeleteAllCustomZoneMappingsExecute_Call struct {
 
 // DeleteAllCustomZoneMappingsExecute is a helper method to define mock.On call
 //   - r admin.DeleteAllCustomZoneMappingsApiRequest
-func (_e *GlobalClustersApi_Expecter) DeleteAllCustomZoneMappingsExecute(r interface{}) *GlobalClustersApi_DeleteAllCustomZoneMappingsExecute_Call {
+func (_e *GlobalClustersApi_Expecter) DeleteAllCustomZoneMappingsExecute(r any) *GlobalClustersApi_DeleteAllCustomZoneMappingsExecute_Call {
 	return &GlobalClustersApi_DeleteAllCustomZoneMappingsExecute_Call{Call: _e.mock.On("DeleteAllCustomZoneMappingsExecute", r)}
 }
 
@@ -492,7 +492,7 @@ type GlobalClustersApi_DeleteAllCustomZoneMappingsWithParams_Call struct {
 // DeleteAllCustomZoneMappingsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteAllCustomZoneMappingsApiParams
-func (_e *GlobalClustersApi_Expecter) DeleteAllCustomZoneMappingsWithParams(ctx interface{}, args interface{}) *GlobalClustersApi_DeleteAllCustomZoneMappingsWithParams_Call {
+func (_e *GlobalClustersApi_Expecter) DeleteAllCustomZoneMappingsWithParams(ctx any, args any) *GlobalClustersApi_DeleteAllCustomZoneMappingsWithParams_Call {
 	return &GlobalClustersApi_DeleteAllCustomZoneMappingsWithParams_Call{Call: _e.mock.On("DeleteAllCustomZoneMappingsWithParams", ctx, args)}
 }
 
@@ -540,7 +540,7 @@ type GlobalClustersApi_DeleteManagedNamespace_Call struct {
 //   - ctx context.Context
 //   - clusterName string
 //   - groupId string
-func (_e *GlobalClustersApi_Expecter) DeleteManagedNamespace(ctx interface{}, clusterName interface{}, groupId interface{}) *GlobalClustersApi_DeleteManagedNamespace_Call {
+func (_e *GlobalClustersApi_Expecter) DeleteManagedNamespace(ctx any, clusterName any, groupId any) *GlobalClustersApi_DeleteManagedNamespace_Call {
 	return &GlobalClustersApi_DeleteManagedNamespace_Call{Call: _e.mock.On("DeleteManagedNamespace", ctx, clusterName, groupId)}
 }
 
@@ -607,7 +607,7 @@ type GlobalClustersApi_DeleteManagedNamespaceExecute_Call struct {
 
 // DeleteManagedNamespaceExecute is a helper method to define mock.On call
 //   - r admin.DeleteManagedNamespaceApiRequest
-func (_e *GlobalClustersApi_Expecter) DeleteManagedNamespaceExecute(r interface{}) *GlobalClustersApi_DeleteManagedNamespaceExecute_Call {
+func (_e *GlobalClustersApi_Expecter) DeleteManagedNamespaceExecute(r any) *GlobalClustersApi_DeleteManagedNamespaceExecute_Call {
 	return &GlobalClustersApi_DeleteManagedNamespaceExecute_Call{Call: _e.mock.On("DeleteManagedNamespaceExecute", r)}
 }
 
@@ -654,7 +654,7 @@ type GlobalClustersApi_DeleteManagedNamespaceWithParams_Call struct {
 // DeleteManagedNamespaceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteManagedNamespaceApiParams
-func (_e *GlobalClustersApi_Expecter) DeleteManagedNamespaceWithParams(ctx interface{}, args interface{}) *GlobalClustersApi_DeleteManagedNamespaceWithParams_Call {
+func (_e *GlobalClustersApi_Expecter) DeleteManagedNamespaceWithParams(ctx any, args any) *GlobalClustersApi_DeleteManagedNamespaceWithParams_Call {
 	return &GlobalClustersApi_DeleteManagedNamespaceWithParams_Call{Call: _e.mock.On("DeleteManagedNamespaceWithParams", ctx, args)}
 }
 
@@ -702,7 +702,7 @@ type GlobalClustersApi_GetManagedNamespace_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *GlobalClustersApi_Expecter) GetManagedNamespace(ctx interface{}, groupId interface{}, clusterName interface{}) *GlobalClustersApi_GetManagedNamespace_Call {
+func (_e *GlobalClustersApi_Expecter) GetManagedNamespace(ctx any, groupId any, clusterName any) *GlobalClustersApi_GetManagedNamespace_Call {
 	return &GlobalClustersApi_GetManagedNamespace_Call{Call: _e.mock.On("GetManagedNamespace", ctx, groupId, clusterName)}
 }
 
@@ -769,7 +769,7 @@ type GlobalClustersApi_GetManagedNamespaceExecute_Call struct {
 
 // GetManagedNamespaceExecute is a helper method to define mock.On call
 //   - r admin.GetManagedNamespaceApiRequest
-func (_e *GlobalClustersApi_Expecter) GetManagedNamespaceExecute(r interface{}) *GlobalClustersApi_GetManagedNamespaceExecute_Call {
+func (_e *GlobalClustersApi_Expecter) GetManagedNamespaceExecute(r any) *GlobalClustersApi_GetManagedNamespaceExecute_Call {
 	return &GlobalClustersApi_GetManagedNamespaceExecute_Call{Call: _e.mock.On("GetManagedNamespaceExecute", r)}
 }
 
@@ -816,7 +816,7 @@ type GlobalClustersApi_GetManagedNamespaceWithParams_Call struct {
 // GetManagedNamespaceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetManagedNamespaceApiParams
-func (_e *GlobalClustersApi_Expecter) GetManagedNamespaceWithParams(ctx interface{}, args interface{}) *GlobalClustersApi_GetManagedNamespaceWithParams_Call {
+func (_e *GlobalClustersApi_Expecter) GetManagedNamespaceWithParams(ctx any, args any) *GlobalClustersApi_GetManagedNamespaceWithParams_Call {
 	return &GlobalClustersApi_GetManagedNamespaceWithParams_Call{Call: _e.mock.On("GetManagedNamespaceWithParams", ctx, args)}
 }
 

--- a/mockadmin/invoices_api.go
+++ b/mockadmin/invoices_api.go
@@ -52,7 +52,7 @@ type InvoicesApi_CreateCostExplorerQueryProcess_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - costExplorerFilterRequestBody *admin.CostExplorerFilterRequestBody
-func (_e *InvoicesApi_Expecter) CreateCostExplorerQueryProcess(ctx interface{}, orgId interface{}, costExplorerFilterRequestBody interface{}) *InvoicesApi_CreateCostExplorerQueryProcess_Call {
+func (_e *InvoicesApi_Expecter) CreateCostExplorerQueryProcess(ctx any, orgId any, costExplorerFilterRequestBody any) *InvoicesApi_CreateCostExplorerQueryProcess_Call {
 	return &InvoicesApi_CreateCostExplorerQueryProcess_Call{Call: _e.mock.On("CreateCostExplorerQueryProcess", ctx, orgId, costExplorerFilterRequestBody)}
 }
 
@@ -100,7 +100,7 @@ type InvoicesApi_CreateCostExplorerQueryProcess1_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - token string
-func (_e *InvoicesApi_Expecter) CreateCostExplorerQueryProcess1(ctx interface{}, orgId interface{}, token interface{}) *InvoicesApi_CreateCostExplorerQueryProcess1_Call {
+func (_e *InvoicesApi_Expecter) CreateCostExplorerQueryProcess1(ctx any, orgId any, token any) *InvoicesApi_CreateCostExplorerQueryProcess1_Call {
 	return &InvoicesApi_CreateCostExplorerQueryProcess1_Call{Call: _e.mock.On("CreateCostExplorerQueryProcess1", ctx, orgId, token)}
 }
 
@@ -165,7 +165,7 @@ type InvoicesApi_CreateCostExplorerQueryProcess1Execute_Call struct {
 
 // CreateCostExplorerQueryProcess1Execute is a helper method to define mock.On call
 //   - r admin.CreateCostExplorerQueryProcess1ApiRequest
-func (_e *InvoicesApi_Expecter) CreateCostExplorerQueryProcess1Execute(r interface{}) *InvoicesApi_CreateCostExplorerQueryProcess1Execute_Call {
+func (_e *InvoicesApi_Expecter) CreateCostExplorerQueryProcess1Execute(r any) *InvoicesApi_CreateCostExplorerQueryProcess1Execute_Call {
 	return &InvoicesApi_CreateCostExplorerQueryProcess1Execute_Call{Call: _e.mock.On("CreateCostExplorerQueryProcess1Execute", r)}
 }
 
@@ -212,7 +212,7 @@ type InvoicesApi_CreateCostExplorerQueryProcess1WithParams_Call struct {
 // CreateCostExplorerQueryProcess1WithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateCostExplorerQueryProcess1ApiParams
-func (_e *InvoicesApi_Expecter) CreateCostExplorerQueryProcess1WithParams(ctx interface{}, args interface{}) *InvoicesApi_CreateCostExplorerQueryProcess1WithParams_Call {
+func (_e *InvoicesApi_Expecter) CreateCostExplorerQueryProcess1WithParams(ctx any, args any) *InvoicesApi_CreateCostExplorerQueryProcess1WithParams_Call {
 	return &InvoicesApi_CreateCostExplorerQueryProcess1WithParams_Call{Call: _e.mock.On("CreateCostExplorerQueryProcess1WithParams", ctx, args)}
 }
 
@@ -279,7 +279,7 @@ type InvoicesApi_CreateCostExplorerQueryProcessExecute_Call struct {
 
 // CreateCostExplorerQueryProcessExecute is a helper method to define mock.On call
 //   - r admin.CreateCostExplorerQueryProcessApiRequest
-func (_e *InvoicesApi_Expecter) CreateCostExplorerQueryProcessExecute(r interface{}) *InvoicesApi_CreateCostExplorerQueryProcessExecute_Call {
+func (_e *InvoicesApi_Expecter) CreateCostExplorerQueryProcessExecute(r any) *InvoicesApi_CreateCostExplorerQueryProcessExecute_Call {
 	return &InvoicesApi_CreateCostExplorerQueryProcessExecute_Call{Call: _e.mock.On("CreateCostExplorerQueryProcessExecute", r)}
 }
 
@@ -326,7 +326,7 @@ type InvoicesApi_CreateCostExplorerQueryProcessWithParams_Call struct {
 // CreateCostExplorerQueryProcessWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateCostExplorerQueryProcessApiParams
-func (_e *InvoicesApi_Expecter) CreateCostExplorerQueryProcessWithParams(ctx interface{}, args interface{}) *InvoicesApi_CreateCostExplorerQueryProcessWithParams_Call {
+func (_e *InvoicesApi_Expecter) CreateCostExplorerQueryProcessWithParams(ctx any, args any) *InvoicesApi_CreateCostExplorerQueryProcessWithParams_Call {
 	return &InvoicesApi_CreateCostExplorerQueryProcessWithParams_Call{Call: _e.mock.On("CreateCostExplorerQueryProcessWithParams", ctx, args)}
 }
 
@@ -374,7 +374,7 @@ type InvoicesApi_DownloadInvoiceCSV_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - invoiceId string
-func (_e *InvoicesApi_Expecter) DownloadInvoiceCSV(ctx interface{}, orgId interface{}, invoiceId interface{}) *InvoicesApi_DownloadInvoiceCSV_Call {
+func (_e *InvoicesApi_Expecter) DownloadInvoiceCSV(ctx any, orgId any, invoiceId any) *InvoicesApi_DownloadInvoiceCSV_Call {
 	return &InvoicesApi_DownloadInvoiceCSV_Call{Call: _e.mock.On("DownloadInvoiceCSV", ctx, orgId, invoiceId)}
 }
 
@@ -439,7 +439,7 @@ type InvoicesApi_DownloadInvoiceCSVExecute_Call struct {
 
 // DownloadInvoiceCSVExecute is a helper method to define mock.On call
 //   - r admin.DownloadInvoiceCSVApiRequest
-func (_e *InvoicesApi_Expecter) DownloadInvoiceCSVExecute(r interface{}) *InvoicesApi_DownloadInvoiceCSVExecute_Call {
+func (_e *InvoicesApi_Expecter) DownloadInvoiceCSVExecute(r any) *InvoicesApi_DownloadInvoiceCSVExecute_Call {
 	return &InvoicesApi_DownloadInvoiceCSVExecute_Call{Call: _e.mock.On("DownloadInvoiceCSVExecute", r)}
 }
 
@@ -486,7 +486,7 @@ type InvoicesApi_DownloadInvoiceCSVWithParams_Call struct {
 // DownloadInvoiceCSVWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DownloadInvoiceCSVApiParams
-func (_e *InvoicesApi_Expecter) DownloadInvoiceCSVWithParams(ctx interface{}, args interface{}) *InvoicesApi_DownloadInvoiceCSVWithParams_Call {
+func (_e *InvoicesApi_Expecter) DownloadInvoiceCSVWithParams(ctx any, args any) *InvoicesApi_DownloadInvoiceCSVWithParams_Call {
 	return &InvoicesApi_DownloadInvoiceCSVWithParams_Call{Call: _e.mock.On("DownloadInvoiceCSVWithParams", ctx, args)}
 }
 
@@ -534,7 +534,7 @@ type InvoicesApi_GetInvoice_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - invoiceId string
-func (_e *InvoicesApi_Expecter) GetInvoice(ctx interface{}, orgId interface{}, invoiceId interface{}) *InvoicesApi_GetInvoice_Call {
+func (_e *InvoicesApi_Expecter) GetInvoice(ctx any, orgId any, invoiceId any) *InvoicesApi_GetInvoice_Call {
 	return &InvoicesApi_GetInvoice_Call{Call: _e.mock.On("GetInvoice", ctx, orgId, invoiceId)}
 }
 
@@ -599,7 +599,7 @@ type InvoicesApi_GetInvoiceExecute_Call struct {
 
 // GetInvoiceExecute is a helper method to define mock.On call
 //   - r admin.GetInvoiceApiRequest
-func (_e *InvoicesApi_Expecter) GetInvoiceExecute(r interface{}) *InvoicesApi_GetInvoiceExecute_Call {
+func (_e *InvoicesApi_Expecter) GetInvoiceExecute(r any) *InvoicesApi_GetInvoiceExecute_Call {
 	return &InvoicesApi_GetInvoiceExecute_Call{Call: _e.mock.On("GetInvoiceExecute", r)}
 }
 
@@ -646,7 +646,7 @@ type InvoicesApi_GetInvoiceWithParams_Call struct {
 // GetInvoiceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetInvoiceApiParams
-func (_e *InvoicesApi_Expecter) GetInvoiceWithParams(ctx interface{}, args interface{}) *InvoicesApi_GetInvoiceWithParams_Call {
+func (_e *InvoicesApi_Expecter) GetInvoiceWithParams(ctx any, args any) *InvoicesApi_GetInvoiceWithParams_Call {
 	return &InvoicesApi_GetInvoiceWithParams_Call{Call: _e.mock.On("GetInvoiceWithParams", ctx, args)}
 }
 
@@ -693,7 +693,7 @@ type InvoicesApi_ListInvoices_Call struct {
 // ListInvoices is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *InvoicesApi_Expecter) ListInvoices(ctx interface{}, orgId interface{}) *InvoicesApi_ListInvoices_Call {
+func (_e *InvoicesApi_Expecter) ListInvoices(ctx any, orgId any) *InvoicesApi_ListInvoices_Call {
 	return &InvoicesApi_ListInvoices_Call{Call: _e.mock.On("ListInvoices", ctx, orgId)}
 }
 
@@ -760,7 +760,7 @@ type InvoicesApi_ListInvoicesExecute_Call struct {
 
 // ListInvoicesExecute is a helper method to define mock.On call
 //   - r admin.ListInvoicesApiRequest
-func (_e *InvoicesApi_Expecter) ListInvoicesExecute(r interface{}) *InvoicesApi_ListInvoicesExecute_Call {
+func (_e *InvoicesApi_Expecter) ListInvoicesExecute(r any) *InvoicesApi_ListInvoicesExecute_Call {
 	return &InvoicesApi_ListInvoicesExecute_Call{Call: _e.mock.On("ListInvoicesExecute", r)}
 }
 
@@ -807,7 +807,7 @@ type InvoicesApi_ListInvoicesWithParams_Call struct {
 // ListInvoicesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListInvoicesApiParams
-func (_e *InvoicesApi_Expecter) ListInvoicesWithParams(ctx interface{}, args interface{}) *InvoicesApi_ListInvoicesWithParams_Call {
+func (_e *InvoicesApi_Expecter) ListInvoicesWithParams(ctx any, args any) *InvoicesApi_ListInvoicesWithParams_Call {
 	return &InvoicesApi_ListInvoicesWithParams_Call{Call: _e.mock.On("ListInvoicesWithParams", ctx, args)}
 }
 
@@ -854,7 +854,7 @@ type InvoicesApi_ListPendingInvoices_Call struct {
 // ListPendingInvoices is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *InvoicesApi_Expecter) ListPendingInvoices(ctx interface{}, orgId interface{}) *InvoicesApi_ListPendingInvoices_Call {
+func (_e *InvoicesApi_Expecter) ListPendingInvoices(ctx any, orgId any) *InvoicesApi_ListPendingInvoices_Call {
 	return &InvoicesApi_ListPendingInvoices_Call{Call: _e.mock.On("ListPendingInvoices", ctx, orgId)}
 }
 
@@ -921,7 +921,7 @@ type InvoicesApi_ListPendingInvoicesExecute_Call struct {
 
 // ListPendingInvoicesExecute is a helper method to define mock.On call
 //   - r admin.ListPendingInvoicesApiRequest
-func (_e *InvoicesApi_Expecter) ListPendingInvoicesExecute(r interface{}) *InvoicesApi_ListPendingInvoicesExecute_Call {
+func (_e *InvoicesApi_Expecter) ListPendingInvoicesExecute(r any) *InvoicesApi_ListPendingInvoicesExecute_Call {
 	return &InvoicesApi_ListPendingInvoicesExecute_Call{Call: _e.mock.On("ListPendingInvoicesExecute", r)}
 }
 
@@ -968,7 +968,7 @@ type InvoicesApi_ListPendingInvoicesWithParams_Call struct {
 // ListPendingInvoicesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListPendingInvoicesApiParams
-func (_e *InvoicesApi_Expecter) ListPendingInvoicesWithParams(ctx interface{}, args interface{}) *InvoicesApi_ListPendingInvoicesWithParams_Call {
+func (_e *InvoicesApi_Expecter) ListPendingInvoicesWithParams(ctx any, args any) *InvoicesApi_ListPendingInvoicesWithParams_Call {
 	return &InvoicesApi_ListPendingInvoicesWithParams_Call{Call: _e.mock.On("ListPendingInvoicesWithParams", ctx, args)}
 }
 
@@ -1017,7 +1017,7 @@ type InvoicesApi_QueryLineItemsFromSingleInvoice_Call struct {
 //   - orgId string
 //   - invoiceId string
 //   - apiPublicUsageDetailsQueryRequest *admin.ApiPublicUsageDetailsQueryRequest
-func (_e *InvoicesApi_Expecter) QueryLineItemsFromSingleInvoice(ctx interface{}, orgId interface{}, invoiceId interface{}, apiPublicUsageDetailsQueryRequest interface{}) *InvoicesApi_QueryLineItemsFromSingleInvoice_Call {
+func (_e *InvoicesApi_Expecter) QueryLineItemsFromSingleInvoice(ctx any, orgId any, invoiceId any, apiPublicUsageDetailsQueryRequest any) *InvoicesApi_QueryLineItemsFromSingleInvoice_Call {
 	return &InvoicesApi_QueryLineItemsFromSingleInvoice_Call{Call: _e.mock.On("QueryLineItemsFromSingleInvoice", ctx, orgId, invoiceId, apiPublicUsageDetailsQueryRequest)}
 }
 
@@ -1084,7 +1084,7 @@ type InvoicesApi_QueryLineItemsFromSingleInvoiceExecute_Call struct {
 
 // QueryLineItemsFromSingleInvoiceExecute is a helper method to define mock.On call
 //   - r admin.QueryLineItemsFromSingleInvoiceApiRequest
-func (_e *InvoicesApi_Expecter) QueryLineItemsFromSingleInvoiceExecute(r interface{}) *InvoicesApi_QueryLineItemsFromSingleInvoiceExecute_Call {
+func (_e *InvoicesApi_Expecter) QueryLineItemsFromSingleInvoiceExecute(r any) *InvoicesApi_QueryLineItemsFromSingleInvoiceExecute_Call {
 	return &InvoicesApi_QueryLineItemsFromSingleInvoiceExecute_Call{Call: _e.mock.On("QueryLineItemsFromSingleInvoiceExecute", r)}
 }
 
@@ -1131,7 +1131,7 @@ type InvoicesApi_QueryLineItemsFromSingleInvoiceWithParams_Call struct {
 // QueryLineItemsFromSingleInvoiceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.QueryLineItemsFromSingleInvoiceApiParams
-func (_e *InvoicesApi_Expecter) QueryLineItemsFromSingleInvoiceWithParams(ctx interface{}, args interface{}) *InvoicesApi_QueryLineItemsFromSingleInvoiceWithParams_Call {
+func (_e *InvoicesApi_Expecter) QueryLineItemsFromSingleInvoiceWithParams(ctx any, args any) *InvoicesApi_QueryLineItemsFromSingleInvoiceWithParams_Call {
 	return &InvoicesApi_QueryLineItemsFromSingleInvoiceWithParams_Call{Call: _e.mock.On("QueryLineItemsFromSingleInvoiceWithParams", ctx, args)}
 }
 

--- a/mockadmin/ldap_configuration_api.go
+++ b/mockadmin/ldap_configuration_api.go
@@ -51,7 +51,7 @@ type LDAPConfigurationApi_DeleteLDAPConfiguration_Call struct {
 // DeleteLDAPConfiguration is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *LDAPConfigurationApi_Expecter) DeleteLDAPConfiguration(ctx interface{}, groupId interface{}) *LDAPConfigurationApi_DeleteLDAPConfiguration_Call {
+func (_e *LDAPConfigurationApi_Expecter) DeleteLDAPConfiguration(ctx any, groupId any) *LDAPConfigurationApi_DeleteLDAPConfiguration_Call {
 	return &LDAPConfigurationApi_DeleteLDAPConfiguration_Call{Call: _e.mock.On("DeleteLDAPConfiguration", ctx, groupId)}
 }
 
@@ -118,7 +118,7 @@ type LDAPConfigurationApi_DeleteLDAPConfigurationExecute_Call struct {
 
 // DeleteLDAPConfigurationExecute is a helper method to define mock.On call
 //   - r admin.DeleteLDAPConfigurationApiRequest
-func (_e *LDAPConfigurationApi_Expecter) DeleteLDAPConfigurationExecute(r interface{}) *LDAPConfigurationApi_DeleteLDAPConfigurationExecute_Call {
+func (_e *LDAPConfigurationApi_Expecter) DeleteLDAPConfigurationExecute(r any) *LDAPConfigurationApi_DeleteLDAPConfigurationExecute_Call {
 	return &LDAPConfigurationApi_DeleteLDAPConfigurationExecute_Call{Call: _e.mock.On("DeleteLDAPConfigurationExecute", r)}
 }
 
@@ -165,7 +165,7 @@ type LDAPConfigurationApi_DeleteLDAPConfigurationWithParams_Call struct {
 // DeleteLDAPConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteLDAPConfigurationApiParams
-func (_e *LDAPConfigurationApi_Expecter) DeleteLDAPConfigurationWithParams(ctx interface{}, args interface{}) *LDAPConfigurationApi_DeleteLDAPConfigurationWithParams_Call {
+func (_e *LDAPConfigurationApi_Expecter) DeleteLDAPConfigurationWithParams(ctx any, args any) *LDAPConfigurationApi_DeleteLDAPConfigurationWithParams_Call {
 	return &LDAPConfigurationApi_DeleteLDAPConfigurationWithParams_Call{Call: _e.mock.On("DeleteLDAPConfigurationWithParams", ctx, args)}
 }
 
@@ -212,7 +212,7 @@ type LDAPConfigurationApi_GetLDAPConfiguration_Call struct {
 // GetLDAPConfiguration is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *LDAPConfigurationApi_Expecter) GetLDAPConfiguration(ctx interface{}, groupId interface{}) *LDAPConfigurationApi_GetLDAPConfiguration_Call {
+func (_e *LDAPConfigurationApi_Expecter) GetLDAPConfiguration(ctx any, groupId any) *LDAPConfigurationApi_GetLDAPConfiguration_Call {
 	return &LDAPConfigurationApi_GetLDAPConfiguration_Call{Call: _e.mock.On("GetLDAPConfiguration", ctx, groupId)}
 }
 
@@ -279,7 +279,7 @@ type LDAPConfigurationApi_GetLDAPConfigurationExecute_Call struct {
 
 // GetLDAPConfigurationExecute is a helper method to define mock.On call
 //   - r admin.GetLDAPConfigurationApiRequest
-func (_e *LDAPConfigurationApi_Expecter) GetLDAPConfigurationExecute(r interface{}) *LDAPConfigurationApi_GetLDAPConfigurationExecute_Call {
+func (_e *LDAPConfigurationApi_Expecter) GetLDAPConfigurationExecute(r any) *LDAPConfigurationApi_GetLDAPConfigurationExecute_Call {
 	return &LDAPConfigurationApi_GetLDAPConfigurationExecute_Call{Call: _e.mock.On("GetLDAPConfigurationExecute", r)}
 }
 
@@ -327,7 +327,7 @@ type LDAPConfigurationApi_GetLDAPConfigurationStatus_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - requestId string
-func (_e *LDAPConfigurationApi_Expecter) GetLDAPConfigurationStatus(ctx interface{}, groupId interface{}, requestId interface{}) *LDAPConfigurationApi_GetLDAPConfigurationStatus_Call {
+func (_e *LDAPConfigurationApi_Expecter) GetLDAPConfigurationStatus(ctx any, groupId any, requestId any) *LDAPConfigurationApi_GetLDAPConfigurationStatus_Call {
 	return &LDAPConfigurationApi_GetLDAPConfigurationStatus_Call{Call: _e.mock.On("GetLDAPConfigurationStatus", ctx, groupId, requestId)}
 }
 
@@ -394,7 +394,7 @@ type LDAPConfigurationApi_GetLDAPConfigurationStatusExecute_Call struct {
 
 // GetLDAPConfigurationStatusExecute is a helper method to define mock.On call
 //   - r admin.GetLDAPConfigurationStatusApiRequest
-func (_e *LDAPConfigurationApi_Expecter) GetLDAPConfigurationStatusExecute(r interface{}) *LDAPConfigurationApi_GetLDAPConfigurationStatusExecute_Call {
+func (_e *LDAPConfigurationApi_Expecter) GetLDAPConfigurationStatusExecute(r any) *LDAPConfigurationApi_GetLDAPConfigurationStatusExecute_Call {
 	return &LDAPConfigurationApi_GetLDAPConfigurationStatusExecute_Call{Call: _e.mock.On("GetLDAPConfigurationStatusExecute", r)}
 }
 
@@ -441,7 +441,7 @@ type LDAPConfigurationApi_GetLDAPConfigurationStatusWithParams_Call struct {
 // GetLDAPConfigurationStatusWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetLDAPConfigurationStatusApiParams
-func (_e *LDAPConfigurationApi_Expecter) GetLDAPConfigurationStatusWithParams(ctx interface{}, args interface{}) *LDAPConfigurationApi_GetLDAPConfigurationStatusWithParams_Call {
+func (_e *LDAPConfigurationApi_Expecter) GetLDAPConfigurationStatusWithParams(ctx any, args any) *LDAPConfigurationApi_GetLDAPConfigurationStatusWithParams_Call {
 	return &LDAPConfigurationApi_GetLDAPConfigurationStatusWithParams_Call{Call: _e.mock.On("GetLDAPConfigurationStatusWithParams", ctx, args)}
 }
 
@@ -488,7 +488,7 @@ type LDAPConfigurationApi_GetLDAPConfigurationWithParams_Call struct {
 // GetLDAPConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetLDAPConfigurationApiParams
-func (_e *LDAPConfigurationApi_Expecter) GetLDAPConfigurationWithParams(ctx interface{}, args interface{}) *LDAPConfigurationApi_GetLDAPConfigurationWithParams_Call {
+func (_e *LDAPConfigurationApi_Expecter) GetLDAPConfigurationWithParams(ctx any, args any) *LDAPConfigurationApi_GetLDAPConfigurationWithParams_Call {
 	return &LDAPConfigurationApi_GetLDAPConfigurationWithParams_Call{Call: _e.mock.On("GetLDAPConfigurationWithParams", ctx, args)}
 }
 
@@ -536,7 +536,7 @@ type LDAPConfigurationApi_SaveLDAPConfiguration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - userSecurity *admin.UserSecurity
-func (_e *LDAPConfigurationApi_Expecter) SaveLDAPConfiguration(ctx interface{}, groupId interface{}, userSecurity interface{}) *LDAPConfigurationApi_SaveLDAPConfiguration_Call {
+func (_e *LDAPConfigurationApi_Expecter) SaveLDAPConfiguration(ctx any, groupId any, userSecurity any) *LDAPConfigurationApi_SaveLDAPConfiguration_Call {
 	return &LDAPConfigurationApi_SaveLDAPConfiguration_Call{Call: _e.mock.On("SaveLDAPConfiguration", ctx, groupId, userSecurity)}
 }
 
@@ -603,7 +603,7 @@ type LDAPConfigurationApi_SaveLDAPConfigurationExecute_Call struct {
 
 // SaveLDAPConfigurationExecute is a helper method to define mock.On call
 //   - r admin.SaveLDAPConfigurationApiRequest
-func (_e *LDAPConfigurationApi_Expecter) SaveLDAPConfigurationExecute(r interface{}) *LDAPConfigurationApi_SaveLDAPConfigurationExecute_Call {
+func (_e *LDAPConfigurationApi_Expecter) SaveLDAPConfigurationExecute(r any) *LDAPConfigurationApi_SaveLDAPConfigurationExecute_Call {
 	return &LDAPConfigurationApi_SaveLDAPConfigurationExecute_Call{Call: _e.mock.On("SaveLDAPConfigurationExecute", r)}
 }
 
@@ -650,7 +650,7 @@ type LDAPConfigurationApi_SaveLDAPConfigurationWithParams_Call struct {
 // SaveLDAPConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.SaveLDAPConfigurationApiParams
-func (_e *LDAPConfigurationApi_Expecter) SaveLDAPConfigurationWithParams(ctx interface{}, args interface{}) *LDAPConfigurationApi_SaveLDAPConfigurationWithParams_Call {
+func (_e *LDAPConfigurationApi_Expecter) SaveLDAPConfigurationWithParams(ctx any, args any) *LDAPConfigurationApi_SaveLDAPConfigurationWithParams_Call {
 	return &LDAPConfigurationApi_SaveLDAPConfigurationWithParams_Call{Call: _e.mock.On("SaveLDAPConfigurationWithParams", ctx, args)}
 }
 
@@ -698,7 +698,7 @@ type LDAPConfigurationApi_VerifyLDAPConfiguration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - lDAPVerifyConnectivityJobRequestParams *admin.LDAPVerifyConnectivityJobRequestParams
-func (_e *LDAPConfigurationApi_Expecter) VerifyLDAPConfiguration(ctx interface{}, groupId interface{}, lDAPVerifyConnectivityJobRequestParams interface{}) *LDAPConfigurationApi_VerifyLDAPConfiguration_Call {
+func (_e *LDAPConfigurationApi_Expecter) VerifyLDAPConfiguration(ctx any, groupId any, lDAPVerifyConnectivityJobRequestParams any) *LDAPConfigurationApi_VerifyLDAPConfiguration_Call {
 	return &LDAPConfigurationApi_VerifyLDAPConfiguration_Call{Call: _e.mock.On("VerifyLDAPConfiguration", ctx, groupId, lDAPVerifyConnectivityJobRequestParams)}
 }
 
@@ -765,7 +765,7 @@ type LDAPConfigurationApi_VerifyLDAPConfigurationExecute_Call struct {
 
 // VerifyLDAPConfigurationExecute is a helper method to define mock.On call
 //   - r admin.VerifyLDAPConfigurationApiRequest
-func (_e *LDAPConfigurationApi_Expecter) VerifyLDAPConfigurationExecute(r interface{}) *LDAPConfigurationApi_VerifyLDAPConfigurationExecute_Call {
+func (_e *LDAPConfigurationApi_Expecter) VerifyLDAPConfigurationExecute(r any) *LDAPConfigurationApi_VerifyLDAPConfigurationExecute_Call {
 	return &LDAPConfigurationApi_VerifyLDAPConfigurationExecute_Call{Call: _e.mock.On("VerifyLDAPConfigurationExecute", r)}
 }
 
@@ -812,7 +812,7 @@ type LDAPConfigurationApi_VerifyLDAPConfigurationWithParams_Call struct {
 // VerifyLDAPConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.VerifyLDAPConfigurationApiParams
-func (_e *LDAPConfigurationApi_Expecter) VerifyLDAPConfigurationWithParams(ctx interface{}, args interface{}) *LDAPConfigurationApi_VerifyLDAPConfigurationWithParams_Call {
+func (_e *LDAPConfigurationApi_Expecter) VerifyLDAPConfigurationWithParams(ctx any, args any) *LDAPConfigurationApi_VerifyLDAPConfigurationWithParams_Call {
 	return &LDAPConfigurationApi_VerifyLDAPConfigurationWithParams_Call{Call: _e.mock.On("VerifyLDAPConfigurationWithParams", ctx, args)}
 }
 

--- a/mockadmin/legacy_backup_api.go
+++ b/mockadmin/legacy_backup_api.go
@@ -53,7 +53,7 @@ type LegacyBackupApi_CreateLegacyBackupRestoreJob_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - backupRestoreJob *admin.BackupRestoreJob
-func (_e *LegacyBackupApi_Expecter) CreateLegacyBackupRestoreJob(ctx interface{}, groupId interface{}, clusterName interface{}, backupRestoreJob interface{}) *LegacyBackupApi_CreateLegacyBackupRestoreJob_Call {
+func (_e *LegacyBackupApi_Expecter) CreateLegacyBackupRestoreJob(ctx any, groupId any, clusterName any, backupRestoreJob any) *LegacyBackupApi_CreateLegacyBackupRestoreJob_Call {
 	return &LegacyBackupApi_CreateLegacyBackupRestoreJob_Call{Call: _e.mock.On("CreateLegacyBackupRestoreJob", ctx, groupId, clusterName, backupRestoreJob)}
 }
 
@@ -120,7 +120,7 @@ type LegacyBackupApi_CreateLegacyBackupRestoreJobExecute_Call struct {
 
 // CreateLegacyBackupRestoreJobExecute is a helper method to define mock.On call
 //   - r admin.CreateLegacyBackupRestoreJobApiRequest
-func (_e *LegacyBackupApi_Expecter) CreateLegacyBackupRestoreJobExecute(r interface{}) *LegacyBackupApi_CreateLegacyBackupRestoreJobExecute_Call {
+func (_e *LegacyBackupApi_Expecter) CreateLegacyBackupRestoreJobExecute(r any) *LegacyBackupApi_CreateLegacyBackupRestoreJobExecute_Call {
 	return &LegacyBackupApi_CreateLegacyBackupRestoreJobExecute_Call{Call: _e.mock.On("CreateLegacyBackupRestoreJobExecute", r)}
 }
 
@@ -167,7 +167,7 @@ type LegacyBackupApi_CreateLegacyBackupRestoreJobWithParams_Call struct {
 // CreateLegacyBackupRestoreJobWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateLegacyBackupRestoreJobApiParams
-func (_e *LegacyBackupApi_Expecter) CreateLegacyBackupRestoreJobWithParams(ctx interface{}, args interface{}) *LegacyBackupApi_CreateLegacyBackupRestoreJobWithParams_Call {
+func (_e *LegacyBackupApi_Expecter) CreateLegacyBackupRestoreJobWithParams(ctx any, args any) *LegacyBackupApi_CreateLegacyBackupRestoreJobWithParams_Call {
 	return &LegacyBackupApi_CreateLegacyBackupRestoreJobWithParams_Call{Call: _e.mock.On("CreateLegacyBackupRestoreJobWithParams", ctx, args)}
 }
 
@@ -216,7 +216,7 @@ type LegacyBackupApi_DeleteLegacySnapshot_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - snapshotId string
-func (_e *LegacyBackupApi_Expecter) DeleteLegacySnapshot(ctx interface{}, groupId interface{}, clusterName interface{}, snapshotId interface{}) *LegacyBackupApi_DeleteLegacySnapshot_Call {
+func (_e *LegacyBackupApi_Expecter) DeleteLegacySnapshot(ctx any, groupId any, clusterName any, snapshotId any) *LegacyBackupApi_DeleteLegacySnapshot_Call {
 	return &LegacyBackupApi_DeleteLegacySnapshot_Call{Call: _e.mock.On("DeleteLegacySnapshot", ctx, groupId, clusterName, snapshotId)}
 }
 
@@ -238,24 +238,24 @@ func (_c *LegacyBackupApi_DeleteLegacySnapshot_Call) RunAndReturn(run func(conte
 }
 
 // DeleteLegacySnapshotExecute provides a mock function with given fields: r
-func (_m *LegacyBackupApi) DeleteLegacySnapshotExecute(r admin.DeleteLegacySnapshotApiRequest) (interface{}, *http.Response, error) {
+func (_m *LegacyBackupApi) DeleteLegacySnapshotExecute(r admin.DeleteLegacySnapshotApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteLegacySnapshotExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteLegacySnapshotApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteLegacySnapshotApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteLegacySnapshotApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteLegacySnapshotApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -283,7 +283,7 @@ type LegacyBackupApi_DeleteLegacySnapshotExecute_Call struct {
 
 // DeleteLegacySnapshotExecute is a helper method to define mock.On call
 //   - r admin.DeleteLegacySnapshotApiRequest
-func (_e *LegacyBackupApi_Expecter) DeleteLegacySnapshotExecute(r interface{}) *LegacyBackupApi_DeleteLegacySnapshotExecute_Call {
+func (_e *LegacyBackupApi_Expecter) DeleteLegacySnapshotExecute(r any) *LegacyBackupApi_DeleteLegacySnapshotExecute_Call {
 	return &LegacyBackupApi_DeleteLegacySnapshotExecute_Call{Call: _e.mock.On("DeleteLegacySnapshotExecute", r)}
 }
 
@@ -294,12 +294,12 @@ func (_c *LegacyBackupApi_DeleteLegacySnapshotExecute_Call) Run(run func(r admin
 	return _c
 }
 
-func (_c *LegacyBackupApi_DeleteLegacySnapshotExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *LegacyBackupApi_DeleteLegacySnapshotExecute_Call {
+func (_c *LegacyBackupApi_DeleteLegacySnapshotExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *LegacyBackupApi_DeleteLegacySnapshotExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *LegacyBackupApi_DeleteLegacySnapshotExecute_Call) RunAndReturn(run func(admin.DeleteLegacySnapshotApiRequest) (interface{}, *http.Response, error)) *LegacyBackupApi_DeleteLegacySnapshotExecute_Call {
+func (_c *LegacyBackupApi_DeleteLegacySnapshotExecute_Call) RunAndReturn(run func(admin.DeleteLegacySnapshotApiRequest) (any, *http.Response, error)) *LegacyBackupApi_DeleteLegacySnapshotExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -330,7 +330,7 @@ type LegacyBackupApi_DeleteLegacySnapshotWithParams_Call struct {
 // DeleteLegacySnapshotWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteLegacySnapshotApiParams
-func (_e *LegacyBackupApi_Expecter) DeleteLegacySnapshotWithParams(ctx interface{}, args interface{}) *LegacyBackupApi_DeleteLegacySnapshotWithParams_Call {
+func (_e *LegacyBackupApi_Expecter) DeleteLegacySnapshotWithParams(ctx any, args any) *LegacyBackupApi_DeleteLegacySnapshotWithParams_Call {
 	return &LegacyBackupApi_DeleteLegacySnapshotWithParams_Call{Call: _e.mock.On("DeleteLegacySnapshotWithParams", ctx, args)}
 }
 
@@ -379,7 +379,7 @@ type LegacyBackupApi_GetLegacyBackupCheckpoint_Call struct {
 //   - groupId string
 //   - checkpointId string
 //   - clusterName string
-func (_e *LegacyBackupApi_Expecter) GetLegacyBackupCheckpoint(ctx interface{}, groupId interface{}, checkpointId interface{}, clusterName interface{}) *LegacyBackupApi_GetLegacyBackupCheckpoint_Call {
+func (_e *LegacyBackupApi_Expecter) GetLegacyBackupCheckpoint(ctx any, groupId any, checkpointId any, clusterName any) *LegacyBackupApi_GetLegacyBackupCheckpoint_Call {
 	return &LegacyBackupApi_GetLegacyBackupCheckpoint_Call{Call: _e.mock.On("GetLegacyBackupCheckpoint", ctx, groupId, checkpointId, clusterName)}
 }
 
@@ -446,7 +446,7 @@ type LegacyBackupApi_GetLegacyBackupCheckpointExecute_Call struct {
 
 // GetLegacyBackupCheckpointExecute is a helper method to define mock.On call
 //   - r admin.GetLegacyBackupCheckpointApiRequest
-func (_e *LegacyBackupApi_Expecter) GetLegacyBackupCheckpointExecute(r interface{}) *LegacyBackupApi_GetLegacyBackupCheckpointExecute_Call {
+func (_e *LegacyBackupApi_Expecter) GetLegacyBackupCheckpointExecute(r any) *LegacyBackupApi_GetLegacyBackupCheckpointExecute_Call {
 	return &LegacyBackupApi_GetLegacyBackupCheckpointExecute_Call{Call: _e.mock.On("GetLegacyBackupCheckpointExecute", r)}
 }
 
@@ -493,7 +493,7 @@ type LegacyBackupApi_GetLegacyBackupCheckpointWithParams_Call struct {
 // GetLegacyBackupCheckpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetLegacyBackupCheckpointApiParams
-func (_e *LegacyBackupApi_Expecter) GetLegacyBackupCheckpointWithParams(ctx interface{}, args interface{}) *LegacyBackupApi_GetLegacyBackupCheckpointWithParams_Call {
+func (_e *LegacyBackupApi_Expecter) GetLegacyBackupCheckpointWithParams(ctx any, args any) *LegacyBackupApi_GetLegacyBackupCheckpointWithParams_Call {
 	return &LegacyBackupApi_GetLegacyBackupCheckpointWithParams_Call{Call: _e.mock.On("GetLegacyBackupCheckpointWithParams", ctx, args)}
 }
 
@@ -542,7 +542,7 @@ type LegacyBackupApi_GetLegacyBackupRestoreJob_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - jobId string
-func (_e *LegacyBackupApi_Expecter) GetLegacyBackupRestoreJob(ctx interface{}, groupId interface{}, clusterName interface{}, jobId interface{}) *LegacyBackupApi_GetLegacyBackupRestoreJob_Call {
+func (_e *LegacyBackupApi_Expecter) GetLegacyBackupRestoreJob(ctx any, groupId any, clusterName any, jobId any) *LegacyBackupApi_GetLegacyBackupRestoreJob_Call {
 	return &LegacyBackupApi_GetLegacyBackupRestoreJob_Call{Call: _e.mock.On("GetLegacyBackupRestoreJob", ctx, groupId, clusterName, jobId)}
 }
 
@@ -609,7 +609,7 @@ type LegacyBackupApi_GetLegacyBackupRestoreJobExecute_Call struct {
 
 // GetLegacyBackupRestoreJobExecute is a helper method to define mock.On call
 //   - r admin.GetLegacyBackupRestoreJobApiRequest
-func (_e *LegacyBackupApi_Expecter) GetLegacyBackupRestoreJobExecute(r interface{}) *LegacyBackupApi_GetLegacyBackupRestoreJobExecute_Call {
+func (_e *LegacyBackupApi_Expecter) GetLegacyBackupRestoreJobExecute(r any) *LegacyBackupApi_GetLegacyBackupRestoreJobExecute_Call {
 	return &LegacyBackupApi_GetLegacyBackupRestoreJobExecute_Call{Call: _e.mock.On("GetLegacyBackupRestoreJobExecute", r)}
 }
 
@@ -656,7 +656,7 @@ type LegacyBackupApi_GetLegacyBackupRestoreJobWithParams_Call struct {
 // GetLegacyBackupRestoreJobWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetLegacyBackupRestoreJobApiParams
-func (_e *LegacyBackupApi_Expecter) GetLegacyBackupRestoreJobWithParams(ctx interface{}, args interface{}) *LegacyBackupApi_GetLegacyBackupRestoreJobWithParams_Call {
+func (_e *LegacyBackupApi_Expecter) GetLegacyBackupRestoreJobWithParams(ctx any, args any) *LegacyBackupApi_GetLegacyBackupRestoreJobWithParams_Call {
 	return &LegacyBackupApi_GetLegacyBackupRestoreJobWithParams_Call{Call: _e.mock.On("GetLegacyBackupRestoreJobWithParams", ctx, args)}
 }
 
@@ -705,7 +705,7 @@ type LegacyBackupApi_GetLegacySnapshot_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - snapshotId string
-func (_e *LegacyBackupApi_Expecter) GetLegacySnapshot(ctx interface{}, groupId interface{}, clusterName interface{}, snapshotId interface{}) *LegacyBackupApi_GetLegacySnapshot_Call {
+func (_e *LegacyBackupApi_Expecter) GetLegacySnapshot(ctx any, groupId any, clusterName any, snapshotId any) *LegacyBackupApi_GetLegacySnapshot_Call {
 	return &LegacyBackupApi_GetLegacySnapshot_Call{Call: _e.mock.On("GetLegacySnapshot", ctx, groupId, clusterName, snapshotId)}
 }
 
@@ -772,7 +772,7 @@ type LegacyBackupApi_GetLegacySnapshotExecute_Call struct {
 
 // GetLegacySnapshotExecute is a helper method to define mock.On call
 //   - r admin.GetLegacySnapshotApiRequest
-func (_e *LegacyBackupApi_Expecter) GetLegacySnapshotExecute(r interface{}) *LegacyBackupApi_GetLegacySnapshotExecute_Call {
+func (_e *LegacyBackupApi_Expecter) GetLegacySnapshotExecute(r any) *LegacyBackupApi_GetLegacySnapshotExecute_Call {
 	return &LegacyBackupApi_GetLegacySnapshotExecute_Call{Call: _e.mock.On("GetLegacySnapshotExecute", r)}
 }
 
@@ -820,7 +820,7 @@ type LegacyBackupApi_GetLegacySnapshotSchedule_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *LegacyBackupApi_Expecter) GetLegacySnapshotSchedule(ctx interface{}, groupId interface{}, clusterName interface{}) *LegacyBackupApi_GetLegacySnapshotSchedule_Call {
+func (_e *LegacyBackupApi_Expecter) GetLegacySnapshotSchedule(ctx any, groupId any, clusterName any) *LegacyBackupApi_GetLegacySnapshotSchedule_Call {
 	return &LegacyBackupApi_GetLegacySnapshotSchedule_Call{Call: _e.mock.On("GetLegacySnapshotSchedule", ctx, groupId, clusterName)}
 }
 
@@ -887,7 +887,7 @@ type LegacyBackupApi_GetLegacySnapshotScheduleExecute_Call struct {
 
 // GetLegacySnapshotScheduleExecute is a helper method to define mock.On call
 //   - r admin.GetLegacySnapshotScheduleApiRequest
-func (_e *LegacyBackupApi_Expecter) GetLegacySnapshotScheduleExecute(r interface{}) *LegacyBackupApi_GetLegacySnapshotScheduleExecute_Call {
+func (_e *LegacyBackupApi_Expecter) GetLegacySnapshotScheduleExecute(r any) *LegacyBackupApi_GetLegacySnapshotScheduleExecute_Call {
 	return &LegacyBackupApi_GetLegacySnapshotScheduleExecute_Call{Call: _e.mock.On("GetLegacySnapshotScheduleExecute", r)}
 }
 
@@ -934,7 +934,7 @@ type LegacyBackupApi_GetLegacySnapshotScheduleWithParams_Call struct {
 // GetLegacySnapshotScheduleWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetLegacySnapshotScheduleApiParams
-func (_e *LegacyBackupApi_Expecter) GetLegacySnapshotScheduleWithParams(ctx interface{}, args interface{}) *LegacyBackupApi_GetLegacySnapshotScheduleWithParams_Call {
+func (_e *LegacyBackupApi_Expecter) GetLegacySnapshotScheduleWithParams(ctx any, args any) *LegacyBackupApi_GetLegacySnapshotScheduleWithParams_Call {
 	return &LegacyBackupApi_GetLegacySnapshotScheduleWithParams_Call{Call: _e.mock.On("GetLegacySnapshotScheduleWithParams", ctx, args)}
 }
 
@@ -981,7 +981,7 @@ type LegacyBackupApi_GetLegacySnapshotWithParams_Call struct {
 // GetLegacySnapshotWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetLegacySnapshotApiParams
-func (_e *LegacyBackupApi_Expecter) GetLegacySnapshotWithParams(ctx interface{}, args interface{}) *LegacyBackupApi_GetLegacySnapshotWithParams_Call {
+func (_e *LegacyBackupApi_Expecter) GetLegacySnapshotWithParams(ctx any, args any) *LegacyBackupApi_GetLegacySnapshotWithParams_Call {
 	return &LegacyBackupApi_GetLegacySnapshotWithParams_Call{Call: _e.mock.On("GetLegacySnapshotWithParams", ctx, args)}
 }
 
@@ -1029,7 +1029,7 @@ type LegacyBackupApi_ListLegacyBackupCheckpoints_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *LegacyBackupApi_Expecter) ListLegacyBackupCheckpoints(ctx interface{}, groupId interface{}, clusterName interface{}) *LegacyBackupApi_ListLegacyBackupCheckpoints_Call {
+func (_e *LegacyBackupApi_Expecter) ListLegacyBackupCheckpoints(ctx any, groupId any, clusterName any) *LegacyBackupApi_ListLegacyBackupCheckpoints_Call {
 	return &LegacyBackupApi_ListLegacyBackupCheckpoints_Call{Call: _e.mock.On("ListLegacyBackupCheckpoints", ctx, groupId, clusterName)}
 }
 
@@ -1096,7 +1096,7 @@ type LegacyBackupApi_ListLegacyBackupCheckpointsExecute_Call struct {
 
 // ListLegacyBackupCheckpointsExecute is a helper method to define mock.On call
 //   - r admin.ListLegacyBackupCheckpointsApiRequest
-func (_e *LegacyBackupApi_Expecter) ListLegacyBackupCheckpointsExecute(r interface{}) *LegacyBackupApi_ListLegacyBackupCheckpointsExecute_Call {
+func (_e *LegacyBackupApi_Expecter) ListLegacyBackupCheckpointsExecute(r any) *LegacyBackupApi_ListLegacyBackupCheckpointsExecute_Call {
 	return &LegacyBackupApi_ListLegacyBackupCheckpointsExecute_Call{Call: _e.mock.On("ListLegacyBackupCheckpointsExecute", r)}
 }
 
@@ -1143,7 +1143,7 @@ type LegacyBackupApi_ListLegacyBackupCheckpointsWithParams_Call struct {
 // ListLegacyBackupCheckpointsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListLegacyBackupCheckpointsApiParams
-func (_e *LegacyBackupApi_Expecter) ListLegacyBackupCheckpointsWithParams(ctx interface{}, args interface{}) *LegacyBackupApi_ListLegacyBackupCheckpointsWithParams_Call {
+func (_e *LegacyBackupApi_Expecter) ListLegacyBackupCheckpointsWithParams(ctx any, args any) *LegacyBackupApi_ListLegacyBackupCheckpointsWithParams_Call {
 	return &LegacyBackupApi_ListLegacyBackupCheckpointsWithParams_Call{Call: _e.mock.On("ListLegacyBackupCheckpointsWithParams", ctx, args)}
 }
 
@@ -1191,7 +1191,7 @@ type LegacyBackupApi_ListLegacyBackupRestoreJobs_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *LegacyBackupApi_Expecter) ListLegacyBackupRestoreJobs(ctx interface{}, groupId interface{}, clusterName interface{}) *LegacyBackupApi_ListLegacyBackupRestoreJobs_Call {
+func (_e *LegacyBackupApi_Expecter) ListLegacyBackupRestoreJobs(ctx any, groupId any, clusterName any) *LegacyBackupApi_ListLegacyBackupRestoreJobs_Call {
 	return &LegacyBackupApi_ListLegacyBackupRestoreJobs_Call{Call: _e.mock.On("ListLegacyBackupRestoreJobs", ctx, groupId, clusterName)}
 }
 
@@ -1258,7 +1258,7 @@ type LegacyBackupApi_ListLegacyBackupRestoreJobsExecute_Call struct {
 
 // ListLegacyBackupRestoreJobsExecute is a helper method to define mock.On call
 //   - r admin.ListLegacyBackupRestoreJobsApiRequest
-func (_e *LegacyBackupApi_Expecter) ListLegacyBackupRestoreJobsExecute(r interface{}) *LegacyBackupApi_ListLegacyBackupRestoreJobsExecute_Call {
+func (_e *LegacyBackupApi_Expecter) ListLegacyBackupRestoreJobsExecute(r any) *LegacyBackupApi_ListLegacyBackupRestoreJobsExecute_Call {
 	return &LegacyBackupApi_ListLegacyBackupRestoreJobsExecute_Call{Call: _e.mock.On("ListLegacyBackupRestoreJobsExecute", r)}
 }
 
@@ -1305,7 +1305,7 @@ type LegacyBackupApi_ListLegacyBackupRestoreJobsWithParams_Call struct {
 // ListLegacyBackupRestoreJobsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListLegacyBackupRestoreJobsApiParams
-func (_e *LegacyBackupApi_Expecter) ListLegacyBackupRestoreJobsWithParams(ctx interface{}, args interface{}) *LegacyBackupApi_ListLegacyBackupRestoreJobsWithParams_Call {
+func (_e *LegacyBackupApi_Expecter) ListLegacyBackupRestoreJobsWithParams(ctx any, args any) *LegacyBackupApi_ListLegacyBackupRestoreJobsWithParams_Call {
 	return &LegacyBackupApi_ListLegacyBackupRestoreJobsWithParams_Call{Call: _e.mock.On("ListLegacyBackupRestoreJobsWithParams", ctx, args)}
 }
 
@@ -1353,7 +1353,7 @@ type LegacyBackupApi_ListLegacySnapshots_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *LegacyBackupApi_Expecter) ListLegacySnapshots(ctx interface{}, groupId interface{}, clusterName interface{}) *LegacyBackupApi_ListLegacySnapshots_Call {
+func (_e *LegacyBackupApi_Expecter) ListLegacySnapshots(ctx any, groupId any, clusterName any) *LegacyBackupApi_ListLegacySnapshots_Call {
 	return &LegacyBackupApi_ListLegacySnapshots_Call{Call: _e.mock.On("ListLegacySnapshots", ctx, groupId, clusterName)}
 }
 
@@ -1420,7 +1420,7 @@ type LegacyBackupApi_ListLegacySnapshotsExecute_Call struct {
 
 // ListLegacySnapshotsExecute is a helper method to define mock.On call
 //   - r admin.ListLegacySnapshotsApiRequest
-func (_e *LegacyBackupApi_Expecter) ListLegacySnapshotsExecute(r interface{}) *LegacyBackupApi_ListLegacySnapshotsExecute_Call {
+func (_e *LegacyBackupApi_Expecter) ListLegacySnapshotsExecute(r any) *LegacyBackupApi_ListLegacySnapshotsExecute_Call {
 	return &LegacyBackupApi_ListLegacySnapshotsExecute_Call{Call: _e.mock.On("ListLegacySnapshotsExecute", r)}
 }
 
@@ -1467,7 +1467,7 @@ type LegacyBackupApi_ListLegacySnapshotsWithParams_Call struct {
 // ListLegacySnapshotsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListLegacySnapshotsApiParams
-func (_e *LegacyBackupApi_Expecter) ListLegacySnapshotsWithParams(ctx interface{}, args interface{}) *LegacyBackupApi_ListLegacySnapshotsWithParams_Call {
+func (_e *LegacyBackupApi_Expecter) ListLegacySnapshotsWithParams(ctx any, args any) *LegacyBackupApi_ListLegacySnapshotsWithParams_Call {
 	return &LegacyBackupApi_ListLegacySnapshotsWithParams_Call{Call: _e.mock.On("ListLegacySnapshotsWithParams", ctx, args)}
 }
 
@@ -1517,7 +1517,7 @@ type LegacyBackupApi_UpdateLegacySnapshotRetention_Call struct {
 //   - clusterName string
 //   - snapshotId string
 //   - backupSnapshot *admin.BackupSnapshot
-func (_e *LegacyBackupApi_Expecter) UpdateLegacySnapshotRetention(ctx interface{}, groupId interface{}, clusterName interface{}, snapshotId interface{}, backupSnapshot interface{}) *LegacyBackupApi_UpdateLegacySnapshotRetention_Call {
+func (_e *LegacyBackupApi_Expecter) UpdateLegacySnapshotRetention(ctx any, groupId any, clusterName any, snapshotId any, backupSnapshot any) *LegacyBackupApi_UpdateLegacySnapshotRetention_Call {
 	return &LegacyBackupApi_UpdateLegacySnapshotRetention_Call{Call: _e.mock.On("UpdateLegacySnapshotRetention", ctx, groupId, clusterName, snapshotId, backupSnapshot)}
 }
 
@@ -1584,7 +1584,7 @@ type LegacyBackupApi_UpdateLegacySnapshotRetentionExecute_Call struct {
 
 // UpdateLegacySnapshotRetentionExecute is a helper method to define mock.On call
 //   - r admin.UpdateLegacySnapshotRetentionApiRequest
-func (_e *LegacyBackupApi_Expecter) UpdateLegacySnapshotRetentionExecute(r interface{}) *LegacyBackupApi_UpdateLegacySnapshotRetentionExecute_Call {
+func (_e *LegacyBackupApi_Expecter) UpdateLegacySnapshotRetentionExecute(r any) *LegacyBackupApi_UpdateLegacySnapshotRetentionExecute_Call {
 	return &LegacyBackupApi_UpdateLegacySnapshotRetentionExecute_Call{Call: _e.mock.On("UpdateLegacySnapshotRetentionExecute", r)}
 }
 
@@ -1631,7 +1631,7 @@ type LegacyBackupApi_UpdateLegacySnapshotRetentionWithParams_Call struct {
 // UpdateLegacySnapshotRetentionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateLegacySnapshotRetentionApiParams
-func (_e *LegacyBackupApi_Expecter) UpdateLegacySnapshotRetentionWithParams(ctx interface{}, args interface{}) *LegacyBackupApi_UpdateLegacySnapshotRetentionWithParams_Call {
+func (_e *LegacyBackupApi_Expecter) UpdateLegacySnapshotRetentionWithParams(ctx any, args any) *LegacyBackupApi_UpdateLegacySnapshotRetentionWithParams_Call {
 	return &LegacyBackupApi_UpdateLegacySnapshotRetentionWithParams_Call{Call: _e.mock.On("UpdateLegacySnapshotRetentionWithParams", ctx, args)}
 }
 
@@ -1680,7 +1680,7 @@ type LegacyBackupApi_UpdateLegacySnapshotSchedule_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - apiAtlasSnapshotSchedule *admin.ApiAtlasSnapshotSchedule
-func (_e *LegacyBackupApi_Expecter) UpdateLegacySnapshotSchedule(ctx interface{}, groupId interface{}, clusterName interface{}, apiAtlasSnapshotSchedule interface{}) *LegacyBackupApi_UpdateLegacySnapshotSchedule_Call {
+func (_e *LegacyBackupApi_Expecter) UpdateLegacySnapshotSchedule(ctx any, groupId any, clusterName any, apiAtlasSnapshotSchedule any) *LegacyBackupApi_UpdateLegacySnapshotSchedule_Call {
 	return &LegacyBackupApi_UpdateLegacySnapshotSchedule_Call{Call: _e.mock.On("UpdateLegacySnapshotSchedule", ctx, groupId, clusterName, apiAtlasSnapshotSchedule)}
 }
 
@@ -1747,7 +1747,7 @@ type LegacyBackupApi_UpdateLegacySnapshotScheduleExecute_Call struct {
 
 // UpdateLegacySnapshotScheduleExecute is a helper method to define mock.On call
 //   - r admin.UpdateLegacySnapshotScheduleApiRequest
-func (_e *LegacyBackupApi_Expecter) UpdateLegacySnapshotScheduleExecute(r interface{}) *LegacyBackupApi_UpdateLegacySnapshotScheduleExecute_Call {
+func (_e *LegacyBackupApi_Expecter) UpdateLegacySnapshotScheduleExecute(r any) *LegacyBackupApi_UpdateLegacySnapshotScheduleExecute_Call {
 	return &LegacyBackupApi_UpdateLegacySnapshotScheduleExecute_Call{Call: _e.mock.On("UpdateLegacySnapshotScheduleExecute", r)}
 }
 
@@ -1794,7 +1794,7 @@ type LegacyBackupApi_UpdateLegacySnapshotScheduleWithParams_Call struct {
 // UpdateLegacySnapshotScheduleWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateLegacySnapshotScheduleApiParams
-func (_e *LegacyBackupApi_Expecter) UpdateLegacySnapshotScheduleWithParams(ctx interface{}, args interface{}) *LegacyBackupApi_UpdateLegacySnapshotScheduleWithParams_Call {
+func (_e *LegacyBackupApi_Expecter) UpdateLegacySnapshotScheduleWithParams(ctx any, args any) *LegacyBackupApi_UpdateLegacySnapshotScheduleWithParams_Call {
 	return &LegacyBackupApi_UpdateLegacySnapshotScheduleWithParams_Call{Call: _e.mock.On("UpdateLegacySnapshotScheduleWithParams", ctx, args)}
 }
 

--- a/mockadmin/maintenance_windows_api.go
+++ b/mockadmin/maintenance_windows_api.go
@@ -51,7 +51,7 @@ type MaintenanceWindowsApi_DeferMaintenanceWindow_Call struct {
 // DeferMaintenanceWindow is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *MaintenanceWindowsApi_Expecter) DeferMaintenanceWindow(ctx interface{}, groupId interface{}) *MaintenanceWindowsApi_DeferMaintenanceWindow_Call {
+func (_e *MaintenanceWindowsApi_Expecter) DeferMaintenanceWindow(ctx any, groupId any) *MaintenanceWindowsApi_DeferMaintenanceWindow_Call {
 	return &MaintenanceWindowsApi_DeferMaintenanceWindow_Call{Call: _e.mock.On("DeferMaintenanceWindow", ctx, groupId)}
 }
 
@@ -109,7 +109,7 @@ type MaintenanceWindowsApi_DeferMaintenanceWindowExecute_Call struct {
 
 // DeferMaintenanceWindowExecute is a helper method to define mock.On call
 //   - r admin.DeferMaintenanceWindowApiRequest
-func (_e *MaintenanceWindowsApi_Expecter) DeferMaintenanceWindowExecute(r interface{}) *MaintenanceWindowsApi_DeferMaintenanceWindowExecute_Call {
+func (_e *MaintenanceWindowsApi_Expecter) DeferMaintenanceWindowExecute(r any) *MaintenanceWindowsApi_DeferMaintenanceWindowExecute_Call {
 	return &MaintenanceWindowsApi_DeferMaintenanceWindowExecute_Call{Call: _e.mock.On("DeferMaintenanceWindowExecute", r)}
 }
 
@@ -156,7 +156,7 @@ type MaintenanceWindowsApi_DeferMaintenanceWindowWithParams_Call struct {
 // DeferMaintenanceWindowWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeferMaintenanceWindowApiParams
-func (_e *MaintenanceWindowsApi_Expecter) DeferMaintenanceWindowWithParams(ctx interface{}, args interface{}) *MaintenanceWindowsApi_DeferMaintenanceWindowWithParams_Call {
+func (_e *MaintenanceWindowsApi_Expecter) DeferMaintenanceWindowWithParams(ctx any, args any) *MaintenanceWindowsApi_DeferMaintenanceWindowWithParams_Call {
 	return &MaintenanceWindowsApi_DeferMaintenanceWindowWithParams_Call{Call: _e.mock.On("DeferMaintenanceWindowWithParams", ctx, args)}
 }
 
@@ -203,7 +203,7 @@ type MaintenanceWindowsApi_GetMaintenanceWindow_Call struct {
 // GetMaintenanceWindow is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *MaintenanceWindowsApi_Expecter) GetMaintenanceWindow(ctx interface{}, groupId interface{}) *MaintenanceWindowsApi_GetMaintenanceWindow_Call {
+func (_e *MaintenanceWindowsApi_Expecter) GetMaintenanceWindow(ctx any, groupId any) *MaintenanceWindowsApi_GetMaintenanceWindow_Call {
 	return &MaintenanceWindowsApi_GetMaintenanceWindow_Call{Call: _e.mock.On("GetMaintenanceWindow", ctx, groupId)}
 }
 
@@ -270,7 +270,7 @@ type MaintenanceWindowsApi_GetMaintenanceWindowExecute_Call struct {
 
 // GetMaintenanceWindowExecute is a helper method to define mock.On call
 //   - r admin.GetMaintenanceWindowApiRequest
-func (_e *MaintenanceWindowsApi_Expecter) GetMaintenanceWindowExecute(r interface{}) *MaintenanceWindowsApi_GetMaintenanceWindowExecute_Call {
+func (_e *MaintenanceWindowsApi_Expecter) GetMaintenanceWindowExecute(r any) *MaintenanceWindowsApi_GetMaintenanceWindowExecute_Call {
 	return &MaintenanceWindowsApi_GetMaintenanceWindowExecute_Call{Call: _e.mock.On("GetMaintenanceWindowExecute", r)}
 }
 
@@ -317,7 +317,7 @@ type MaintenanceWindowsApi_GetMaintenanceWindowWithParams_Call struct {
 // GetMaintenanceWindowWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetMaintenanceWindowApiParams
-func (_e *MaintenanceWindowsApi_Expecter) GetMaintenanceWindowWithParams(ctx interface{}, args interface{}) *MaintenanceWindowsApi_GetMaintenanceWindowWithParams_Call {
+func (_e *MaintenanceWindowsApi_Expecter) GetMaintenanceWindowWithParams(ctx any, args any) *MaintenanceWindowsApi_GetMaintenanceWindowWithParams_Call {
 	return &MaintenanceWindowsApi_GetMaintenanceWindowWithParams_Call{Call: _e.mock.On("GetMaintenanceWindowWithParams", ctx, args)}
 }
 
@@ -364,7 +364,7 @@ type MaintenanceWindowsApi_ResetMaintenanceWindow_Call struct {
 // ResetMaintenanceWindow is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *MaintenanceWindowsApi_Expecter) ResetMaintenanceWindow(ctx interface{}, groupId interface{}) *MaintenanceWindowsApi_ResetMaintenanceWindow_Call {
+func (_e *MaintenanceWindowsApi_Expecter) ResetMaintenanceWindow(ctx any, groupId any) *MaintenanceWindowsApi_ResetMaintenanceWindow_Call {
 	return &MaintenanceWindowsApi_ResetMaintenanceWindow_Call{Call: _e.mock.On("ResetMaintenanceWindow", ctx, groupId)}
 }
 
@@ -422,7 +422,7 @@ type MaintenanceWindowsApi_ResetMaintenanceWindowExecute_Call struct {
 
 // ResetMaintenanceWindowExecute is a helper method to define mock.On call
 //   - r admin.ResetMaintenanceWindowApiRequest
-func (_e *MaintenanceWindowsApi_Expecter) ResetMaintenanceWindowExecute(r interface{}) *MaintenanceWindowsApi_ResetMaintenanceWindowExecute_Call {
+func (_e *MaintenanceWindowsApi_Expecter) ResetMaintenanceWindowExecute(r any) *MaintenanceWindowsApi_ResetMaintenanceWindowExecute_Call {
 	return &MaintenanceWindowsApi_ResetMaintenanceWindowExecute_Call{Call: _e.mock.On("ResetMaintenanceWindowExecute", r)}
 }
 
@@ -469,7 +469,7 @@ type MaintenanceWindowsApi_ResetMaintenanceWindowWithParams_Call struct {
 // ResetMaintenanceWindowWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ResetMaintenanceWindowApiParams
-func (_e *MaintenanceWindowsApi_Expecter) ResetMaintenanceWindowWithParams(ctx interface{}, args interface{}) *MaintenanceWindowsApi_ResetMaintenanceWindowWithParams_Call {
+func (_e *MaintenanceWindowsApi_Expecter) ResetMaintenanceWindowWithParams(ctx any, args any) *MaintenanceWindowsApi_ResetMaintenanceWindowWithParams_Call {
 	return &MaintenanceWindowsApi_ResetMaintenanceWindowWithParams_Call{Call: _e.mock.On("ResetMaintenanceWindowWithParams", ctx, args)}
 }
 
@@ -516,7 +516,7 @@ type MaintenanceWindowsApi_ToggleMaintenanceAutoDefer_Call struct {
 // ToggleMaintenanceAutoDefer is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *MaintenanceWindowsApi_Expecter) ToggleMaintenanceAutoDefer(ctx interface{}, groupId interface{}) *MaintenanceWindowsApi_ToggleMaintenanceAutoDefer_Call {
+func (_e *MaintenanceWindowsApi_Expecter) ToggleMaintenanceAutoDefer(ctx any, groupId any) *MaintenanceWindowsApi_ToggleMaintenanceAutoDefer_Call {
 	return &MaintenanceWindowsApi_ToggleMaintenanceAutoDefer_Call{Call: _e.mock.On("ToggleMaintenanceAutoDefer", ctx, groupId)}
 }
 
@@ -574,7 +574,7 @@ type MaintenanceWindowsApi_ToggleMaintenanceAutoDeferExecute_Call struct {
 
 // ToggleMaintenanceAutoDeferExecute is a helper method to define mock.On call
 //   - r admin.ToggleMaintenanceAutoDeferApiRequest
-func (_e *MaintenanceWindowsApi_Expecter) ToggleMaintenanceAutoDeferExecute(r interface{}) *MaintenanceWindowsApi_ToggleMaintenanceAutoDeferExecute_Call {
+func (_e *MaintenanceWindowsApi_Expecter) ToggleMaintenanceAutoDeferExecute(r any) *MaintenanceWindowsApi_ToggleMaintenanceAutoDeferExecute_Call {
 	return &MaintenanceWindowsApi_ToggleMaintenanceAutoDeferExecute_Call{Call: _e.mock.On("ToggleMaintenanceAutoDeferExecute", r)}
 }
 
@@ -621,7 +621,7 @@ type MaintenanceWindowsApi_ToggleMaintenanceAutoDeferWithParams_Call struct {
 // ToggleMaintenanceAutoDeferWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ToggleMaintenanceAutoDeferApiParams
-func (_e *MaintenanceWindowsApi_Expecter) ToggleMaintenanceAutoDeferWithParams(ctx interface{}, args interface{}) *MaintenanceWindowsApi_ToggleMaintenanceAutoDeferWithParams_Call {
+func (_e *MaintenanceWindowsApi_Expecter) ToggleMaintenanceAutoDeferWithParams(ctx any, args any) *MaintenanceWindowsApi_ToggleMaintenanceAutoDeferWithParams_Call {
 	return &MaintenanceWindowsApi_ToggleMaintenanceAutoDeferWithParams_Call{Call: _e.mock.On("ToggleMaintenanceAutoDeferWithParams", ctx, args)}
 }
 
@@ -669,7 +669,7 @@ type MaintenanceWindowsApi_UpdateMaintenanceWindow_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - groupMaintenanceWindow *admin.GroupMaintenanceWindow
-func (_e *MaintenanceWindowsApi_Expecter) UpdateMaintenanceWindow(ctx interface{}, groupId interface{}, groupMaintenanceWindow interface{}) *MaintenanceWindowsApi_UpdateMaintenanceWindow_Call {
+func (_e *MaintenanceWindowsApi_Expecter) UpdateMaintenanceWindow(ctx any, groupId any, groupMaintenanceWindow any) *MaintenanceWindowsApi_UpdateMaintenanceWindow_Call {
 	return &MaintenanceWindowsApi_UpdateMaintenanceWindow_Call{Call: _e.mock.On("UpdateMaintenanceWindow", ctx, groupId, groupMaintenanceWindow)}
 }
 
@@ -691,24 +691,24 @@ func (_c *MaintenanceWindowsApi_UpdateMaintenanceWindow_Call) RunAndReturn(run f
 }
 
 // UpdateMaintenanceWindowExecute provides a mock function with given fields: r
-func (_m *MaintenanceWindowsApi) UpdateMaintenanceWindowExecute(r admin.UpdateMaintenanceWindowApiRequest) (interface{}, *http.Response, error) {
+func (_m *MaintenanceWindowsApi) UpdateMaintenanceWindowExecute(r admin.UpdateMaintenanceWindowApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateMaintenanceWindowExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.UpdateMaintenanceWindowApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.UpdateMaintenanceWindowApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.UpdateMaintenanceWindowApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.UpdateMaintenanceWindowApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -736,7 +736,7 @@ type MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call struct {
 
 // UpdateMaintenanceWindowExecute is a helper method to define mock.On call
 //   - r admin.UpdateMaintenanceWindowApiRequest
-func (_e *MaintenanceWindowsApi_Expecter) UpdateMaintenanceWindowExecute(r interface{}) *MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call {
+func (_e *MaintenanceWindowsApi_Expecter) UpdateMaintenanceWindowExecute(r any) *MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call {
 	return &MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call{Call: _e.mock.On("UpdateMaintenanceWindowExecute", r)}
 }
 
@@ -747,12 +747,12 @@ func (_c *MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call) Run(run fun
 	return _c
 }
 
-func (_c *MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call {
+func (_c *MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call) RunAndReturn(run func(admin.UpdateMaintenanceWindowApiRequest) (interface{}, *http.Response, error)) *MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call {
+func (_c *MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call) RunAndReturn(run func(admin.UpdateMaintenanceWindowApiRequest) (any, *http.Response, error)) *MaintenanceWindowsApi_UpdateMaintenanceWindowExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -783,7 +783,7 @@ type MaintenanceWindowsApi_UpdateMaintenanceWindowWithParams_Call struct {
 // UpdateMaintenanceWindowWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateMaintenanceWindowApiParams
-func (_e *MaintenanceWindowsApi_Expecter) UpdateMaintenanceWindowWithParams(ctx interface{}, args interface{}) *MaintenanceWindowsApi_UpdateMaintenanceWindowWithParams_Call {
+func (_e *MaintenanceWindowsApi_Expecter) UpdateMaintenanceWindowWithParams(ctx any, args any) *MaintenanceWindowsApi_UpdateMaintenanceWindowWithParams_Call {
 	return &MaintenanceWindowsApi_UpdateMaintenanceWindowWithParams_Call{Call: _e.mock.On("UpdateMaintenanceWindowWithParams", ctx, args)}
 }
 

--- a/mockadmin/mongo_db_cloud_users_api.go
+++ b/mockadmin/mongo_db_cloud_users_api.go
@@ -51,7 +51,7 @@ type MongoDBCloudUsersApi_CreateUser_Call struct {
 // CreateUser is a helper method to define mock.On call
 //   - ctx context.Context
 //   - cloudAppUser *admin.CloudAppUser
-func (_e *MongoDBCloudUsersApi_Expecter) CreateUser(ctx interface{}, cloudAppUser interface{}) *MongoDBCloudUsersApi_CreateUser_Call {
+func (_e *MongoDBCloudUsersApi_Expecter) CreateUser(ctx any, cloudAppUser any) *MongoDBCloudUsersApi_CreateUser_Call {
 	return &MongoDBCloudUsersApi_CreateUser_Call{Call: _e.mock.On("CreateUser", ctx, cloudAppUser)}
 }
 
@@ -118,7 +118,7 @@ type MongoDBCloudUsersApi_CreateUserExecute_Call struct {
 
 // CreateUserExecute is a helper method to define mock.On call
 //   - r admin.CreateUserApiRequest
-func (_e *MongoDBCloudUsersApi_Expecter) CreateUserExecute(r interface{}) *MongoDBCloudUsersApi_CreateUserExecute_Call {
+func (_e *MongoDBCloudUsersApi_Expecter) CreateUserExecute(r any) *MongoDBCloudUsersApi_CreateUserExecute_Call {
 	return &MongoDBCloudUsersApi_CreateUserExecute_Call{Call: _e.mock.On("CreateUserExecute", r)}
 }
 
@@ -165,7 +165,7 @@ type MongoDBCloudUsersApi_CreateUserWithParams_Call struct {
 // CreateUserWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateUserApiParams
-func (_e *MongoDBCloudUsersApi_Expecter) CreateUserWithParams(ctx interface{}, args interface{}) *MongoDBCloudUsersApi_CreateUserWithParams_Call {
+func (_e *MongoDBCloudUsersApi_Expecter) CreateUserWithParams(ctx any, args any) *MongoDBCloudUsersApi_CreateUserWithParams_Call {
 	return &MongoDBCloudUsersApi_CreateUserWithParams_Call{Call: _e.mock.On("CreateUserWithParams", ctx, args)}
 }
 
@@ -212,7 +212,7 @@ type MongoDBCloudUsersApi_GetUser_Call struct {
 // GetUser is a helper method to define mock.On call
 //   - ctx context.Context
 //   - userId string
-func (_e *MongoDBCloudUsersApi_Expecter) GetUser(ctx interface{}, userId interface{}) *MongoDBCloudUsersApi_GetUser_Call {
+func (_e *MongoDBCloudUsersApi_Expecter) GetUser(ctx any, userId any) *MongoDBCloudUsersApi_GetUser_Call {
 	return &MongoDBCloudUsersApi_GetUser_Call{Call: _e.mock.On("GetUser", ctx, userId)}
 }
 
@@ -259,7 +259,7 @@ type MongoDBCloudUsersApi_GetUserByUsername_Call struct {
 // GetUserByUsername is a helper method to define mock.On call
 //   - ctx context.Context
 //   - userName string
-func (_e *MongoDBCloudUsersApi_Expecter) GetUserByUsername(ctx interface{}, userName interface{}) *MongoDBCloudUsersApi_GetUserByUsername_Call {
+func (_e *MongoDBCloudUsersApi_Expecter) GetUserByUsername(ctx any, userName any) *MongoDBCloudUsersApi_GetUserByUsername_Call {
 	return &MongoDBCloudUsersApi_GetUserByUsername_Call{Call: _e.mock.On("GetUserByUsername", ctx, userName)}
 }
 
@@ -326,7 +326,7 @@ type MongoDBCloudUsersApi_GetUserByUsernameExecute_Call struct {
 
 // GetUserByUsernameExecute is a helper method to define mock.On call
 //   - r admin.GetUserByUsernameApiRequest
-func (_e *MongoDBCloudUsersApi_Expecter) GetUserByUsernameExecute(r interface{}) *MongoDBCloudUsersApi_GetUserByUsernameExecute_Call {
+func (_e *MongoDBCloudUsersApi_Expecter) GetUserByUsernameExecute(r any) *MongoDBCloudUsersApi_GetUserByUsernameExecute_Call {
 	return &MongoDBCloudUsersApi_GetUserByUsernameExecute_Call{Call: _e.mock.On("GetUserByUsernameExecute", r)}
 }
 
@@ -373,7 +373,7 @@ type MongoDBCloudUsersApi_GetUserByUsernameWithParams_Call struct {
 // GetUserByUsernameWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetUserByUsernameApiParams
-func (_e *MongoDBCloudUsersApi_Expecter) GetUserByUsernameWithParams(ctx interface{}, args interface{}) *MongoDBCloudUsersApi_GetUserByUsernameWithParams_Call {
+func (_e *MongoDBCloudUsersApi_Expecter) GetUserByUsernameWithParams(ctx any, args any) *MongoDBCloudUsersApi_GetUserByUsernameWithParams_Call {
 	return &MongoDBCloudUsersApi_GetUserByUsernameWithParams_Call{Call: _e.mock.On("GetUserByUsernameWithParams", ctx, args)}
 }
 
@@ -440,7 +440,7 @@ type MongoDBCloudUsersApi_GetUserExecute_Call struct {
 
 // GetUserExecute is a helper method to define mock.On call
 //   - r admin.GetUserApiRequest
-func (_e *MongoDBCloudUsersApi_Expecter) GetUserExecute(r interface{}) *MongoDBCloudUsersApi_GetUserExecute_Call {
+func (_e *MongoDBCloudUsersApi_Expecter) GetUserExecute(r any) *MongoDBCloudUsersApi_GetUserExecute_Call {
 	return &MongoDBCloudUsersApi_GetUserExecute_Call{Call: _e.mock.On("GetUserExecute", r)}
 }
 
@@ -487,7 +487,7 @@ type MongoDBCloudUsersApi_GetUserWithParams_Call struct {
 // GetUserWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetUserApiParams
-func (_e *MongoDBCloudUsersApi_Expecter) GetUserWithParams(ctx interface{}, args interface{}) *MongoDBCloudUsersApi_GetUserWithParams_Call {
+func (_e *MongoDBCloudUsersApi_Expecter) GetUserWithParams(ctx any, args any) *MongoDBCloudUsersApi_GetUserWithParams_Call {
 	return &MongoDBCloudUsersApi_GetUserWithParams_Call{Call: _e.mock.On("GetUserWithParams", ctx, args)}
 }
 

--- a/mockadmin/monitoring_and_logs_api.go
+++ b/mockadmin/monitoring_and_logs_api.go
@@ -54,7 +54,7 @@ type MonitoringAndLogsApi_GetAtlasProcess_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - processId string
-func (_e *MonitoringAndLogsApi_Expecter) GetAtlasProcess(ctx interface{}, groupId interface{}, processId interface{}) *MonitoringAndLogsApi_GetAtlasProcess_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetAtlasProcess(ctx any, groupId any, processId any) *MonitoringAndLogsApi_GetAtlasProcess_Call {
 	return &MonitoringAndLogsApi_GetAtlasProcess_Call{Call: _e.mock.On("GetAtlasProcess", ctx, groupId, processId)}
 }
 
@@ -121,7 +121,7 @@ type MonitoringAndLogsApi_GetAtlasProcessExecute_Call struct {
 
 // GetAtlasProcessExecute is a helper method to define mock.On call
 //   - r admin.GetAtlasProcessApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) GetAtlasProcessExecute(r interface{}) *MonitoringAndLogsApi_GetAtlasProcessExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetAtlasProcessExecute(r any) *MonitoringAndLogsApi_GetAtlasProcessExecute_Call {
 	return &MonitoringAndLogsApi_GetAtlasProcessExecute_Call{Call: _e.mock.On("GetAtlasProcessExecute", r)}
 }
 
@@ -168,7 +168,7 @@ type MonitoringAndLogsApi_GetAtlasProcessWithParams_Call struct {
 // GetAtlasProcessWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetAtlasProcessApiParams
-func (_e *MonitoringAndLogsApi_Expecter) GetAtlasProcessWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_GetAtlasProcessWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetAtlasProcessWithParams(ctx any, args any) *MonitoringAndLogsApi_GetAtlasProcessWithParams_Call {
 	return &MonitoringAndLogsApi_GetAtlasProcessWithParams_Call{Call: _e.mock.On("GetAtlasProcessWithParams", ctx, args)}
 }
 
@@ -217,7 +217,7 @@ type MonitoringAndLogsApi_GetDatabase_Call struct {
 //   - groupId string
 //   - databaseName string
 //   - processId string
-func (_e *MonitoringAndLogsApi_Expecter) GetDatabase(ctx interface{}, groupId interface{}, databaseName interface{}, processId interface{}) *MonitoringAndLogsApi_GetDatabase_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetDatabase(ctx any, groupId any, databaseName any, processId any) *MonitoringAndLogsApi_GetDatabase_Call {
 	return &MonitoringAndLogsApi_GetDatabase_Call{Call: _e.mock.On("GetDatabase", ctx, groupId, databaseName, processId)}
 }
 
@@ -284,7 +284,7 @@ type MonitoringAndLogsApi_GetDatabaseExecute_Call struct {
 
 // GetDatabaseExecute is a helper method to define mock.On call
 //   - r admin.GetDatabaseApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) GetDatabaseExecute(r interface{}) *MonitoringAndLogsApi_GetDatabaseExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetDatabaseExecute(r any) *MonitoringAndLogsApi_GetDatabaseExecute_Call {
 	return &MonitoringAndLogsApi_GetDatabaseExecute_Call{Call: _e.mock.On("GetDatabaseExecute", r)}
 }
 
@@ -333,7 +333,7 @@ type MonitoringAndLogsApi_GetDatabaseMeasurements_Call struct {
 //   - groupId string
 //   - databaseName string
 //   - processId string
-func (_e *MonitoringAndLogsApi_Expecter) GetDatabaseMeasurements(ctx interface{}, groupId interface{}, databaseName interface{}, processId interface{}) *MonitoringAndLogsApi_GetDatabaseMeasurements_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetDatabaseMeasurements(ctx any, groupId any, databaseName any, processId any) *MonitoringAndLogsApi_GetDatabaseMeasurements_Call {
 	return &MonitoringAndLogsApi_GetDatabaseMeasurements_Call{Call: _e.mock.On("GetDatabaseMeasurements", ctx, groupId, databaseName, processId)}
 }
 
@@ -400,7 +400,7 @@ type MonitoringAndLogsApi_GetDatabaseMeasurementsExecute_Call struct {
 
 // GetDatabaseMeasurementsExecute is a helper method to define mock.On call
 //   - r admin.GetDatabaseMeasurementsApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) GetDatabaseMeasurementsExecute(r interface{}) *MonitoringAndLogsApi_GetDatabaseMeasurementsExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetDatabaseMeasurementsExecute(r any) *MonitoringAndLogsApi_GetDatabaseMeasurementsExecute_Call {
 	return &MonitoringAndLogsApi_GetDatabaseMeasurementsExecute_Call{Call: _e.mock.On("GetDatabaseMeasurementsExecute", r)}
 }
 
@@ -447,7 +447,7 @@ type MonitoringAndLogsApi_GetDatabaseMeasurementsWithParams_Call struct {
 // GetDatabaseMeasurementsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetDatabaseMeasurementsApiParams
-func (_e *MonitoringAndLogsApi_Expecter) GetDatabaseMeasurementsWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_GetDatabaseMeasurementsWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetDatabaseMeasurementsWithParams(ctx any, args any) *MonitoringAndLogsApi_GetDatabaseMeasurementsWithParams_Call {
 	return &MonitoringAndLogsApi_GetDatabaseMeasurementsWithParams_Call{Call: _e.mock.On("GetDatabaseMeasurementsWithParams", ctx, args)}
 }
 
@@ -494,7 +494,7 @@ type MonitoringAndLogsApi_GetDatabaseWithParams_Call struct {
 // GetDatabaseWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetDatabaseApiParams
-func (_e *MonitoringAndLogsApi_Expecter) GetDatabaseWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_GetDatabaseWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetDatabaseWithParams(ctx any, args any) *MonitoringAndLogsApi_GetDatabaseWithParams_Call {
 	return &MonitoringAndLogsApi_GetDatabaseWithParams_Call{Call: _e.mock.On("GetDatabaseWithParams", ctx, args)}
 }
 
@@ -543,7 +543,7 @@ type MonitoringAndLogsApi_GetDiskMeasurements_Call struct {
 //   - groupId string
 //   - partitionName string
 //   - processId string
-func (_e *MonitoringAndLogsApi_Expecter) GetDiskMeasurements(ctx interface{}, groupId interface{}, partitionName interface{}, processId interface{}) *MonitoringAndLogsApi_GetDiskMeasurements_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetDiskMeasurements(ctx any, groupId any, partitionName any, processId any) *MonitoringAndLogsApi_GetDiskMeasurements_Call {
 	return &MonitoringAndLogsApi_GetDiskMeasurements_Call{Call: _e.mock.On("GetDiskMeasurements", ctx, groupId, partitionName, processId)}
 }
 
@@ -610,7 +610,7 @@ type MonitoringAndLogsApi_GetDiskMeasurementsExecute_Call struct {
 
 // GetDiskMeasurementsExecute is a helper method to define mock.On call
 //   - r admin.GetDiskMeasurementsApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) GetDiskMeasurementsExecute(r interface{}) *MonitoringAndLogsApi_GetDiskMeasurementsExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetDiskMeasurementsExecute(r any) *MonitoringAndLogsApi_GetDiskMeasurementsExecute_Call {
 	return &MonitoringAndLogsApi_GetDiskMeasurementsExecute_Call{Call: _e.mock.On("GetDiskMeasurementsExecute", r)}
 }
 
@@ -657,7 +657,7 @@ type MonitoringAndLogsApi_GetDiskMeasurementsWithParams_Call struct {
 // GetDiskMeasurementsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetDiskMeasurementsApiParams
-func (_e *MonitoringAndLogsApi_Expecter) GetDiskMeasurementsWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_GetDiskMeasurementsWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetDiskMeasurementsWithParams(ctx any, args any) *MonitoringAndLogsApi_GetDiskMeasurementsWithParams_Call {
 	return &MonitoringAndLogsApi_GetDiskMeasurementsWithParams_Call{Call: _e.mock.On("GetDiskMeasurementsWithParams", ctx, args)}
 }
 
@@ -706,7 +706,7 @@ type MonitoringAndLogsApi_GetHostLogs_Call struct {
 //   - groupId string
 //   - hostName string
 //   - logName string
-func (_e *MonitoringAndLogsApi_Expecter) GetHostLogs(ctx interface{}, groupId interface{}, hostName interface{}, logName interface{}) *MonitoringAndLogsApi_GetHostLogs_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetHostLogs(ctx any, groupId any, hostName any, logName any) *MonitoringAndLogsApi_GetHostLogs_Call {
 	return &MonitoringAndLogsApi_GetHostLogs_Call{Call: _e.mock.On("GetHostLogs", ctx, groupId, hostName, logName)}
 }
 
@@ -773,7 +773,7 @@ type MonitoringAndLogsApi_GetHostLogsExecute_Call struct {
 
 // GetHostLogsExecute is a helper method to define mock.On call
 //   - r admin.GetHostLogsApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) GetHostLogsExecute(r interface{}) *MonitoringAndLogsApi_GetHostLogsExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetHostLogsExecute(r any) *MonitoringAndLogsApi_GetHostLogsExecute_Call {
 	return &MonitoringAndLogsApi_GetHostLogsExecute_Call{Call: _e.mock.On("GetHostLogsExecute", r)}
 }
 
@@ -820,7 +820,7 @@ type MonitoringAndLogsApi_GetHostLogsWithParams_Call struct {
 // GetHostLogsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetHostLogsApiParams
-func (_e *MonitoringAndLogsApi_Expecter) GetHostLogsWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_GetHostLogsWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetHostLogsWithParams(ctx any, args any) *MonitoringAndLogsApi_GetHostLogsWithParams_Call {
 	return &MonitoringAndLogsApi_GetHostLogsWithParams_Call{Call: _e.mock.On("GetHostLogsWithParams", ctx, args)}
 }
 
@@ -868,7 +868,7 @@ type MonitoringAndLogsApi_GetHostMeasurements_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - processId string
-func (_e *MonitoringAndLogsApi_Expecter) GetHostMeasurements(ctx interface{}, groupId interface{}, processId interface{}) *MonitoringAndLogsApi_GetHostMeasurements_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetHostMeasurements(ctx any, groupId any, processId any) *MonitoringAndLogsApi_GetHostMeasurements_Call {
 	return &MonitoringAndLogsApi_GetHostMeasurements_Call{Call: _e.mock.On("GetHostMeasurements", ctx, groupId, processId)}
 }
 
@@ -935,7 +935,7 @@ type MonitoringAndLogsApi_GetHostMeasurementsExecute_Call struct {
 
 // GetHostMeasurementsExecute is a helper method to define mock.On call
 //   - r admin.GetHostMeasurementsApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) GetHostMeasurementsExecute(r interface{}) *MonitoringAndLogsApi_GetHostMeasurementsExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetHostMeasurementsExecute(r any) *MonitoringAndLogsApi_GetHostMeasurementsExecute_Call {
 	return &MonitoringAndLogsApi_GetHostMeasurementsExecute_Call{Call: _e.mock.On("GetHostMeasurementsExecute", r)}
 }
 
@@ -982,7 +982,7 @@ type MonitoringAndLogsApi_GetHostMeasurementsWithParams_Call struct {
 // GetHostMeasurementsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetHostMeasurementsApiParams
-func (_e *MonitoringAndLogsApi_Expecter) GetHostMeasurementsWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_GetHostMeasurementsWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetHostMeasurementsWithParams(ctx any, args any) *MonitoringAndLogsApi_GetHostMeasurementsWithParams_Call {
 	return &MonitoringAndLogsApi_GetHostMeasurementsWithParams_Call{Call: _e.mock.On("GetHostMeasurementsWithParams", ctx, args)}
 }
 
@@ -1033,7 +1033,7 @@ type MonitoringAndLogsApi_GetIndexMetrics_Call struct {
 //   - databaseName string
 //   - collectionName string
 //   - groupId string
-func (_e *MonitoringAndLogsApi_Expecter) GetIndexMetrics(ctx interface{}, processId interface{}, indexName interface{}, databaseName interface{}, collectionName interface{}, groupId interface{}) *MonitoringAndLogsApi_GetIndexMetrics_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetIndexMetrics(ctx any, processId any, indexName any, databaseName any, collectionName any, groupId any) *MonitoringAndLogsApi_GetIndexMetrics_Call {
 	return &MonitoringAndLogsApi_GetIndexMetrics_Call{Call: _e.mock.On("GetIndexMetrics", ctx, processId, indexName, databaseName, collectionName, groupId)}
 }
 
@@ -1100,7 +1100,7 @@ type MonitoringAndLogsApi_GetIndexMetricsExecute_Call struct {
 
 // GetIndexMetricsExecute is a helper method to define mock.On call
 //   - r admin.GetIndexMetricsApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) GetIndexMetricsExecute(r interface{}) *MonitoringAndLogsApi_GetIndexMetricsExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetIndexMetricsExecute(r any) *MonitoringAndLogsApi_GetIndexMetricsExecute_Call {
 	return &MonitoringAndLogsApi_GetIndexMetricsExecute_Call{Call: _e.mock.On("GetIndexMetricsExecute", r)}
 }
 
@@ -1147,7 +1147,7 @@ type MonitoringAndLogsApi_GetIndexMetricsWithParams_Call struct {
 // GetIndexMetricsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetIndexMetricsApiParams
-func (_e *MonitoringAndLogsApi_Expecter) GetIndexMetricsWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_GetIndexMetricsWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetIndexMetricsWithParams(ctx any, args any) *MonitoringAndLogsApi_GetIndexMetricsWithParams_Call {
 	return &MonitoringAndLogsApi_GetIndexMetricsWithParams_Call{Call: _e.mock.On("GetIndexMetricsWithParams", ctx, args)}
 }
 
@@ -1195,7 +1195,7 @@ type MonitoringAndLogsApi_GetMeasurements_Call struct {
 //   - ctx context.Context
 //   - processId string
 //   - groupId string
-func (_e *MonitoringAndLogsApi_Expecter) GetMeasurements(ctx interface{}, processId interface{}, groupId interface{}) *MonitoringAndLogsApi_GetMeasurements_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetMeasurements(ctx any, processId any, groupId any) *MonitoringAndLogsApi_GetMeasurements_Call {
 	return &MonitoringAndLogsApi_GetMeasurements_Call{Call: _e.mock.On("GetMeasurements", ctx, processId, groupId)}
 }
 
@@ -1262,7 +1262,7 @@ type MonitoringAndLogsApi_GetMeasurementsExecute_Call struct {
 
 // GetMeasurementsExecute is a helper method to define mock.On call
 //   - r admin.GetMeasurementsApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) GetMeasurementsExecute(r interface{}) *MonitoringAndLogsApi_GetMeasurementsExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetMeasurementsExecute(r any) *MonitoringAndLogsApi_GetMeasurementsExecute_Call {
 	return &MonitoringAndLogsApi_GetMeasurementsExecute_Call{Call: _e.mock.On("GetMeasurementsExecute", r)}
 }
 
@@ -1309,7 +1309,7 @@ type MonitoringAndLogsApi_GetMeasurementsWithParams_Call struct {
 // GetMeasurementsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetMeasurementsApiParams
-func (_e *MonitoringAndLogsApi_Expecter) GetMeasurementsWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_GetMeasurementsWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) GetMeasurementsWithParams(ctx any, args any) *MonitoringAndLogsApi_GetMeasurementsWithParams_Call {
 	return &MonitoringAndLogsApi_GetMeasurementsWithParams_Call{Call: _e.mock.On("GetMeasurementsWithParams", ctx, args)}
 }
 
@@ -1356,7 +1356,7 @@ type MonitoringAndLogsApi_ListAtlasProcesses_Call struct {
 // ListAtlasProcesses is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *MonitoringAndLogsApi_Expecter) ListAtlasProcesses(ctx interface{}, groupId interface{}) *MonitoringAndLogsApi_ListAtlasProcesses_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListAtlasProcesses(ctx any, groupId any) *MonitoringAndLogsApi_ListAtlasProcesses_Call {
 	return &MonitoringAndLogsApi_ListAtlasProcesses_Call{Call: _e.mock.On("ListAtlasProcesses", ctx, groupId)}
 }
 
@@ -1423,7 +1423,7 @@ type MonitoringAndLogsApi_ListAtlasProcessesExecute_Call struct {
 
 // ListAtlasProcessesExecute is a helper method to define mock.On call
 //   - r admin.ListAtlasProcessesApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) ListAtlasProcessesExecute(r interface{}) *MonitoringAndLogsApi_ListAtlasProcessesExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListAtlasProcessesExecute(r any) *MonitoringAndLogsApi_ListAtlasProcessesExecute_Call {
 	return &MonitoringAndLogsApi_ListAtlasProcessesExecute_Call{Call: _e.mock.On("ListAtlasProcessesExecute", r)}
 }
 
@@ -1470,7 +1470,7 @@ type MonitoringAndLogsApi_ListAtlasProcessesWithParams_Call struct {
 // ListAtlasProcessesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListAtlasProcessesApiParams
-func (_e *MonitoringAndLogsApi_Expecter) ListAtlasProcessesWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_ListAtlasProcessesWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListAtlasProcessesWithParams(ctx any, args any) *MonitoringAndLogsApi_ListAtlasProcessesWithParams_Call {
 	return &MonitoringAndLogsApi_ListAtlasProcessesWithParams_Call{Call: _e.mock.On("ListAtlasProcessesWithParams", ctx, args)}
 }
 
@@ -1518,7 +1518,7 @@ type MonitoringAndLogsApi_ListDatabases_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - processId string
-func (_e *MonitoringAndLogsApi_Expecter) ListDatabases(ctx interface{}, groupId interface{}, processId interface{}) *MonitoringAndLogsApi_ListDatabases_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListDatabases(ctx any, groupId any, processId any) *MonitoringAndLogsApi_ListDatabases_Call {
 	return &MonitoringAndLogsApi_ListDatabases_Call{Call: _e.mock.On("ListDatabases", ctx, groupId, processId)}
 }
 
@@ -1585,7 +1585,7 @@ type MonitoringAndLogsApi_ListDatabasesExecute_Call struct {
 
 // ListDatabasesExecute is a helper method to define mock.On call
 //   - r admin.ListDatabasesApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) ListDatabasesExecute(r interface{}) *MonitoringAndLogsApi_ListDatabasesExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListDatabasesExecute(r any) *MonitoringAndLogsApi_ListDatabasesExecute_Call {
 	return &MonitoringAndLogsApi_ListDatabasesExecute_Call{Call: _e.mock.On("ListDatabasesExecute", r)}
 }
 
@@ -1632,7 +1632,7 @@ type MonitoringAndLogsApi_ListDatabasesWithParams_Call struct {
 // ListDatabasesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListDatabasesApiParams
-func (_e *MonitoringAndLogsApi_Expecter) ListDatabasesWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_ListDatabasesWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListDatabasesWithParams(ctx any, args any) *MonitoringAndLogsApi_ListDatabasesWithParams_Call {
 	return &MonitoringAndLogsApi_ListDatabasesWithParams_Call{Call: _e.mock.On("ListDatabasesWithParams", ctx, args)}
 }
 
@@ -1681,7 +1681,7 @@ type MonitoringAndLogsApi_ListDiskMeasurements_Call struct {
 //   - partitionName string
 //   - groupId string
 //   - processId string
-func (_e *MonitoringAndLogsApi_Expecter) ListDiskMeasurements(ctx interface{}, partitionName interface{}, groupId interface{}, processId interface{}) *MonitoringAndLogsApi_ListDiskMeasurements_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListDiskMeasurements(ctx any, partitionName any, groupId any, processId any) *MonitoringAndLogsApi_ListDiskMeasurements_Call {
 	return &MonitoringAndLogsApi_ListDiskMeasurements_Call{Call: _e.mock.On("ListDiskMeasurements", ctx, partitionName, groupId, processId)}
 }
 
@@ -1748,7 +1748,7 @@ type MonitoringAndLogsApi_ListDiskMeasurementsExecute_Call struct {
 
 // ListDiskMeasurementsExecute is a helper method to define mock.On call
 //   - r admin.ListDiskMeasurementsApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) ListDiskMeasurementsExecute(r interface{}) *MonitoringAndLogsApi_ListDiskMeasurementsExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListDiskMeasurementsExecute(r any) *MonitoringAndLogsApi_ListDiskMeasurementsExecute_Call {
 	return &MonitoringAndLogsApi_ListDiskMeasurementsExecute_Call{Call: _e.mock.On("ListDiskMeasurementsExecute", r)}
 }
 
@@ -1795,7 +1795,7 @@ type MonitoringAndLogsApi_ListDiskMeasurementsWithParams_Call struct {
 // ListDiskMeasurementsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListDiskMeasurementsApiParams
-func (_e *MonitoringAndLogsApi_Expecter) ListDiskMeasurementsWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_ListDiskMeasurementsWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListDiskMeasurementsWithParams(ctx any, args any) *MonitoringAndLogsApi_ListDiskMeasurementsWithParams_Call {
 	return &MonitoringAndLogsApi_ListDiskMeasurementsWithParams_Call{Call: _e.mock.On("ListDiskMeasurementsWithParams", ctx, args)}
 }
 
@@ -1843,7 +1843,7 @@ type MonitoringAndLogsApi_ListDiskPartitions_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - processId string
-func (_e *MonitoringAndLogsApi_Expecter) ListDiskPartitions(ctx interface{}, groupId interface{}, processId interface{}) *MonitoringAndLogsApi_ListDiskPartitions_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListDiskPartitions(ctx any, groupId any, processId any) *MonitoringAndLogsApi_ListDiskPartitions_Call {
 	return &MonitoringAndLogsApi_ListDiskPartitions_Call{Call: _e.mock.On("ListDiskPartitions", ctx, groupId, processId)}
 }
 
@@ -1910,7 +1910,7 @@ type MonitoringAndLogsApi_ListDiskPartitionsExecute_Call struct {
 
 // ListDiskPartitionsExecute is a helper method to define mock.On call
 //   - r admin.ListDiskPartitionsApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) ListDiskPartitionsExecute(r interface{}) *MonitoringAndLogsApi_ListDiskPartitionsExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListDiskPartitionsExecute(r any) *MonitoringAndLogsApi_ListDiskPartitionsExecute_Call {
 	return &MonitoringAndLogsApi_ListDiskPartitionsExecute_Call{Call: _e.mock.On("ListDiskPartitionsExecute", r)}
 }
 
@@ -1957,7 +1957,7 @@ type MonitoringAndLogsApi_ListDiskPartitionsWithParams_Call struct {
 // ListDiskPartitionsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListDiskPartitionsApiParams
-func (_e *MonitoringAndLogsApi_Expecter) ListDiskPartitionsWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_ListDiskPartitionsWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListDiskPartitionsWithParams(ctx any, args any) *MonitoringAndLogsApi_ListDiskPartitionsWithParams_Call {
 	return &MonitoringAndLogsApi_ListDiskPartitionsWithParams_Call{Call: _e.mock.On("ListDiskPartitionsWithParams", ctx, args)}
 }
 
@@ -2007,7 +2007,7 @@ type MonitoringAndLogsApi_ListIndexMetrics_Call struct {
 //   - databaseName string
 //   - collectionName string
 //   - groupId string
-func (_e *MonitoringAndLogsApi_Expecter) ListIndexMetrics(ctx interface{}, processId interface{}, databaseName interface{}, collectionName interface{}, groupId interface{}) *MonitoringAndLogsApi_ListIndexMetrics_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListIndexMetrics(ctx any, processId any, databaseName any, collectionName any, groupId any) *MonitoringAndLogsApi_ListIndexMetrics_Call {
 	return &MonitoringAndLogsApi_ListIndexMetrics_Call{Call: _e.mock.On("ListIndexMetrics", ctx, processId, databaseName, collectionName, groupId)}
 }
 
@@ -2074,7 +2074,7 @@ type MonitoringAndLogsApi_ListIndexMetricsExecute_Call struct {
 
 // ListIndexMetricsExecute is a helper method to define mock.On call
 //   - r admin.ListIndexMetricsApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) ListIndexMetricsExecute(r interface{}) *MonitoringAndLogsApi_ListIndexMetricsExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListIndexMetricsExecute(r any) *MonitoringAndLogsApi_ListIndexMetricsExecute_Call {
 	return &MonitoringAndLogsApi_ListIndexMetricsExecute_Call{Call: _e.mock.On("ListIndexMetricsExecute", r)}
 }
 
@@ -2121,7 +2121,7 @@ type MonitoringAndLogsApi_ListIndexMetricsWithParams_Call struct {
 // ListIndexMetricsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListIndexMetricsApiParams
-func (_e *MonitoringAndLogsApi_Expecter) ListIndexMetricsWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_ListIndexMetricsWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListIndexMetricsWithParams(ctx any, args any) *MonitoringAndLogsApi_ListIndexMetricsWithParams_Call {
 	return &MonitoringAndLogsApi_ListIndexMetricsWithParams_Call{Call: _e.mock.On("ListIndexMetricsWithParams", ctx, args)}
 }
 
@@ -2169,7 +2169,7 @@ type MonitoringAndLogsApi_ListMetricTypes_Call struct {
 //   - ctx context.Context
 //   - processId string
 //   - groupId string
-func (_e *MonitoringAndLogsApi_Expecter) ListMetricTypes(ctx interface{}, processId interface{}, groupId interface{}) *MonitoringAndLogsApi_ListMetricTypes_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListMetricTypes(ctx any, processId any, groupId any) *MonitoringAndLogsApi_ListMetricTypes_Call {
 	return &MonitoringAndLogsApi_ListMetricTypes_Call{Call: _e.mock.On("ListMetricTypes", ctx, processId, groupId)}
 }
 
@@ -2236,7 +2236,7 @@ type MonitoringAndLogsApi_ListMetricTypesExecute_Call struct {
 
 // ListMetricTypesExecute is a helper method to define mock.On call
 //   - r admin.ListMetricTypesApiRequest
-func (_e *MonitoringAndLogsApi_Expecter) ListMetricTypesExecute(r interface{}) *MonitoringAndLogsApi_ListMetricTypesExecute_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListMetricTypesExecute(r any) *MonitoringAndLogsApi_ListMetricTypesExecute_Call {
 	return &MonitoringAndLogsApi_ListMetricTypesExecute_Call{Call: _e.mock.On("ListMetricTypesExecute", r)}
 }
 
@@ -2283,7 +2283,7 @@ type MonitoringAndLogsApi_ListMetricTypesWithParams_Call struct {
 // ListMetricTypesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListMetricTypesApiParams
-func (_e *MonitoringAndLogsApi_Expecter) ListMetricTypesWithParams(ctx interface{}, args interface{}) *MonitoringAndLogsApi_ListMetricTypesWithParams_Call {
+func (_e *MonitoringAndLogsApi_Expecter) ListMetricTypesWithParams(ctx any, args any) *MonitoringAndLogsApi_ListMetricTypesWithParams_Call {
 	return &MonitoringAndLogsApi_ListMetricTypesWithParams_Call{Call: _e.mock.On("ListMetricTypesWithParams", ctx, args)}
 }
 

--- a/mockadmin/network_peering_api.go
+++ b/mockadmin/network_peering_api.go
@@ -52,7 +52,7 @@ type NetworkPeeringApi_CreatePeeringConnection_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - baseNetworkPeeringConnectionSettings *admin.BaseNetworkPeeringConnectionSettings
-func (_e *NetworkPeeringApi_Expecter) CreatePeeringConnection(ctx interface{}, groupId interface{}, baseNetworkPeeringConnectionSettings interface{}) *NetworkPeeringApi_CreatePeeringConnection_Call {
+func (_e *NetworkPeeringApi_Expecter) CreatePeeringConnection(ctx any, groupId any, baseNetworkPeeringConnectionSettings any) *NetworkPeeringApi_CreatePeeringConnection_Call {
 	return &NetworkPeeringApi_CreatePeeringConnection_Call{Call: _e.mock.On("CreatePeeringConnection", ctx, groupId, baseNetworkPeeringConnectionSettings)}
 }
 
@@ -119,7 +119,7 @@ type NetworkPeeringApi_CreatePeeringConnectionExecute_Call struct {
 
 // CreatePeeringConnectionExecute is a helper method to define mock.On call
 //   - r admin.CreatePeeringConnectionApiRequest
-func (_e *NetworkPeeringApi_Expecter) CreatePeeringConnectionExecute(r interface{}) *NetworkPeeringApi_CreatePeeringConnectionExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) CreatePeeringConnectionExecute(r any) *NetworkPeeringApi_CreatePeeringConnectionExecute_Call {
 	return &NetworkPeeringApi_CreatePeeringConnectionExecute_Call{Call: _e.mock.On("CreatePeeringConnectionExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type NetworkPeeringApi_CreatePeeringConnectionWithParams_Call struct {
 // CreatePeeringConnectionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreatePeeringConnectionApiParams
-func (_e *NetworkPeeringApi_Expecter) CreatePeeringConnectionWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_CreatePeeringConnectionWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) CreatePeeringConnectionWithParams(ctx any, args any) *NetworkPeeringApi_CreatePeeringConnectionWithParams_Call {
 	return &NetworkPeeringApi_CreatePeeringConnectionWithParams_Call{Call: _e.mock.On("CreatePeeringConnectionWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type NetworkPeeringApi_CreatePeeringContainer_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - cloudProviderContainer *admin.CloudProviderContainer
-func (_e *NetworkPeeringApi_Expecter) CreatePeeringContainer(ctx interface{}, groupId interface{}, cloudProviderContainer interface{}) *NetworkPeeringApi_CreatePeeringContainer_Call {
+func (_e *NetworkPeeringApi_Expecter) CreatePeeringContainer(ctx any, groupId any, cloudProviderContainer any) *NetworkPeeringApi_CreatePeeringContainer_Call {
 	return &NetworkPeeringApi_CreatePeeringContainer_Call{Call: _e.mock.On("CreatePeeringContainer", ctx, groupId, cloudProviderContainer)}
 }
 
@@ -281,7 +281,7 @@ type NetworkPeeringApi_CreatePeeringContainerExecute_Call struct {
 
 // CreatePeeringContainerExecute is a helper method to define mock.On call
 //   - r admin.CreatePeeringContainerApiRequest
-func (_e *NetworkPeeringApi_Expecter) CreatePeeringContainerExecute(r interface{}) *NetworkPeeringApi_CreatePeeringContainerExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) CreatePeeringContainerExecute(r any) *NetworkPeeringApi_CreatePeeringContainerExecute_Call {
 	return &NetworkPeeringApi_CreatePeeringContainerExecute_Call{Call: _e.mock.On("CreatePeeringContainerExecute", r)}
 }
 
@@ -328,7 +328,7 @@ type NetworkPeeringApi_CreatePeeringContainerWithParams_Call struct {
 // CreatePeeringContainerWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreatePeeringContainerApiParams
-func (_e *NetworkPeeringApi_Expecter) CreatePeeringContainerWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_CreatePeeringContainerWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) CreatePeeringContainerWithParams(ctx any, args any) *NetworkPeeringApi_CreatePeeringContainerWithParams_Call {
 	return &NetworkPeeringApi_CreatePeeringContainerWithParams_Call{Call: _e.mock.On("CreatePeeringContainerWithParams", ctx, args)}
 }
 
@@ -376,7 +376,7 @@ type NetworkPeeringApi_DeletePeeringConnection_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - peerId string
-func (_e *NetworkPeeringApi_Expecter) DeletePeeringConnection(ctx interface{}, groupId interface{}, peerId interface{}) *NetworkPeeringApi_DeletePeeringConnection_Call {
+func (_e *NetworkPeeringApi_Expecter) DeletePeeringConnection(ctx any, groupId any, peerId any) *NetworkPeeringApi_DeletePeeringConnection_Call {
 	return &NetworkPeeringApi_DeletePeeringConnection_Call{Call: _e.mock.On("DeletePeeringConnection", ctx, groupId, peerId)}
 }
 
@@ -398,24 +398,24 @@ func (_c *NetworkPeeringApi_DeletePeeringConnection_Call) RunAndReturn(run func(
 }
 
 // DeletePeeringConnectionExecute provides a mock function with given fields: r
-func (_m *NetworkPeeringApi) DeletePeeringConnectionExecute(r admin.DeletePeeringConnectionApiRequest) (interface{}, *http.Response, error) {
+func (_m *NetworkPeeringApi) DeletePeeringConnectionExecute(r admin.DeletePeeringConnectionApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeletePeeringConnectionExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeletePeeringConnectionApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeletePeeringConnectionApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeletePeeringConnectionApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeletePeeringConnectionApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -443,7 +443,7 @@ type NetworkPeeringApi_DeletePeeringConnectionExecute_Call struct {
 
 // DeletePeeringConnectionExecute is a helper method to define mock.On call
 //   - r admin.DeletePeeringConnectionApiRequest
-func (_e *NetworkPeeringApi_Expecter) DeletePeeringConnectionExecute(r interface{}) *NetworkPeeringApi_DeletePeeringConnectionExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) DeletePeeringConnectionExecute(r any) *NetworkPeeringApi_DeletePeeringConnectionExecute_Call {
 	return &NetworkPeeringApi_DeletePeeringConnectionExecute_Call{Call: _e.mock.On("DeletePeeringConnectionExecute", r)}
 }
 
@@ -454,12 +454,12 @@ func (_c *NetworkPeeringApi_DeletePeeringConnectionExecute_Call) Run(run func(r 
 	return _c
 }
 
-func (_c *NetworkPeeringApi_DeletePeeringConnectionExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *NetworkPeeringApi_DeletePeeringConnectionExecute_Call {
+func (_c *NetworkPeeringApi_DeletePeeringConnectionExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *NetworkPeeringApi_DeletePeeringConnectionExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *NetworkPeeringApi_DeletePeeringConnectionExecute_Call) RunAndReturn(run func(admin.DeletePeeringConnectionApiRequest) (interface{}, *http.Response, error)) *NetworkPeeringApi_DeletePeeringConnectionExecute_Call {
+func (_c *NetworkPeeringApi_DeletePeeringConnectionExecute_Call) RunAndReturn(run func(admin.DeletePeeringConnectionApiRequest) (any, *http.Response, error)) *NetworkPeeringApi_DeletePeeringConnectionExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -490,7 +490,7 @@ type NetworkPeeringApi_DeletePeeringConnectionWithParams_Call struct {
 // DeletePeeringConnectionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeletePeeringConnectionApiParams
-func (_e *NetworkPeeringApi_Expecter) DeletePeeringConnectionWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_DeletePeeringConnectionWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) DeletePeeringConnectionWithParams(ctx any, args any) *NetworkPeeringApi_DeletePeeringConnectionWithParams_Call {
 	return &NetworkPeeringApi_DeletePeeringConnectionWithParams_Call{Call: _e.mock.On("DeletePeeringConnectionWithParams", ctx, args)}
 }
 
@@ -538,7 +538,7 @@ type NetworkPeeringApi_DeletePeeringContainer_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - containerId string
-func (_e *NetworkPeeringApi_Expecter) DeletePeeringContainer(ctx interface{}, groupId interface{}, containerId interface{}) *NetworkPeeringApi_DeletePeeringContainer_Call {
+func (_e *NetworkPeeringApi_Expecter) DeletePeeringContainer(ctx any, groupId any, containerId any) *NetworkPeeringApi_DeletePeeringContainer_Call {
 	return &NetworkPeeringApi_DeletePeeringContainer_Call{Call: _e.mock.On("DeletePeeringContainer", ctx, groupId, containerId)}
 }
 
@@ -560,24 +560,24 @@ func (_c *NetworkPeeringApi_DeletePeeringContainer_Call) RunAndReturn(run func(c
 }
 
 // DeletePeeringContainerExecute provides a mock function with given fields: r
-func (_m *NetworkPeeringApi) DeletePeeringContainerExecute(r admin.DeletePeeringContainerApiRequest) (interface{}, *http.Response, error) {
+func (_m *NetworkPeeringApi) DeletePeeringContainerExecute(r admin.DeletePeeringContainerApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeletePeeringContainerExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeletePeeringContainerApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeletePeeringContainerApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeletePeeringContainerApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeletePeeringContainerApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -605,7 +605,7 @@ type NetworkPeeringApi_DeletePeeringContainerExecute_Call struct {
 
 // DeletePeeringContainerExecute is a helper method to define mock.On call
 //   - r admin.DeletePeeringContainerApiRequest
-func (_e *NetworkPeeringApi_Expecter) DeletePeeringContainerExecute(r interface{}) *NetworkPeeringApi_DeletePeeringContainerExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) DeletePeeringContainerExecute(r any) *NetworkPeeringApi_DeletePeeringContainerExecute_Call {
 	return &NetworkPeeringApi_DeletePeeringContainerExecute_Call{Call: _e.mock.On("DeletePeeringContainerExecute", r)}
 }
 
@@ -616,12 +616,12 @@ func (_c *NetworkPeeringApi_DeletePeeringContainerExecute_Call) Run(run func(r a
 	return _c
 }
 
-func (_c *NetworkPeeringApi_DeletePeeringContainerExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *NetworkPeeringApi_DeletePeeringContainerExecute_Call {
+func (_c *NetworkPeeringApi_DeletePeeringContainerExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *NetworkPeeringApi_DeletePeeringContainerExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *NetworkPeeringApi_DeletePeeringContainerExecute_Call) RunAndReturn(run func(admin.DeletePeeringContainerApiRequest) (interface{}, *http.Response, error)) *NetworkPeeringApi_DeletePeeringContainerExecute_Call {
+func (_c *NetworkPeeringApi_DeletePeeringContainerExecute_Call) RunAndReturn(run func(admin.DeletePeeringContainerApiRequest) (any, *http.Response, error)) *NetworkPeeringApi_DeletePeeringContainerExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -652,7 +652,7 @@ type NetworkPeeringApi_DeletePeeringContainerWithParams_Call struct {
 // DeletePeeringContainerWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeletePeeringContainerApiParams
-func (_e *NetworkPeeringApi_Expecter) DeletePeeringContainerWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_DeletePeeringContainerWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) DeletePeeringContainerWithParams(ctx any, args any) *NetworkPeeringApi_DeletePeeringContainerWithParams_Call {
 	return &NetworkPeeringApi_DeletePeeringContainerWithParams_Call{Call: _e.mock.On("DeletePeeringContainerWithParams", ctx, args)}
 }
 
@@ -700,7 +700,7 @@ type NetworkPeeringApi_DisablePeering_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - privateIPMode *admin.PrivateIPMode
-func (_e *NetworkPeeringApi_Expecter) DisablePeering(ctx interface{}, groupId interface{}, privateIPMode interface{}) *NetworkPeeringApi_DisablePeering_Call {
+func (_e *NetworkPeeringApi_Expecter) DisablePeering(ctx any, groupId any, privateIPMode any) *NetworkPeeringApi_DisablePeering_Call {
 	return &NetworkPeeringApi_DisablePeering_Call{Call: _e.mock.On("DisablePeering", ctx, groupId, privateIPMode)}
 }
 
@@ -767,7 +767,7 @@ type NetworkPeeringApi_DisablePeeringExecute_Call struct {
 
 // DisablePeeringExecute is a helper method to define mock.On call
 //   - r admin.DisablePeeringApiRequest
-func (_e *NetworkPeeringApi_Expecter) DisablePeeringExecute(r interface{}) *NetworkPeeringApi_DisablePeeringExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) DisablePeeringExecute(r any) *NetworkPeeringApi_DisablePeeringExecute_Call {
 	return &NetworkPeeringApi_DisablePeeringExecute_Call{Call: _e.mock.On("DisablePeeringExecute", r)}
 }
 
@@ -814,7 +814,7 @@ type NetworkPeeringApi_DisablePeeringWithParams_Call struct {
 // DisablePeeringWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DisablePeeringApiParams
-func (_e *NetworkPeeringApi_Expecter) DisablePeeringWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_DisablePeeringWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) DisablePeeringWithParams(ctx any, args any) *NetworkPeeringApi_DisablePeeringWithParams_Call {
 	return &NetworkPeeringApi_DisablePeeringWithParams_Call{Call: _e.mock.On("DisablePeeringWithParams", ctx, args)}
 }
 
@@ -862,7 +862,7 @@ type NetworkPeeringApi_GetPeeringConnection_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - peerId string
-func (_e *NetworkPeeringApi_Expecter) GetPeeringConnection(ctx interface{}, groupId interface{}, peerId interface{}) *NetworkPeeringApi_GetPeeringConnection_Call {
+func (_e *NetworkPeeringApi_Expecter) GetPeeringConnection(ctx any, groupId any, peerId any) *NetworkPeeringApi_GetPeeringConnection_Call {
 	return &NetworkPeeringApi_GetPeeringConnection_Call{Call: _e.mock.On("GetPeeringConnection", ctx, groupId, peerId)}
 }
 
@@ -929,7 +929,7 @@ type NetworkPeeringApi_GetPeeringConnectionExecute_Call struct {
 
 // GetPeeringConnectionExecute is a helper method to define mock.On call
 //   - r admin.GetPeeringConnectionApiRequest
-func (_e *NetworkPeeringApi_Expecter) GetPeeringConnectionExecute(r interface{}) *NetworkPeeringApi_GetPeeringConnectionExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) GetPeeringConnectionExecute(r any) *NetworkPeeringApi_GetPeeringConnectionExecute_Call {
 	return &NetworkPeeringApi_GetPeeringConnectionExecute_Call{Call: _e.mock.On("GetPeeringConnectionExecute", r)}
 }
 
@@ -976,7 +976,7 @@ type NetworkPeeringApi_GetPeeringConnectionWithParams_Call struct {
 // GetPeeringConnectionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetPeeringConnectionApiParams
-func (_e *NetworkPeeringApi_Expecter) GetPeeringConnectionWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_GetPeeringConnectionWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) GetPeeringConnectionWithParams(ctx any, args any) *NetworkPeeringApi_GetPeeringConnectionWithParams_Call {
 	return &NetworkPeeringApi_GetPeeringConnectionWithParams_Call{Call: _e.mock.On("GetPeeringConnectionWithParams", ctx, args)}
 }
 
@@ -1024,7 +1024,7 @@ type NetworkPeeringApi_GetPeeringContainer_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - containerId string
-func (_e *NetworkPeeringApi_Expecter) GetPeeringContainer(ctx interface{}, groupId interface{}, containerId interface{}) *NetworkPeeringApi_GetPeeringContainer_Call {
+func (_e *NetworkPeeringApi_Expecter) GetPeeringContainer(ctx any, groupId any, containerId any) *NetworkPeeringApi_GetPeeringContainer_Call {
 	return &NetworkPeeringApi_GetPeeringContainer_Call{Call: _e.mock.On("GetPeeringContainer", ctx, groupId, containerId)}
 }
 
@@ -1091,7 +1091,7 @@ type NetworkPeeringApi_GetPeeringContainerExecute_Call struct {
 
 // GetPeeringContainerExecute is a helper method to define mock.On call
 //   - r admin.GetPeeringContainerApiRequest
-func (_e *NetworkPeeringApi_Expecter) GetPeeringContainerExecute(r interface{}) *NetworkPeeringApi_GetPeeringContainerExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) GetPeeringContainerExecute(r any) *NetworkPeeringApi_GetPeeringContainerExecute_Call {
 	return &NetworkPeeringApi_GetPeeringContainerExecute_Call{Call: _e.mock.On("GetPeeringContainerExecute", r)}
 }
 
@@ -1138,7 +1138,7 @@ type NetworkPeeringApi_GetPeeringContainerWithParams_Call struct {
 // GetPeeringContainerWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetPeeringContainerApiParams
-func (_e *NetworkPeeringApi_Expecter) GetPeeringContainerWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_GetPeeringContainerWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) GetPeeringContainerWithParams(ctx any, args any) *NetworkPeeringApi_GetPeeringContainerWithParams_Call {
 	return &NetworkPeeringApi_GetPeeringContainerWithParams_Call{Call: _e.mock.On("GetPeeringContainerWithParams", ctx, args)}
 }
 
@@ -1185,7 +1185,7 @@ type NetworkPeeringApi_ListPeeringConnections_Call struct {
 // ListPeeringConnections is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *NetworkPeeringApi_Expecter) ListPeeringConnections(ctx interface{}, groupId interface{}) *NetworkPeeringApi_ListPeeringConnections_Call {
+func (_e *NetworkPeeringApi_Expecter) ListPeeringConnections(ctx any, groupId any) *NetworkPeeringApi_ListPeeringConnections_Call {
 	return &NetworkPeeringApi_ListPeeringConnections_Call{Call: _e.mock.On("ListPeeringConnections", ctx, groupId)}
 }
 
@@ -1252,7 +1252,7 @@ type NetworkPeeringApi_ListPeeringConnectionsExecute_Call struct {
 
 // ListPeeringConnectionsExecute is a helper method to define mock.On call
 //   - r admin.ListPeeringConnectionsApiRequest
-func (_e *NetworkPeeringApi_Expecter) ListPeeringConnectionsExecute(r interface{}) *NetworkPeeringApi_ListPeeringConnectionsExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) ListPeeringConnectionsExecute(r any) *NetworkPeeringApi_ListPeeringConnectionsExecute_Call {
 	return &NetworkPeeringApi_ListPeeringConnectionsExecute_Call{Call: _e.mock.On("ListPeeringConnectionsExecute", r)}
 }
 
@@ -1299,7 +1299,7 @@ type NetworkPeeringApi_ListPeeringConnectionsWithParams_Call struct {
 // ListPeeringConnectionsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListPeeringConnectionsApiParams
-func (_e *NetworkPeeringApi_Expecter) ListPeeringConnectionsWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_ListPeeringConnectionsWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) ListPeeringConnectionsWithParams(ctx any, args any) *NetworkPeeringApi_ListPeeringConnectionsWithParams_Call {
 	return &NetworkPeeringApi_ListPeeringConnectionsWithParams_Call{Call: _e.mock.On("ListPeeringConnectionsWithParams", ctx, args)}
 }
 
@@ -1346,7 +1346,7 @@ type NetworkPeeringApi_ListPeeringContainerByCloudProvider_Call struct {
 // ListPeeringContainerByCloudProvider is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *NetworkPeeringApi_Expecter) ListPeeringContainerByCloudProvider(ctx interface{}, groupId interface{}) *NetworkPeeringApi_ListPeeringContainerByCloudProvider_Call {
+func (_e *NetworkPeeringApi_Expecter) ListPeeringContainerByCloudProvider(ctx any, groupId any) *NetworkPeeringApi_ListPeeringContainerByCloudProvider_Call {
 	return &NetworkPeeringApi_ListPeeringContainerByCloudProvider_Call{Call: _e.mock.On("ListPeeringContainerByCloudProvider", ctx, groupId)}
 }
 
@@ -1413,7 +1413,7 @@ type NetworkPeeringApi_ListPeeringContainerByCloudProviderExecute_Call struct {
 
 // ListPeeringContainerByCloudProviderExecute is a helper method to define mock.On call
 //   - r admin.ListPeeringContainerByCloudProviderApiRequest
-func (_e *NetworkPeeringApi_Expecter) ListPeeringContainerByCloudProviderExecute(r interface{}) *NetworkPeeringApi_ListPeeringContainerByCloudProviderExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) ListPeeringContainerByCloudProviderExecute(r any) *NetworkPeeringApi_ListPeeringContainerByCloudProviderExecute_Call {
 	return &NetworkPeeringApi_ListPeeringContainerByCloudProviderExecute_Call{Call: _e.mock.On("ListPeeringContainerByCloudProviderExecute", r)}
 }
 
@@ -1460,7 +1460,7 @@ type NetworkPeeringApi_ListPeeringContainerByCloudProviderWithParams_Call struct
 // ListPeeringContainerByCloudProviderWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListPeeringContainerByCloudProviderApiParams
-func (_e *NetworkPeeringApi_Expecter) ListPeeringContainerByCloudProviderWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_ListPeeringContainerByCloudProviderWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) ListPeeringContainerByCloudProviderWithParams(ctx any, args any) *NetworkPeeringApi_ListPeeringContainerByCloudProviderWithParams_Call {
 	return &NetworkPeeringApi_ListPeeringContainerByCloudProviderWithParams_Call{Call: _e.mock.On("ListPeeringContainerByCloudProviderWithParams", ctx, args)}
 }
 
@@ -1507,7 +1507,7 @@ type NetworkPeeringApi_ListPeeringContainers_Call struct {
 // ListPeeringContainers is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *NetworkPeeringApi_Expecter) ListPeeringContainers(ctx interface{}, groupId interface{}) *NetworkPeeringApi_ListPeeringContainers_Call {
+func (_e *NetworkPeeringApi_Expecter) ListPeeringContainers(ctx any, groupId any) *NetworkPeeringApi_ListPeeringContainers_Call {
 	return &NetworkPeeringApi_ListPeeringContainers_Call{Call: _e.mock.On("ListPeeringContainers", ctx, groupId)}
 }
 
@@ -1574,7 +1574,7 @@ type NetworkPeeringApi_ListPeeringContainersExecute_Call struct {
 
 // ListPeeringContainersExecute is a helper method to define mock.On call
 //   - r admin.ListPeeringContainersApiRequest
-func (_e *NetworkPeeringApi_Expecter) ListPeeringContainersExecute(r interface{}) *NetworkPeeringApi_ListPeeringContainersExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) ListPeeringContainersExecute(r any) *NetworkPeeringApi_ListPeeringContainersExecute_Call {
 	return &NetworkPeeringApi_ListPeeringContainersExecute_Call{Call: _e.mock.On("ListPeeringContainersExecute", r)}
 }
 
@@ -1621,7 +1621,7 @@ type NetworkPeeringApi_ListPeeringContainersWithParams_Call struct {
 // ListPeeringContainersWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListPeeringContainersApiParams
-func (_e *NetworkPeeringApi_Expecter) ListPeeringContainersWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_ListPeeringContainersWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) ListPeeringContainersWithParams(ctx any, args any) *NetworkPeeringApi_ListPeeringContainersWithParams_Call {
 	return &NetworkPeeringApi_ListPeeringContainersWithParams_Call{Call: _e.mock.On("ListPeeringContainersWithParams", ctx, args)}
 }
 
@@ -1670,7 +1670,7 @@ type NetworkPeeringApi_UpdatePeeringConnection_Call struct {
 //   - groupId string
 //   - peerId string
 //   - baseNetworkPeeringConnectionSettings *admin.BaseNetworkPeeringConnectionSettings
-func (_e *NetworkPeeringApi_Expecter) UpdatePeeringConnection(ctx interface{}, groupId interface{}, peerId interface{}, baseNetworkPeeringConnectionSettings interface{}) *NetworkPeeringApi_UpdatePeeringConnection_Call {
+func (_e *NetworkPeeringApi_Expecter) UpdatePeeringConnection(ctx any, groupId any, peerId any, baseNetworkPeeringConnectionSettings any) *NetworkPeeringApi_UpdatePeeringConnection_Call {
 	return &NetworkPeeringApi_UpdatePeeringConnection_Call{Call: _e.mock.On("UpdatePeeringConnection", ctx, groupId, peerId, baseNetworkPeeringConnectionSettings)}
 }
 
@@ -1737,7 +1737,7 @@ type NetworkPeeringApi_UpdatePeeringConnectionExecute_Call struct {
 
 // UpdatePeeringConnectionExecute is a helper method to define mock.On call
 //   - r admin.UpdatePeeringConnectionApiRequest
-func (_e *NetworkPeeringApi_Expecter) UpdatePeeringConnectionExecute(r interface{}) *NetworkPeeringApi_UpdatePeeringConnectionExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) UpdatePeeringConnectionExecute(r any) *NetworkPeeringApi_UpdatePeeringConnectionExecute_Call {
 	return &NetworkPeeringApi_UpdatePeeringConnectionExecute_Call{Call: _e.mock.On("UpdatePeeringConnectionExecute", r)}
 }
 
@@ -1784,7 +1784,7 @@ type NetworkPeeringApi_UpdatePeeringConnectionWithParams_Call struct {
 // UpdatePeeringConnectionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdatePeeringConnectionApiParams
-func (_e *NetworkPeeringApi_Expecter) UpdatePeeringConnectionWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_UpdatePeeringConnectionWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) UpdatePeeringConnectionWithParams(ctx any, args any) *NetworkPeeringApi_UpdatePeeringConnectionWithParams_Call {
 	return &NetworkPeeringApi_UpdatePeeringConnectionWithParams_Call{Call: _e.mock.On("UpdatePeeringConnectionWithParams", ctx, args)}
 }
 
@@ -1833,7 +1833,7 @@ type NetworkPeeringApi_UpdatePeeringContainer_Call struct {
 //   - groupId string
 //   - containerId string
 //   - cloudProviderContainer *admin.CloudProviderContainer
-func (_e *NetworkPeeringApi_Expecter) UpdatePeeringContainer(ctx interface{}, groupId interface{}, containerId interface{}, cloudProviderContainer interface{}) *NetworkPeeringApi_UpdatePeeringContainer_Call {
+func (_e *NetworkPeeringApi_Expecter) UpdatePeeringContainer(ctx any, groupId any, containerId any, cloudProviderContainer any) *NetworkPeeringApi_UpdatePeeringContainer_Call {
 	return &NetworkPeeringApi_UpdatePeeringContainer_Call{Call: _e.mock.On("UpdatePeeringContainer", ctx, groupId, containerId, cloudProviderContainer)}
 }
 
@@ -1900,7 +1900,7 @@ type NetworkPeeringApi_UpdatePeeringContainerExecute_Call struct {
 
 // UpdatePeeringContainerExecute is a helper method to define mock.On call
 //   - r admin.UpdatePeeringContainerApiRequest
-func (_e *NetworkPeeringApi_Expecter) UpdatePeeringContainerExecute(r interface{}) *NetworkPeeringApi_UpdatePeeringContainerExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) UpdatePeeringContainerExecute(r any) *NetworkPeeringApi_UpdatePeeringContainerExecute_Call {
 	return &NetworkPeeringApi_UpdatePeeringContainerExecute_Call{Call: _e.mock.On("UpdatePeeringContainerExecute", r)}
 }
 
@@ -1947,7 +1947,7 @@ type NetworkPeeringApi_UpdatePeeringContainerWithParams_Call struct {
 // UpdatePeeringContainerWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdatePeeringContainerApiParams
-func (_e *NetworkPeeringApi_Expecter) UpdatePeeringContainerWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_UpdatePeeringContainerWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) UpdatePeeringContainerWithParams(ctx any, args any) *NetworkPeeringApi_UpdatePeeringContainerWithParams_Call {
 	return &NetworkPeeringApi_UpdatePeeringContainerWithParams_Call{Call: _e.mock.On("UpdatePeeringContainerWithParams", ctx, args)}
 }
 
@@ -1994,7 +1994,7 @@ type NetworkPeeringApi_VerifyConnectViaPeeringOnlyModeForOneProject_Call struct 
 // VerifyConnectViaPeeringOnlyModeForOneProject is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *NetworkPeeringApi_Expecter) VerifyConnectViaPeeringOnlyModeForOneProject(ctx interface{}, groupId interface{}) *NetworkPeeringApi_VerifyConnectViaPeeringOnlyModeForOneProject_Call {
+func (_e *NetworkPeeringApi_Expecter) VerifyConnectViaPeeringOnlyModeForOneProject(ctx any, groupId any) *NetworkPeeringApi_VerifyConnectViaPeeringOnlyModeForOneProject_Call {
 	return &NetworkPeeringApi_VerifyConnectViaPeeringOnlyModeForOneProject_Call{Call: _e.mock.On("VerifyConnectViaPeeringOnlyModeForOneProject", ctx, groupId)}
 }
 
@@ -2061,7 +2061,7 @@ type NetworkPeeringApi_VerifyConnectViaPeeringOnlyModeForOneProjectExecute_Call 
 
 // VerifyConnectViaPeeringOnlyModeForOneProjectExecute is a helper method to define mock.On call
 //   - r admin.VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
-func (_e *NetworkPeeringApi_Expecter) VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r interface{}) *NetworkPeeringApi_VerifyConnectViaPeeringOnlyModeForOneProjectExecute_Call {
+func (_e *NetworkPeeringApi_Expecter) VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r any) *NetworkPeeringApi_VerifyConnectViaPeeringOnlyModeForOneProjectExecute_Call {
 	return &NetworkPeeringApi_VerifyConnectViaPeeringOnlyModeForOneProjectExecute_Call{Call: _e.mock.On("VerifyConnectViaPeeringOnlyModeForOneProjectExecute", r)}
 }
 
@@ -2108,7 +2108,7 @@ type NetworkPeeringApi_VerifyConnectViaPeeringOnlyModeForOneProjectWithParams_Ca
 // VerifyConnectViaPeeringOnlyModeForOneProjectWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams
-func (_e *NetworkPeeringApi_Expecter) VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx interface{}, args interface{}) *NetworkPeeringApi_VerifyConnectViaPeeringOnlyModeForOneProjectWithParams_Call {
+func (_e *NetworkPeeringApi_Expecter) VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx any, args any) *NetworkPeeringApi_VerifyConnectViaPeeringOnlyModeForOneProjectWithParams_Call {
 	return &NetworkPeeringApi_VerifyConnectViaPeeringOnlyModeForOneProjectWithParams_Call{Call: _e.mock.On("VerifyConnectViaPeeringOnlyModeForOneProjectWithParams", ctx, args)}
 }
 

--- a/mockadmin/online_archive_api.go
+++ b/mockadmin/online_archive_api.go
@@ -55,7 +55,7 @@ type OnlineArchiveApi_CreateOnlineArchive_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - backupOnlineArchiveCreate *admin.BackupOnlineArchiveCreate
-func (_e *OnlineArchiveApi_Expecter) CreateOnlineArchive(ctx interface{}, groupId interface{}, clusterName interface{}, backupOnlineArchiveCreate interface{}) *OnlineArchiveApi_CreateOnlineArchive_Call {
+func (_e *OnlineArchiveApi_Expecter) CreateOnlineArchive(ctx any, groupId any, clusterName any, backupOnlineArchiveCreate any) *OnlineArchiveApi_CreateOnlineArchive_Call {
 	return &OnlineArchiveApi_CreateOnlineArchive_Call{Call: _e.mock.On("CreateOnlineArchive", ctx, groupId, clusterName, backupOnlineArchiveCreate)}
 }
 
@@ -122,7 +122,7 @@ type OnlineArchiveApi_CreateOnlineArchiveExecute_Call struct {
 
 // CreateOnlineArchiveExecute is a helper method to define mock.On call
 //   - r admin.CreateOnlineArchiveApiRequest
-func (_e *OnlineArchiveApi_Expecter) CreateOnlineArchiveExecute(r interface{}) *OnlineArchiveApi_CreateOnlineArchiveExecute_Call {
+func (_e *OnlineArchiveApi_Expecter) CreateOnlineArchiveExecute(r any) *OnlineArchiveApi_CreateOnlineArchiveExecute_Call {
 	return &OnlineArchiveApi_CreateOnlineArchiveExecute_Call{Call: _e.mock.On("CreateOnlineArchiveExecute", r)}
 }
 
@@ -169,7 +169,7 @@ type OnlineArchiveApi_CreateOnlineArchiveWithParams_Call struct {
 // CreateOnlineArchiveWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateOnlineArchiveApiParams
-func (_e *OnlineArchiveApi_Expecter) CreateOnlineArchiveWithParams(ctx interface{}, args interface{}) *OnlineArchiveApi_CreateOnlineArchiveWithParams_Call {
+func (_e *OnlineArchiveApi_Expecter) CreateOnlineArchiveWithParams(ctx any, args any) *OnlineArchiveApi_CreateOnlineArchiveWithParams_Call {
 	return &OnlineArchiveApi_CreateOnlineArchiveWithParams_Call{Call: _e.mock.On("CreateOnlineArchiveWithParams", ctx, args)}
 }
 
@@ -218,7 +218,7 @@ type OnlineArchiveApi_DeleteOnlineArchive_Call struct {
 //   - groupId string
 //   - archiveId string
 //   - clusterName string
-func (_e *OnlineArchiveApi_Expecter) DeleteOnlineArchive(ctx interface{}, groupId interface{}, archiveId interface{}, clusterName interface{}) *OnlineArchiveApi_DeleteOnlineArchive_Call {
+func (_e *OnlineArchiveApi_Expecter) DeleteOnlineArchive(ctx any, groupId any, archiveId any, clusterName any) *OnlineArchiveApi_DeleteOnlineArchive_Call {
 	return &OnlineArchiveApi_DeleteOnlineArchive_Call{Call: _e.mock.On("DeleteOnlineArchive", ctx, groupId, archiveId, clusterName)}
 }
 
@@ -240,24 +240,24 @@ func (_c *OnlineArchiveApi_DeleteOnlineArchive_Call) RunAndReturn(run func(conte
 }
 
 // DeleteOnlineArchiveExecute provides a mock function with given fields: r
-func (_m *OnlineArchiveApi) DeleteOnlineArchiveExecute(r admin.DeleteOnlineArchiveApiRequest) (interface{}, *http.Response, error) {
+func (_m *OnlineArchiveApi) DeleteOnlineArchiveExecute(r admin.DeleteOnlineArchiveApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteOnlineArchiveExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteOnlineArchiveApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteOnlineArchiveApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteOnlineArchiveApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteOnlineArchiveApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -285,7 +285,7 @@ type OnlineArchiveApi_DeleteOnlineArchiveExecute_Call struct {
 
 // DeleteOnlineArchiveExecute is a helper method to define mock.On call
 //   - r admin.DeleteOnlineArchiveApiRequest
-func (_e *OnlineArchiveApi_Expecter) DeleteOnlineArchiveExecute(r interface{}) *OnlineArchiveApi_DeleteOnlineArchiveExecute_Call {
+func (_e *OnlineArchiveApi_Expecter) DeleteOnlineArchiveExecute(r any) *OnlineArchiveApi_DeleteOnlineArchiveExecute_Call {
 	return &OnlineArchiveApi_DeleteOnlineArchiveExecute_Call{Call: _e.mock.On("DeleteOnlineArchiveExecute", r)}
 }
 
@@ -296,12 +296,12 @@ func (_c *OnlineArchiveApi_DeleteOnlineArchiveExecute_Call) Run(run func(r admin
 	return _c
 }
 
-func (_c *OnlineArchiveApi_DeleteOnlineArchiveExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *OnlineArchiveApi_DeleteOnlineArchiveExecute_Call {
+func (_c *OnlineArchiveApi_DeleteOnlineArchiveExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *OnlineArchiveApi_DeleteOnlineArchiveExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *OnlineArchiveApi_DeleteOnlineArchiveExecute_Call) RunAndReturn(run func(admin.DeleteOnlineArchiveApiRequest) (interface{}, *http.Response, error)) *OnlineArchiveApi_DeleteOnlineArchiveExecute_Call {
+func (_c *OnlineArchiveApi_DeleteOnlineArchiveExecute_Call) RunAndReturn(run func(admin.DeleteOnlineArchiveApiRequest) (any, *http.Response, error)) *OnlineArchiveApi_DeleteOnlineArchiveExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -332,7 +332,7 @@ type OnlineArchiveApi_DeleteOnlineArchiveWithParams_Call struct {
 // DeleteOnlineArchiveWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteOnlineArchiveApiParams
-func (_e *OnlineArchiveApi_Expecter) DeleteOnlineArchiveWithParams(ctx interface{}, args interface{}) *OnlineArchiveApi_DeleteOnlineArchiveWithParams_Call {
+func (_e *OnlineArchiveApi_Expecter) DeleteOnlineArchiveWithParams(ctx any, args any) *OnlineArchiveApi_DeleteOnlineArchiveWithParams_Call {
 	return &OnlineArchiveApi_DeleteOnlineArchiveWithParams_Call{Call: _e.mock.On("DeleteOnlineArchiveWithParams", ctx, args)}
 }
 
@@ -380,7 +380,7 @@ type OnlineArchiveApi_DownloadOnlineArchiveQueryLogs_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *OnlineArchiveApi_Expecter) DownloadOnlineArchiveQueryLogs(ctx interface{}, groupId interface{}, clusterName interface{}) *OnlineArchiveApi_DownloadOnlineArchiveQueryLogs_Call {
+func (_e *OnlineArchiveApi_Expecter) DownloadOnlineArchiveQueryLogs(ctx any, groupId any, clusterName any) *OnlineArchiveApi_DownloadOnlineArchiveQueryLogs_Call {
 	return &OnlineArchiveApi_DownloadOnlineArchiveQueryLogs_Call{Call: _e.mock.On("DownloadOnlineArchiveQueryLogs", ctx, groupId, clusterName)}
 }
 
@@ -447,7 +447,7 @@ type OnlineArchiveApi_DownloadOnlineArchiveQueryLogsExecute_Call struct {
 
 // DownloadOnlineArchiveQueryLogsExecute is a helper method to define mock.On call
 //   - r admin.DownloadOnlineArchiveQueryLogsApiRequest
-func (_e *OnlineArchiveApi_Expecter) DownloadOnlineArchiveQueryLogsExecute(r interface{}) *OnlineArchiveApi_DownloadOnlineArchiveQueryLogsExecute_Call {
+func (_e *OnlineArchiveApi_Expecter) DownloadOnlineArchiveQueryLogsExecute(r any) *OnlineArchiveApi_DownloadOnlineArchiveQueryLogsExecute_Call {
 	return &OnlineArchiveApi_DownloadOnlineArchiveQueryLogsExecute_Call{Call: _e.mock.On("DownloadOnlineArchiveQueryLogsExecute", r)}
 }
 
@@ -494,7 +494,7 @@ type OnlineArchiveApi_DownloadOnlineArchiveQueryLogsWithParams_Call struct {
 // DownloadOnlineArchiveQueryLogsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DownloadOnlineArchiveQueryLogsApiParams
-func (_e *OnlineArchiveApi_Expecter) DownloadOnlineArchiveQueryLogsWithParams(ctx interface{}, args interface{}) *OnlineArchiveApi_DownloadOnlineArchiveQueryLogsWithParams_Call {
+func (_e *OnlineArchiveApi_Expecter) DownloadOnlineArchiveQueryLogsWithParams(ctx any, args any) *OnlineArchiveApi_DownloadOnlineArchiveQueryLogsWithParams_Call {
 	return &OnlineArchiveApi_DownloadOnlineArchiveQueryLogsWithParams_Call{Call: _e.mock.On("DownloadOnlineArchiveQueryLogsWithParams", ctx, args)}
 }
 
@@ -543,7 +543,7 @@ type OnlineArchiveApi_GetOnlineArchive_Call struct {
 //   - groupId string
 //   - archiveId string
 //   - clusterName string
-func (_e *OnlineArchiveApi_Expecter) GetOnlineArchive(ctx interface{}, groupId interface{}, archiveId interface{}, clusterName interface{}) *OnlineArchiveApi_GetOnlineArchive_Call {
+func (_e *OnlineArchiveApi_Expecter) GetOnlineArchive(ctx any, groupId any, archiveId any, clusterName any) *OnlineArchiveApi_GetOnlineArchive_Call {
 	return &OnlineArchiveApi_GetOnlineArchive_Call{Call: _e.mock.On("GetOnlineArchive", ctx, groupId, archiveId, clusterName)}
 }
 
@@ -610,7 +610,7 @@ type OnlineArchiveApi_GetOnlineArchiveExecute_Call struct {
 
 // GetOnlineArchiveExecute is a helper method to define mock.On call
 //   - r admin.GetOnlineArchiveApiRequest
-func (_e *OnlineArchiveApi_Expecter) GetOnlineArchiveExecute(r interface{}) *OnlineArchiveApi_GetOnlineArchiveExecute_Call {
+func (_e *OnlineArchiveApi_Expecter) GetOnlineArchiveExecute(r any) *OnlineArchiveApi_GetOnlineArchiveExecute_Call {
 	return &OnlineArchiveApi_GetOnlineArchiveExecute_Call{Call: _e.mock.On("GetOnlineArchiveExecute", r)}
 }
 
@@ -657,7 +657,7 @@ type OnlineArchiveApi_GetOnlineArchiveWithParams_Call struct {
 // GetOnlineArchiveWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetOnlineArchiveApiParams
-func (_e *OnlineArchiveApi_Expecter) GetOnlineArchiveWithParams(ctx interface{}, args interface{}) *OnlineArchiveApi_GetOnlineArchiveWithParams_Call {
+func (_e *OnlineArchiveApi_Expecter) GetOnlineArchiveWithParams(ctx any, args any) *OnlineArchiveApi_GetOnlineArchiveWithParams_Call {
 	return &OnlineArchiveApi_GetOnlineArchiveWithParams_Call{Call: _e.mock.On("GetOnlineArchiveWithParams", ctx, args)}
 }
 
@@ -705,7 +705,7 @@ type OnlineArchiveApi_ListOnlineArchives_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *OnlineArchiveApi_Expecter) ListOnlineArchives(ctx interface{}, groupId interface{}, clusterName interface{}) *OnlineArchiveApi_ListOnlineArchives_Call {
+func (_e *OnlineArchiveApi_Expecter) ListOnlineArchives(ctx any, groupId any, clusterName any) *OnlineArchiveApi_ListOnlineArchives_Call {
 	return &OnlineArchiveApi_ListOnlineArchives_Call{Call: _e.mock.On("ListOnlineArchives", ctx, groupId, clusterName)}
 }
 
@@ -772,7 +772,7 @@ type OnlineArchiveApi_ListOnlineArchivesExecute_Call struct {
 
 // ListOnlineArchivesExecute is a helper method to define mock.On call
 //   - r admin.ListOnlineArchivesApiRequest
-func (_e *OnlineArchiveApi_Expecter) ListOnlineArchivesExecute(r interface{}) *OnlineArchiveApi_ListOnlineArchivesExecute_Call {
+func (_e *OnlineArchiveApi_Expecter) ListOnlineArchivesExecute(r any) *OnlineArchiveApi_ListOnlineArchivesExecute_Call {
 	return &OnlineArchiveApi_ListOnlineArchivesExecute_Call{Call: _e.mock.On("ListOnlineArchivesExecute", r)}
 }
 
@@ -819,7 +819,7 @@ type OnlineArchiveApi_ListOnlineArchivesWithParams_Call struct {
 // ListOnlineArchivesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListOnlineArchivesApiParams
-func (_e *OnlineArchiveApi_Expecter) ListOnlineArchivesWithParams(ctx interface{}, args interface{}) *OnlineArchiveApi_ListOnlineArchivesWithParams_Call {
+func (_e *OnlineArchiveApi_Expecter) ListOnlineArchivesWithParams(ctx any, args any) *OnlineArchiveApi_ListOnlineArchivesWithParams_Call {
 	return &OnlineArchiveApi_ListOnlineArchivesWithParams_Call{Call: _e.mock.On("ListOnlineArchivesWithParams", ctx, args)}
 }
 
@@ -869,7 +869,7 @@ type OnlineArchiveApi_UpdateOnlineArchive_Call struct {
 //   - archiveId string
 //   - clusterName string
 //   - backupOnlineArchive *admin.BackupOnlineArchive
-func (_e *OnlineArchiveApi_Expecter) UpdateOnlineArchive(ctx interface{}, groupId interface{}, archiveId interface{}, clusterName interface{}, backupOnlineArchive interface{}) *OnlineArchiveApi_UpdateOnlineArchive_Call {
+func (_e *OnlineArchiveApi_Expecter) UpdateOnlineArchive(ctx any, groupId any, archiveId any, clusterName any, backupOnlineArchive any) *OnlineArchiveApi_UpdateOnlineArchive_Call {
 	return &OnlineArchiveApi_UpdateOnlineArchive_Call{Call: _e.mock.On("UpdateOnlineArchive", ctx, groupId, archiveId, clusterName, backupOnlineArchive)}
 }
 
@@ -936,7 +936,7 @@ type OnlineArchiveApi_UpdateOnlineArchiveExecute_Call struct {
 
 // UpdateOnlineArchiveExecute is a helper method to define mock.On call
 //   - r admin.UpdateOnlineArchiveApiRequest
-func (_e *OnlineArchiveApi_Expecter) UpdateOnlineArchiveExecute(r interface{}) *OnlineArchiveApi_UpdateOnlineArchiveExecute_Call {
+func (_e *OnlineArchiveApi_Expecter) UpdateOnlineArchiveExecute(r any) *OnlineArchiveApi_UpdateOnlineArchiveExecute_Call {
 	return &OnlineArchiveApi_UpdateOnlineArchiveExecute_Call{Call: _e.mock.On("UpdateOnlineArchiveExecute", r)}
 }
 
@@ -983,7 +983,7 @@ type OnlineArchiveApi_UpdateOnlineArchiveWithParams_Call struct {
 // UpdateOnlineArchiveWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateOnlineArchiveApiParams
-func (_e *OnlineArchiveApi_Expecter) UpdateOnlineArchiveWithParams(ctx interface{}, args interface{}) *OnlineArchiveApi_UpdateOnlineArchiveWithParams_Call {
+func (_e *OnlineArchiveApi_Expecter) UpdateOnlineArchiveWithParams(ctx any, args any) *OnlineArchiveApi_UpdateOnlineArchiveWithParams_Call {
 	return &OnlineArchiveApi_UpdateOnlineArchiveWithParams_Call{Call: _e.mock.On("UpdateOnlineArchiveWithParams", ctx, args)}
 }
 

--- a/mockadmin/organizations_api.go
+++ b/mockadmin/organizations_api.go
@@ -51,7 +51,7 @@ type OrganizationsApi_CreateOrganization_Call struct {
 // CreateOrganization is a helper method to define mock.On call
 //   - ctx context.Context
 //   - createOrganizationRequest *admin.CreateOrganizationRequest
-func (_e *OrganizationsApi_Expecter) CreateOrganization(ctx interface{}, createOrganizationRequest interface{}) *OrganizationsApi_CreateOrganization_Call {
+func (_e *OrganizationsApi_Expecter) CreateOrganization(ctx any, createOrganizationRequest any) *OrganizationsApi_CreateOrganization_Call {
 	return &OrganizationsApi_CreateOrganization_Call{Call: _e.mock.On("CreateOrganization", ctx, createOrganizationRequest)}
 }
 
@@ -118,7 +118,7 @@ type OrganizationsApi_CreateOrganizationExecute_Call struct {
 
 // CreateOrganizationExecute is a helper method to define mock.On call
 //   - r admin.CreateOrganizationApiRequest
-func (_e *OrganizationsApi_Expecter) CreateOrganizationExecute(r interface{}) *OrganizationsApi_CreateOrganizationExecute_Call {
+func (_e *OrganizationsApi_Expecter) CreateOrganizationExecute(r any) *OrganizationsApi_CreateOrganizationExecute_Call {
 	return &OrganizationsApi_CreateOrganizationExecute_Call{Call: _e.mock.On("CreateOrganizationExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type OrganizationsApi_CreateOrganizationInvitation_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - organizationInvitationRequest *admin.OrganizationInvitationRequest
-func (_e *OrganizationsApi_Expecter) CreateOrganizationInvitation(ctx interface{}, orgId interface{}, organizationInvitationRequest interface{}) *OrganizationsApi_CreateOrganizationInvitation_Call {
+func (_e *OrganizationsApi_Expecter) CreateOrganizationInvitation(ctx any, orgId any, organizationInvitationRequest any) *OrganizationsApi_CreateOrganizationInvitation_Call {
 	return &OrganizationsApi_CreateOrganizationInvitation_Call{Call: _e.mock.On("CreateOrganizationInvitation", ctx, orgId, organizationInvitationRequest)}
 }
 
@@ -233,7 +233,7 @@ type OrganizationsApi_CreateOrganizationInvitationExecute_Call struct {
 
 // CreateOrganizationInvitationExecute is a helper method to define mock.On call
 //   - r admin.CreateOrganizationInvitationApiRequest
-func (_e *OrganizationsApi_Expecter) CreateOrganizationInvitationExecute(r interface{}) *OrganizationsApi_CreateOrganizationInvitationExecute_Call {
+func (_e *OrganizationsApi_Expecter) CreateOrganizationInvitationExecute(r any) *OrganizationsApi_CreateOrganizationInvitationExecute_Call {
 	return &OrganizationsApi_CreateOrganizationInvitationExecute_Call{Call: _e.mock.On("CreateOrganizationInvitationExecute", r)}
 }
 
@@ -280,7 +280,7 @@ type OrganizationsApi_CreateOrganizationInvitationWithParams_Call struct {
 // CreateOrganizationInvitationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateOrganizationInvitationApiParams
-func (_e *OrganizationsApi_Expecter) CreateOrganizationInvitationWithParams(ctx interface{}, args interface{}) *OrganizationsApi_CreateOrganizationInvitationWithParams_Call {
+func (_e *OrganizationsApi_Expecter) CreateOrganizationInvitationWithParams(ctx any, args any) *OrganizationsApi_CreateOrganizationInvitationWithParams_Call {
 	return &OrganizationsApi_CreateOrganizationInvitationWithParams_Call{Call: _e.mock.On("CreateOrganizationInvitationWithParams", ctx, args)}
 }
 
@@ -327,7 +327,7 @@ type OrganizationsApi_CreateOrganizationWithParams_Call struct {
 // CreateOrganizationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateOrganizationApiParams
-func (_e *OrganizationsApi_Expecter) CreateOrganizationWithParams(ctx interface{}, args interface{}) *OrganizationsApi_CreateOrganizationWithParams_Call {
+func (_e *OrganizationsApi_Expecter) CreateOrganizationWithParams(ctx any, args any) *OrganizationsApi_CreateOrganizationWithParams_Call {
 	return &OrganizationsApi_CreateOrganizationWithParams_Call{Call: _e.mock.On("CreateOrganizationWithParams", ctx, args)}
 }
 
@@ -374,7 +374,7 @@ type OrganizationsApi_DeleteOrganization_Call struct {
 // DeleteOrganization is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *OrganizationsApi_Expecter) DeleteOrganization(ctx interface{}, orgId interface{}) *OrganizationsApi_DeleteOrganization_Call {
+func (_e *OrganizationsApi_Expecter) DeleteOrganization(ctx any, orgId any) *OrganizationsApi_DeleteOrganization_Call {
 	return &OrganizationsApi_DeleteOrganization_Call{Call: _e.mock.On("DeleteOrganization", ctx, orgId)}
 }
 
@@ -396,24 +396,24 @@ func (_c *OrganizationsApi_DeleteOrganization_Call) RunAndReturn(run func(contex
 }
 
 // DeleteOrganizationExecute provides a mock function with given fields: r
-func (_m *OrganizationsApi) DeleteOrganizationExecute(r admin.DeleteOrganizationApiRequest) (interface{}, *http.Response, error) {
+func (_m *OrganizationsApi) DeleteOrganizationExecute(r admin.DeleteOrganizationApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteOrganizationExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteOrganizationApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteOrganizationApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteOrganizationApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteOrganizationApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -441,7 +441,7 @@ type OrganizationsApi_DeleteOrganizationExecute_Call struct {
 
 // DeleteOrganizationExecute is a helper method to define mock.On call
 //   - r admin.DeleteOrganizationApiRequest
-func (_e *OrganizationsApi_Expecter) DeleteOrganizationExecute(r interface{}) *OrganizationsApi_DeleteOrganizationExecute_Call {
+func (_e *OrganizationsApi_Expecter) DeleteOrganizationExecute(r any) *OrganizationsApi_DeleteOrganizationExecute_Call {
 	return &OrganizationsApi_DeleteOrganizationExecute_Call{Call: _e.mock.On("DeleteOrganizationExecute", r)}
 }
 
@@ -452,12 +452,12 @@ func (_c *OrganizationsApi_DeleteOrganizationExecute_Call) Run(run func(r admin.
 	return _c
 }
 
-func (_c *OrganizationsApi_DeleteOrganizationExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *OrganizationsApi_DeleteOrganizationExecute_Call {
+func (_c *OrganizationsApi_DeleteOrganizationExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *OrganizationsApi_DeleteOrganizationExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *OrganizationsApi_DeleteOrganizationExecute_Call) RunAndReturn(run func(admin.DeleteOrganizationApiRequest) (interface{}, *http.Response, error)) *OrganizationsApi_DeleteOrganizationExecute_Call {
+func (_c *OrganizationsApi_DeleteOrganizationExecute_Call) RunAndReturn(run func(admin.DeleteOrganizationApiRequest) (any, *http.Response, error)) *OrganizationsApi_DeleteOrganizationExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -489,7 +489,7 @@ type OrganizationsApi_DeleteOrganizationInvitation_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - invitationId string
-func (_e *OrganizationsApi_Expecter) DeleteOrganizationInvitation(ctx interface{}, orgId interface{}, invitationId interface{}) *OrganizationsApi_DeleteOrganizationInvitation_Call {
+func (_e *OrganizationsApi_Expecter) DeleteOrganizationInvitation(ctx any, orgId any, invitationId any) *OrganizationsApi_DeleteOrganizationInvitation_Call {
 	return &OrganizationsApi_DeleteOrganizationInvitation_Call{Call: _e.mock.On("DeleteOrganizationInvitation", ctx, orgId, invitationId)}
 }
 
@@ -511,24 +511,24 @@ func (_c *OrganizationsApi_DeleteOrganizationInvitation_Call) RunAndReturn(run f
 }
 
 // DeleteOrganizationInvitationExecute provides a mock function with given fields: r
-func (_m *OrganizationsApi) DeleteOrganizationInvitationExecute(r admin.DeleteOrganizationInvitationApiRequest) (interface{}, *http.Response, error) {
+func (_m *OrganizationsApi) DeleteOrganizationInvitationExecute(r admin.DeleteOrganizationInvitationApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteOrganizationInvitationExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteOrganizationInvitationApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteOrganizationInvitationApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteOrganizationInvitationApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteOrganizationInvitationApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -556,7 +556,7 @@ type OrganizationsApi_DeleteOrganizationInvitationExecute_Call struct {
 
 // DeleteOrganizationInvitationExecute is a helper method to define mock.On call
 //   - r admin.DeleteOrganizationInvitationApiRequest
-func (_e *OrganizationsApi_Expecter) DeleteOrganizationInvitationExecute(r interface{}) *OrganizationsApi_DeleteOrganizationInvitationExecute_Call {
+func (_e *OrganizationsApi_Expecter) DeleteOrganizationInvitationExecute(r any) *OrganizationsApi_DeleteOrganizationInvitationExecute_Call {
 	return &OrganizationsApi_DeleteOrganizationInvitationExecute_Call{Call: _e.mock.On("DeleteOrganizationInvitationExecute", r)}
 }
 
@@ -567,12 +567,12 @@ func (_c *OrganizationsApi_DeleteOrganizationInvitationExecute_Call) Run(run fun
 	return _c
 }
 
-func (_c *OrganizationsApi_DeleteOrganizationInvitationExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *OrganizationsApi_DeleteOrganizationInvitationExecute_Call {
+func (_c *OrganizationsApi_DeleteOrganizationInvitationExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *OrganizationsApi_DeleteOrganizationInvitationExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *OrganizationsApi_DeleteOrganizationInvitationExecute_Call) RunAndReturn(run func(admin.DeleteOrganizationInvitationApiRequest) (interface{}, *http.Response, error)) *OrganizationsApi_DeleteOrganizationInvitationExecute_Call {
+func (_c *OrganizationsApi_DeleteOrganizationInvitationExecute_Call) RunAndReturn(run func(admin.DeleteOrganizationInvitationApiRequest) (any, *http.Response, error)) *OrganizationsApi_DeleteOrganizationInvitationExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -603,7 +603,7 @@ type OrganizationsApi_DeleteOrganizationInvitationWithParams_Call struct {
 // DeleteOrganizationInvitationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteOrganizationInvitationApiParams
-func (_e *OrganizationsApi_Expecter) DeleteOrganizationInvitationWithParams(ctx interface{}, args interface{}) *OrganizationsApi_DeleteOrganizationInvitationWithParams_Call {
+func (_e *OrganizationsApi_Expecter) DeleteOrganizationInvitationWithParams(ctx any, args any) *OrganizationsApi_DeleteOrganizationInvitationWithParams_Call {
 	return &OrganizationsApi_DeleteOrganizationInvitationWithParams_Call{Call: _e.mock.On("DeleteOrganizationInvitationWithParams", ctx, args)}
 }
 
@@ -650,7 +650,7 @@ type OrganizationsApi_DeleteOrganizationWithParams_Call struct {
 // DeleteOrganizationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteOrganizationApiParams
-func (_e *OrganizationsApi_Expecter) DeleteOrganizationWithParams(ctx interface{}, args interface{}) *OrganizationsApi_DeleteOrganizationWithParams_Call {
+func (_e *OrganizationsApi_Expecter) DeleteOrganizationWithParams(ctx any, args any) *OrganizationsApi_DeleteOrganizationWithParams_Call {
 	return &OrganizationsApi_DeleteOrganizationWithParams_Call{Call: _e.mock.On("DeleteOrganizationWithParams", ctx, args)}
 }
 
@@ -697,7 +697,7 @@ type OrganizationsApi_GetOrganization_Call struct {
 // GetOrganization is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *OrganizationsApi_Expecter) GetOrganization(ctx interface{}, orgId interface{}) *OrganizationsApi_GetOrganization_Call {
+func (_e *OrganizationsApi_Expecter) GetOrganization(ctx any, orgId any) *OrganizationsApi_GetOrganization_Call {
 	return &OrganizationsApi_GetOrganization_Call{Call: _e.mock.On("GetOrganization", ctx, orgId)}
 }
 
@@ -764,7 +764,7 @@ type OrganizationsApi_GetOrganizationExecute_Call struct {
 
 // GetOrganizationExecute is a helper method to define mock.On call
 //   - r admin.GetOrganizationApiRequest
-func (_e *OrganizationsApi_Expecter) GetOrganizationExecute(r interface{}) *OrganizationsApi_GetOrganizationExecute_Call {
+func (_e *OrganizationsApi_Expecter) GetOrganizationExecute(r any) *OrganizationsApi_GetOrganizationExecute_Call {
 	return &OrganizationsApi_GetOrganizationExecute_Call{Call: _e.mock.On("GetOrganizationExecute", r)}
 }
 
@@ -812,7 +812,7 @@ type OrganizationsApi_GetOrganizationInvitation_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - invitationId string
-func (_e *OrganizationsApi_Expecter) GetOrganizationInvitation(ctx interface{}, orgId interface{}, invitationId interface{}) *OrganizationsApi_GetOrganizationInvitation_Call {
+func (_e *OrganizationsApi_Expecter) GetOrganizationInvitation(ctx any, orgId any, invitationId any) *OrganizationsApi_GetOrganizationInvitation_Call {
 	return &OrganizationsApi_GetOrganizationInvitation_Call{Call: _e.mock.On("GetOrganizationInvitation", ctx, orgId, invitationId)}
 }
 
@@ -879,7 +879,7 @@ type OrganizationsApi_GetOrganizationInvitationExecute_Call struct {
 
 // GetOrganizationInvitationExecute is a helper method to define mock.On call
 //   - r admin.GetOrganizationInvitationApiRequest
-func (_e *OrganizationsApi_Expecter) GetOrganizationInvitationExecute(r interface{}) *OrganizationsApi_GetOrganizationInvitationExecute_Call {
+func (_e *OrganizationsApi_Expecter) GetOrganizationInvitationExecute(r any) *OrganizationsApi_GetOrganizationInvitationExecute_Call {
 	return &OrganizationsApi_GetOrganizationInvitationExecute_Call{Call: _e.mock.On("GetOrganizationInvitationExecute", r)}
 }
 
@@ -926,7 +926,7 @@ type OrganizationsApi_GetOrganizationInvitationWithParams_Call struct {
 // GetOrganizationInvitationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetOrganizationInvitationApiParams
-func (_e *OrganizationsApi_Expecter) GetOrganizationInvitationWithParams(ctx interface{}, args interface{}) *OrganizationsApi_GetOrganizationInvitationWithParams_Call {
+func (_e *OrganizationsApi_Expecter) GetOrganizationInvitationWithParams(ctx any, args any) *OrganizationsApi_GetOrganizationInvitationWithParams_Call {
 	return &OrganizationsApi_GetOrganizationInvitationWithParams_Call{Call: _e.mock.On("GetOrganizationInvitationWithParams", ctx, args)}
 }
 
@@ -973,7 +973,7 @@ type OrganizationsApi_GetOrganizationSettings_Call struct {
 // GetOrganizationSettings is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *OrganizationsApi_Expecter) GetOrganizationSettings(ctx interface{}, orgId interface{}) *OrganizationsApi_GetOrganizationSettings_Call {
+func (_e *OrganizationsApi_Expecter) GetOrganizationSettings(ctx any, orgId any) *OrganizationsApi_GetOrganizationSettings_Call {
 	return &OrganizationsApi_GetOrganizationSettings_Call{Call: _e.mock.On("GetOrganizationSettings", ctx, orgId)}
 }
 
@@ -1040,7 +1040,7 @@ type OrganizationsApi_GetOrganizationSettingsExecute_Call struct {
 
 // GetOrganizationSettingsExecute is a helper method to define mock.On call
 //   - r admin.GetOrganizationSettingsApiRequest
-func (_e *OrganizationsApi_Expecter) GetOrganizationSettingsExecute(r interface{}) *OrganizationsApi_GetOrganizationSettingsExecute_Call {
+func (_e *OrganizationsApi_Expecter) GetOrganizationSettingsExecute(r any) *OrganizationsApi_GetOrganizationSettingsExecute_Call {
 	return &OrganizationsApi_GetOrganizationSettingsExecute_Call{Call: _e.mock.On("GetOrganizationSettingsExecute", r)}
 }
 
@@ -1087,7 +1087,7 @@ type OrganizationsApi_GetOrganizationSettingsWithParams_Call struct {
 // GetOrganizationSettingsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetOrganizationSettingsApiParams
-func (_e *OrganizationsApi_Expecter) GetOrganizationSettingsWithParams(ctx interface{}, args interface{}) *OrganizationsApi_GetOrganizationSettingsWithParams_Call {
+func (_e *OrganizationsApi_Expecter) GetOrganizationSettingsWithParams(ctx any, args any) *OrganizationsApi_GetOrganizationSettingsWithParams_Call {
 	return &OrganizationsApi_GetOrganizationSettingsWithParams_Call{Call: _e.mock.On("GetOrganizationSettingsWithParams", ctx, args)}
 }
 
@@ -1134,7 +1134,7 @@ type OrganizationsApi_GetOrganizationWithParams_Call struct {
 // GetOrganizationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetOrganizationApiParams
-func (_e *OrganizationsApi_Expecter) GetOrganizationWithParams(ctx interface{}, args interface{}) *OrganizationsApi_GetOrganizationWithParams_Call {
+func (_e *OrganizationsApi_Expecter) GetOrganizationWithParams(ctx any, args any) *OrganizationsApi_GetOrganizationWithParams_Call {
 	return &OrganizationsApi_GetOrganizationWithParams_Call{Call: _e.mock.On("GetOrganizationWithParams", ctx, args)}
 }
 
@@ -1181,7 +1181,7 @@ type OrganizationsApi_ListOrganizationInvitations_Call struct {
 // ListOrganizationInvitations is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *OrganizationsApi_Expecter) ListOrganizationInvitations(ctx interface{}, orgId interface{}) *OrganizationsApi_ListOrganizationInvitations_Call {
+func (_e *OrganizationsApi_Expecter) ListOrganizationInvitations(ctx any, orgId any) *OrganizationsApi_ListOrganizationInvitations_Call {
 	return &OrganizationsApi_ListOrganizationInvitations_Call{Call: _e.mock.On("ListOrganizationInvitations", ctx, orgId)}
 }
 
@@ -1248,7 +1248,7 @@ type OrganizationsApi_ListOrganizationInvitationsExecute_Call struct {
 
 // ListOrganizationInvitationsExecute is a helper method to define mock.On call
 //   - r admin.ListOrganizationInvitationsApiRequest
-func (_e *OrganizationsApi_Expecter) ListOrganizationInvitationsExecute(r interface{}) *OrganizationsApi_ListOrganizationInvitationsExecute_Call {
+func (_e *OrganizationsApi_Expecter) ListOrganizationInvitationsExecute(r any) *OrganizationsApi_ListOrganizationInvitationsExecute_Call {
 	return &OrganizationsApi_ListOrganizationInvitationsExecute_Call{Call: _e.mock.On("ListOrganizationInvitationsExecute", r)}
 }
 
@@ -1295,7 +1295,7 @@ type OrganizationsApi_ListOrganizationInvitationsWithParams_Call struct {
 // ListOrganizationInvitationsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListOrganizationInvitationsApiParams
-func (_e *OrganizationsApi_Expecter) ListOrganizationInvitationsWithParams(ctx interface{}, args interface{}) *OrganizationsApi_ListOrganizationInvitationsWithParams_Call {
+func (_e *OrganizationsApi_Expecter) ListOrganizationInvitationsWithParams(ctx any, args any) *OrganizationsApi_ListOrganizationInvitationsWithParams_Call {
 	return &OrganizationsApi_ListOrganizationInvitationsWithParams_Call{Call: _e.mock.On("ListOrganizationInvitationsWithParams", ctx, args)}
 }
 
@@ -1342,7 +1342,7 @@ type OrganizationsApi_ListOrganizationProjects_Call struct {
 // ListOrganizationProjects is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *OrganizationsApi_Expecter) ListOrganizationProjects(ctx interface{}, orgId interface{}) *OrganizationsApi_ListOrganizationProjects_Call {
+func (_e *OrganizationsApi_Expecter) ListOrganizationProjects(ctx any, orgId any) *OrganizationsApi_ListOrganizationProjects_Call {
 	return &OrganizationsApi_ListOrganizationProjects_Call{Call: _e.mock.On("ListOrganizationProjects", ctx, orgId)}
 }
 
@@ -1409,7 +1409,7 @@ type OrganizationsApi_ListOrganizationProjectsExecute_Call struct {
 
 // ListOrganizationProjectsExecute is a helper method to define mock.On call
 //   - r admin.ListOrganizationProjectsApiRequest
-func (_e *OrganizationsApi_Expecter) ListOrganizationProjectsExecute(r interface{}) *OrganizationsApi_ListOrganizationProjectsExecute_Call {
+func (_e *OrganizationsApi_Expecter) ListOrganizationProjectsExecute(r any) *OrganizationsApi_ListOrganizationProjectsExecute_Call {
 	return &OrganizationsApi_ListOrganizationProjectsExecute_Call{Call: _e.mock.On("ListOrganizationProjectsExecute", r)}
 }
 
@@ -1456,7 +1456,7 @@ type OrganizationsApi_ListOrganizationProjectsWithParams_Call struct {
 // ListOrganizationProjectsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListOrganizationProjectsApiParams
-func (_e *OrganizationsApi_Expecter) ListOrganizationProjectsWithParams(ctx interface{}, args interface{}) *OrganizationsApi_ListOrganizationProjectsWithParams_Call {
+func (_e *OrganizationsApi_Expecter) ListOrganizationProjectsWithParams(ctx any, args any) *OrganizationsApi_ListOrganizationProjectsWithParams_Call {
 	return &OrganizationsApi_ListOrganizationProjectsWithParams_Call{Call: _e.mock.On("ListOrganizationProjectsWithParams", ctx, args)}
 }
 
@@ -1503,7 +1503,7 @@ type OrganizationsApi_ListOrganizationUsers_Call struct {
 // ListOrganizationUsers is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *OrganizationsApi_Expecter) ListOrganizationUsers(ctx interface{}, orgId interface{}) *OrganizationsApi_ListOrganizationUsers_Call {
+func (_e *OrganizationsApi_Expecter) ListOrganizationUsers(ctx any, orgId any) *OrganizationsApi_ListOrganizationUsers_Call {
 	return &OrganizationsApi_ListOrganizationUsers_Call{Call: _e.mock.On("ListOrganizationUsers", ctx, orgId)}
 }
 
@@ -1570,7 +1570,7 @@ type OrganizationsApi_ListOrganizationUsersExecute_Call struct {
 
 // ListOrganizationUsersExecute is a helper method to define mock.On call
 //   - r admin.ListOrganizationUsersApiRequest
-func (_e *OrganizationsApi_Expecter) ListOrganizationUsersExecute(r interface{}) *OrganizationsApi_ListOrganizationUsersExecute_Call {
+func (_e *OrganizationsApi_Expecter) ListOrganizationUsersExecute(r any) *OrganizationsApi_ListOrganizationUsersExecute_Call {
 	return &OrganizationsApi_ListOrganizationUsersExecute_Call{Call: _e.mock.On("ListOrganizationUsersExecute", r)}
 }
 
@@ -1617,7 +1617,7 @@ type OrganizationsApi_ListOrganizationUsersWithParams_Call struct {
 // ListOrganizationUsersWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListOrganizationUsersApiParams
-func (_e *OrganizationsApi_Expecter) ListOrganizationUsersWithParams(ctx interface{}, args interface{}) *OrganizationsApi_ListOrganizationUsersWithParams_Call {
+func (_e *OrganizationsApi_Expecter) ListOrganizationUsersWithParams(ctx any, args any) *OrganizationsApi_ListOrganizationUsersWithParams_Call {
 	return &OrganizationsApi_ListOrganizationUsersWithParams_Call{Call: _e.mock.On("ListOrganizationUsersWithParams", ctx, args)}
 }
 
@@ -1663,7 +1663,7 @@ type OrganizationsApi_ListOrganizations_Call struct {
 
 // ListOrganizations is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *OrganizationsApi_Expecter) ListOrganizations(ctx interface{}) *OrganizationsApi_ListOrganizations_Call {
+func (_e *OrganizationsApi_Expecter) ListOrganizations(ctx any) *OrganizationsApi_ListOrganizations_Call {
 	return &OrganizationsApi_ListOrganizations_Call{Call: _e.mock.On("ListOrganizations", ctx)}
 }
 
@@ -1730,7 +1730,7 @@ type OrganizationsApi_ListOrganizationsExecute_Call struct {
 
 // ListOrganizationsExecute is a helper method to define mock.On call
 //   - r admin.ListOrganizationsApiRequest
-func (_e *OrganizationsApi_Expecter) ListOrganizationsExecute(r interface{}) *OrganizationsApi_ListOrganizationsExecute_Call {
+func (_e *OrganizationsApi_Expecter) ListOrganizationsExecute(r any) *OrganizationsApi_ListOrganizationsExecute_Call {
 	return &OrganizationsApi_ListOrganizationsExecute_Call{Call: _e.mock.On("ListOrganizationsExecute", r)}
 }
 
@@ -1777,7 +1777,7 @@ type OrganizationsApi_ListOrganizationsWithParams_Call struct {
 // ListOrganizationsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListOrganizationsApiParams
-func (_e *OrganizationsApi_Expecter) ListOrganizationsWithParams(ctx interface{}, args interface{}) *OrganizationsApi_ListOrganizationsWithParams_Call {
+func (_e *OrganizationsApi_Expecter) ListOrganizationsWithParams(ctx any, args any) *OrganizationsApi_ListOrganizationsWithParams_Call {
 	return &OrganizationsApi_ListOrganizationsWithParams_Call{Call: _e.mock.On("ListOrganizationsWithParams", ctx, args)}
 }
 
@@ -1825,7 +1825,7 @@ type OrganizationsApi_RemoveOrganizationUser_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - userId string
-func (_e *OrganizationsApi_Expecter) RemoveOrganizationUser(ctx interface{}, orgId interface{}, userId interface{}) *OrganizationsApi_RemoveOrganizationUser_Call {
+func (_e *OrganizationsApi_Expecter) RemoveOrganizationUser(ctx any, orgId any, userId any) *OrganizationsApi_RemoveOrganizationUser_Call {
 	return &OrganizationsApi_RemoveOrganizationUser_Call{Call: _e.mock.On("RemoveOrganizationUser", ctx, orgId, userId)}
 }
 
@@ -1847,24 +1847,24 @@ func (_c *OrganizationsApi_RemoveOrganizationUser_Call) RunAndReturn(run func(co
 }
 
 // RemoveOrganizationUserExecute provides a mock function with given fields: r
-func (_m *OrganizationsApi) RemoveOrganizationUserExecute(r admin.RemoveOrganizationUserApiRequest) (interface{}, *http.Response, error) {
+func (_m *OrganizationsApi) RemoveOrganizationUserExecute(r admin.RemoveOrganizationUserApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RemoveOrganizationUserExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.RemoveOrganizationUserApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.RemoveOrganizationUserApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.RemoveOrganizationUserApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.RemoveOrganizationUserApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -1892,7 +1892,7 @@ type OrganizationsApi_RemoveOrganizationUserExecute_Call struct {
 
 // RemoveOrganizationUserExecute is a helper method to define mock.On call
 //   - r admin.RemoveOrganizationUserApiRequest
-func (_e *OrganizationsApi_Expecter) RemoveOrganizationUserExecute(r interface{}) *OrganizationsApi_RemoveOrganizationUserExecute_Call {
+func (_e *OrganizationsApi_Expecter) RemoveOrganizationUserExecute(r any) *OrganizationsApi_RemoveOrganizationUserExecute_Call {
 	return &OrganizationsApi_RemoveOrganizationUserExecute_Call{Call: _e.mock.On("RemoveOrganizationUserExecute", r)}
 }
 
@@ -1903,12 +1903,12 @@ func (_c *OrganizationsApi_RemoveOrganizationUserExecute_Call) Run(run func(r ad
 	return _c
 }
 
-func (_c *OrganizationsApi_RemoveOrganizationUserExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *OrganizationsApi_RemoveOrganizationUserExecute_Call {
+func (_c *OrganizationsApi_RemoveOrganizationUserExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *OrganizationsApi_RemoveOrganizationUserExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *OrganizationsApi_RemoveOrganizationUserExecute_Call) RunAndReturn(run func(admin.RemoveOrganizationUserApiRequest) (interface{}, *http.Response, error)) *OrganizationsApi_RemoveOrganizationUserExecute_Call {
+func (_c *OrganizationsApi_RemoveOrganizationUserExecute_Call) RunAndReturn(run func(admin.RemoveOrganizationUserApiRequest) (any, *http.Response, error)) *OrganizationsApi_RemoveOrganizationUserExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1939,7 +1939,7 @@ type OrganizationsApi_RemoveOrganizationUserWithParams_Call struct {
 // RemoveOrganizationUserWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.RemoveOrganizationUserApiParams
-func (_e *OrganizationsApi_Expecter) RemoveOrganizationUserWithParams(ctx interface{}, args interface{}) *OrganizationsApi_RemoveOrganizationUserWithParams_Call {
+func (_e *OrganizationsApi_Expecter) RemoveOrganizationUserWithParams(ctx any, args any) *OrganizationsApi_RemoveOrganizationUserWithParams_Call {
 	return &OrganizationsApi_RemoveOrganizationUserWithParams_Call{Call: _e.mock.On("RemoveOrganizationUserWithParams", ctx, args)}
 }
 
@@ -1987,7 +1987,7 @@ type OrganizationsApi_RenameOrganization_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - atlasOrganization *admin.AtlasOrganization
-func (_e *OrganizationsApi_Expecter) RenameOrganization(ctx interface{}, orgId interface{}, atlasOrganization interface{}) *OrganizationsApi_RenameOrganization_Call {
+func (_e *OrganizationsApi_Expecter) RenameOrganization(ctx any, orgId any, atlasOrganization any) *OrganizationsApi_RenameOrganization_Call {
 	return &OrganizationsApi_RenameOrganization_Call{Call: _e.mock.On("RenameOrganization", ctx, orgId, atlasOrganization)}
 }
 
@@ -2054,7 +2054,7 @@ type OrganizationsApi_RenameOrganizationExecute_Call struct {
 
 // RenameOrganizationExecute is a helper method to define mock.On call
 //   - r admin.RenameOrganizationApiRequest
-func (_e *OrganizationsApi_Expecter) RenameOrganizationExecute(r interface{}) *OrganizationsApi_RenameOrganizationExecute_Call {
+func (_e *OrganizationsApi_Expecter) RenameOrganizationExecute(r any) *OrganizationsApi_RenameOrganizationExecute_Call {
 	return &OrganizationsApi_RenameOrganizationExecute_Call{Call: _e.mock.On("RenameOrganizationExecute", r)}
 }
 
@@ -2101,7 +2101,7 @@ type OrganizationsApi_RenameOrganizationWithParams_Call struct {
 // RenameOrganizationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.RenameOrganizationApiParams
-func (_e *OrganizationsApi_Expecter) RenameOrganizationWithParams(ctx interface{}, args interface{}) *OrganizationsApi_RenameOrganizationWithParams_Call {
+func (_e *OrganizationsApi_Expecter) RenameOrganizationWithParams(ctx any, args any) *OrganizationsApi_RenameOrganizationWithParams_Call {
 	return &OrganizationsApi_RenameOrganizationWithParams_Call{Call: _e.mock.On("RenameOrganizationWithParams", ctx, args)}
 }
 
@@ -2149,7 +2149,7 @@ type OrganizationsApi_UpdateOrganizationInvitation_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - organizationInvitationRequest *admin.OrganizationInvitationRequest
-func (_e *OrganizationsApi_Expecter) UpdateOrganizationInvitation(ctx interface{}, orgId interface{}, organizationInvitationRequest interface{}) *OrganizationsApi_UpdateOrganizationInvitation_Call {
+func (_e *OrganizationsApi_Expecter) UpdateOrganizationInvitation(ctx any, orgId any, organizationInvitationRequest any) *OrganizationsApi_UpdateOrganizationInvitation_Call {
 	return &OrganizationsApi_UpdateOrganizationInvitation_Call{Call: _e.mock.On("UpdateOrganizationInvitation", ctx, orgId, organizationInvitationRequest)}
 }
 
@@ -2198,7 +2198,7 @@ type OrganizationsApi_UpdateOrganizationInvitationById_Call struct {
 //   - orgId string
 //   - invitationId string
 //   - organizationInvitationUpdateRequest *admin.OrganizationInvitationUpdateRequest
-func (_e *OrganizationsApi_Expecter) UpdateOrganizationInvitationById(ctx interface{}, orgId interface{}, invitationId interface{}, organizationInvitationUpdateRequest interface{}) *OrganizationsApi_UpdateOrganizationInvitationById_Call {
+func (_e *OrganizationsApi_Expecter) UpdateOrganizationInvitationById(ctx any, orgId any, invitationId any, organizationInvitationUpdateRequest any) *OrganizationsApi_UpdateOrganizationInvitationById_Call {
 	return &OrganizationsApi_UpdateOrganizationInvitationById_Call{Call: _e.mock.On("UpdateOrganizationInvitationById", ctx, orgId, invitationId, organizationInvitationUpdateRequest)}
 }
 
@@ -2265,7 +2265,7 @@ type OrganizationsApi_UpdateOrganizationInvitationByIdExecute_Call struct {
 
 // UpdateOrganizationInvitationByIdExecute is a helper method to define mock.On call
 //   - r admin.UpdateOrganizationInvitationByIdApiRequest
-func (_e *OrganizationsApi_Expecter) UpdateOrganizationInvitationByIdExecute(r interface{}) *OrganizationsApi_UpdateOrganizationInvitationByIdExecute_Call {
+func (_e *OrganizationsApi_Expecter) UpdateOrganizationInvitationByIdExecute(r any) *OrganizationsApi_UpdateOrganizationInvitationByIdExecute_Call {
 	return &OrganizationsApi_UpdateOrganizationInvitationByIdExecute_Call{Call: _e.mock.On("UpdateOrganizationInvitationByIdExecute", r)}
 }
 
@@ -2312,7 +2312,7 @@ type OrganizationsApi_UpdateOrganizationInvitationByIdWithParams_Call struct {
 // UpdateOrganizationInvitationByIdWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateOrganizationInvitationByIdApiParams
-func (_e *OrganizationsApi_Expecter) UpdateOrganizationInvitationByIdWithParams(ctx interface{}, args interface{}) *OrganizationsApi_UpdateOrganizationInvitationByIdWithParams_Call {
+func (_e *OrganizationsApi_Expecter) UpdateOrganizationInvitationByIdWithParams(ctx any, args any) *OrganizationsApi_UpdateOrganizationInvitationByIdWithParams_Call {
 	return &OrganizationsApi_UpdateOrganizationInvitationByIdWithParams_Call{Call: _e.mock.On("UpdateOrganizationInvitationByIdWithParams", ctx, args)}
 }
 
@@ -2379,7 +2379,7 @@ type OrganizationsApi_UpdateOrganizationInvitationExecute_Call struct {
 
 // UpdateOrganizationInvitationExecute is a helper method to define mock.On call
 //   - r admin.UpdateOrganizationInvitationApiRequest
-func (_e *OrganizationsApi_Expecter) UpdateOrganizationInvitationExecute(r interface{}) *OrganizationsApi_UpdateOrganizationInvitationExecute_Call {
+func (_e *OrganizationsApi_Expecter) UpdateOrganizationInvitationExecute(r any) *OrganizationsApi_UpdateOrganizationInvitationExecute_Call {
 	return &OrganizationsApi_UpdateOrganizationInvitationExecute_Call{Call: _e.mock.On("UpdateOrganizationInvitationExecute", r)}
 }
 
@@ -2426,7 +2426,7 @@ type OrganizationsApi_UpdateOrganizationInvitationWithParams_Call struct {
 // UpdateOrganizationInvitationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateOrganizationInvitationApiParams
-func (_e *OrganizationsApi_Expecter) UpdateOrganizationInvitationWithParams(ctx interface{}, args interface{}) *OrganizationsApi_UpdateOrganizationInvitationWithParams_Call {
+func (_e *OrganizationsApi_Expecter) UpdateOrganizationInvitationWithParams(ctx any, args any) *OrganizationsApi_UpdateOrganizationInvitationWithParams_Call {
 	return &OrganizationsApi_UpdateOrganizationInvitationWithParams_Call{Call: _e.mock.On("UpdateOrganizationInvitationWithParams", ctx, args)}
 }
 
@@ -2475,7 +2475,7 @@ type OrganizationsApi_UpdateOrganizationRoles_Call struct {
 //   - orgId string
 //   - userId string
 //   - updateOrgRolesForUser *admin.UpdateOrgRolesForUser
-func (_e *OrganizationsApi_Expecter) UpdateOrganizationRoles(ctx interface{}, orgId interface{}, userId interface{}, updateOrgRolesForUser interface{}) *OrganizationsApi_UpdateOrganizationRoles_Call {
+func (_e *OrganizationsApi_Expecter) UpdateOrganizationRoles(ctx any, orgId any, userId any, updateOrgRolesForUser any) *OrganizationsApi_UpdateOrganizationRoles_Call {
 	return &OrganizationsApi_UpdateOrganizationRoles_Call{Call: _e.mock.On("UpdateOrganizationRoles", ctx, orgId, userId, updateOrgRolesForUser)}
 }
 
@@ -2542,7 +2542,7 @@ type OrganizationsApi_UpdateOrganizationRolesExecute_Call struct {
 
 // UpdateOrganizationRolesExecute is a helper method to define mock.On call
 //   - r admin.UpdateOrganizationRolesApiRequest
-func (_e *OrganizationsApi_Expecter) UpdateOrganizationRolesExecute(r interface{}) *OrganizationsApi_UpdateOrganizationRolesExecute_Call {
+func (_e *OrganizationsApi_Expecter) UpdateOrganizationRolesExecute(r any) *OrganizationsApi_UpdateOrganizationRolesExecute_Call {
 	return &OrganizationsApi_UpdateOrganizationRolesExecute_Call{Call: _e.mock.On("UpdateOrganizationRolesExecute", r)}
 }
 
@@ -2589,7 +2589,7 @@ type OrganizationsApi_UpdateOrganizationRolesWithParams_Call struct {
 // UpdateOrganizationRolesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateOrganizationRolesApiParams
-func (_e *OrganizationsApi_Expecter) UpdateOrganizationRolesWithParams(ctx interface{}, args interface{}) *OrganizationsApi_UpdateOrganizationRolesWithParams_Call {
+func (_e *OrganizationsApi_Expecter) UpdateOrganizationRolesWithParams(ctx any, args any) *OrganizationsApi_UpdateOrganizationRolesWithParams_Call {
 	return &OrganizationsApi_UpdateOrganizationRolesWithParams_Call{Call: _e.mock.On("UpdateOrganizationRolesWithParams", ctx, args)}
 }
 
@@ -2637,7 +2637,7 @@ type OrganizationsApi_UpdateOrganizationSettings_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - organizationSettings *admin.OrganizationSettings
-func (_e *OrganizationsApi_Expecter) UpdateOrganizationSettings(ctx interface{}, orgId interface{}, organizationSettings interface{}) *OrganizationsApi_UpdateOrganizationSettings_Call {
+func (_e *OrganizationsApi_Expecter) UpdateOrganizationSettings(ctx any, orgId any, organizationSettings any) *OrganizationsApi_UpdateOrganizationSettings_Call {
 	return &OrganizationsApi_UpdateOrganizationSettings_Call{Call: _e.mock.On("UpdateOrganizationSettings", ctx, orgId, organizationSettings)}
 }
 
@@ -2704,7 +2704,7 @@ type OrganizationsApi_UpdateOrganizationSettingsExecute_Call struct {
 
 // UpdateOrganizationSettingsExecute is a helper method to define mock.On call
 //   - r admin.UpdateOrganizationSettingsApiRequest
-func (_e *OrganizationsApi_Expecter) UpdateOrganizationSettingsExecute(r interface{}) *OrganizationsApi_UpdateOrganizationSettingsExecute_Call {
+func (_e *OrganizationsApi_Expecter) UpdateOrganizationSettingsExecute(r any) *OrganizationsApi_UpdateOrganizationSettingsExecute_Call {
 	return &OrganizationsApi_UpdateOrganizationSettingsExecute_Call{Call: _e.mock.On("UpdateOrganizationSettingsExecute", r)}
 }
 
@@ -2751,7 +2751,7 @@ type OrganizationsApi_UpdateOrganizationSettingsWithParams_Call struct {
 // UpdateOrganizationSettingsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateOrganizationSettingsApiParams
-func (_e *OrganizationsApi_Expecter) UpdateOrganizationSettingsWithParams(ctx interface{}, args interface{}) *OrganizationsApi_UpdateOrganizationSettingsWithParams_Call {
+func (_e *OrganizationsApi_Expecter) UpdateOrganizationSettingsWithParams(ctx any, args any) *OrganizationsApi_UpdateOrganizationSettingsWithParams_Call {
 	return &OrganizationsApi_UpdateOrganizationSettingsWithParams_Call{Call: _e.mock.On("UpdateOrganizationSettingsWithParams", ctx, args)}
 }
 

--- a/mockadmin/performance_advisor_api.go
+++ b/mockadmin/performance_advisor_api.go
@@ -51,7 +51,7 @@ type PerformanceAdvisorApi_DisableSlowOperationThresholding_Call struct {
 // DisableSlowOperationThresholding is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *PerformanceAdvisorApi_Expecter) DisableSlowOperationThresholding(ctx interface{}, groupId interface{}) *PerformanceAdvisorApi_DisableSlowOperationThresholding_Call {
+func (_e *PerformanceAdvisorApi_Expecter) DisableSlowOperationThresholding(ctx any, groupId any) *PerformanceAdvisorApi_DisableSlowOperationThresholding_Call {
 	return &PerformanceAdvisorApi_DisableSlowOperationThresholding_Call{Call: _e.mock.On("DisableSlowOperationThresholding", ctx, groupId)}
 }
 
@@ -109,7 +109,7 @@ type PerformanceAdvisorApi_DisableSlowOperationThresholdingExecute_Call struct {
 
 // DisableSlowOperationThresholdingExecute is a helper method to define mock.On call
 //   - r admin.DisableSlowOperationThresholdingApiRequest
-func (_e *PerformanceAdvisorApi_Expecter) DisableSlowOperationThresholdingExecute(r interface{}) *PerformanceAdvisorApi_DisableSlowOperationThresholdingExecute_Call {
+func (_e *PerformanceAdvisorApi_Expecter) DisableSlowOperationThresholdingExecute(r any) *PerformanceAdvisorApi_DisableSlowOperationThresholdingExecute_Call {
 	return &PerformanceAdvisorApi_DisableSlowOperationThresholdingExecute_Call{Call: _e.mock.On("DisableSlowOperationThresholdingExecute", r)}
 }
 
@@ -156,7 +156,7 @@ type PerformanceAdvisorApi_DisableSlowOperationThresholdingWithParams_Call struc
 // DisableSlowOperationThresholdingWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DisableSlowOperationThresholdingApiParams
-func (_e *PerformanceAdvisorApi_Expecter) DisableSlowOperationThresholdingWithParams(ctx interface{}, args interface{}) *PerformanceAdvisorApi_DisableSlowOperationThresholdingWithParams_Call {
+func (_e *PerformanceAdvisorApi_Expecter) DisableSlowOperationThresholdingWithParams(ctx any, args any) *PerformanceAdvisorApi_DisableSlowOperationThresholdingWithParams_Call {
 	return &PerformanceAdvisorApi_DisableSlowOperationThresholdingWithParams_Call{Call: _e.mock.On("DisableSlowOperationThresholdingWithParams", ctx, args)}
 }
 
@@ -203,7 +203,7 @@ type PerformanceAdvisorApi_EnableSlowOperationThresholding_Call struct {
 // EnableSlowOperationThresholding is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *PerformanceAdvisorApi_Expecter) EnableSlowOperationThresholding(ctx interface{}, groupId interface{}) *PerformanceAdvisorApi_EnableSlowOperationThresholding_Call {
+func (_e *PerformanceAdvisorApi_Expecter) EnableSlowOperationThresholding(ctx any, groupId any) *PerformanceAdvisorApi_EnableSlowOperationThresholding_Call {
 	return &PerformanceAdvisorApi_EnableSlowOperationThresholding_Call{Call: _e.mock.On("EnableSlowOperationThresholding", ctx, groupId)}
 }
 
@@ -261,7 +261,7 @@ type PerformanceAdvisorApi_EnableSlowOperationThresholdingExecute_Call struct {
 
 // EnableSlowOperationThresholdingExecute is a helper method to define mock.On call
 //   - r admin.EnableSlowOperationThresholdingApiRequest
-func (_e *PerformanceAdvisorApi_Expecter) EnableSlowOperationThresholdingExecute(r interface{}) *PerformanceAdvisorApi_EnableSlowOperationThresholdingExecute_Call {
+func (_e *PerformanceAdvisorApi_Expecter) EnableSlowOperationThresholdingExecute(r any) *PerformanceAdvisorApi_EnableSlowOperationThresholdingExecute_Call {
 	return &PerformanceAdvisorApi_EnableSlowOperationThresholdingExecute_Call{Call: _e.mock.On("EnableSlowOperationThresholdingExecute", r)}
 }
 
@@ -308,7 +308,7 @@ type PerformanceAdvisorApi_EnableSlowOperationThresholdingWithParams_Call struct
 // EnableSlowOperationThresholdingWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.EnableSlowOperationThresholdingApiParams
-func (_e *PerformanceAdvisorApi_Expecter) EnableSlowOperationThresholdingWithParams(ctx interface{}, args interface{}) *PerformanceAdvisorApi_EnableSlowOperationThresholdingWithParams_Call {
+func (_e *PerformanceAdvisorApi_Expecter) EnableSlowOperationThresholdingWithParams(ctx any, args any) *PerformanceAdvisorApi_EnableSlowOperationThresholdingWithParams_Call {
 	return &PerformanceAdvisorApi_EnableSlowOperationThresholdingWithParams_Call{Call: _e.mock.On("EnableSlowOperationThresholdingWithParams", ctx, args)}
 }
 
@@ -355,7 +355,7 @@ type PerformanceAdvisorApi_GetManagedSlowMs_Call struct {
 // GetManagedSlowMs is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *PerformanceAdvisorApi_Expecter) GetManagedSlowMs(ctx interface{}, groupId interface{}) *PerformanceAdvisorApi_GetManagedSlowMs_Call {
+func (_e *PerformanceAdvisorApi_Expecter) GetManagedSlowMs(ctx any, groupId any) *PerformanceAdvisorApi_GetManagedSlowMs_Call {
 	return &PerformanceAdvisorApi_GetManagedSlowMs_Call{Call: _e.mock.On("GetManagedSlowMs", ctx, groupId)}
 }
 
@@ -413,7 +413,7 @@ type PerformanceAdvisorApi_GetManagedSlowMsExecute_Call struct {
 
 // GetManagedSlowMsExecute is a helper method to define mock.On call
 //   - r admin.GetManagedSlowMsApiRequest
-func (_e *PerformanceAdvisorApi_Expecter) GetManagedSlowMsExecute(r interface{}) *PerformanceAdvisorApi_GetManagedSlowMsExecute_Call {
+func (_e *PerformanceAdvisorApi_Expecter) GetManagedSlowMsExecute(r any) *PerformanceAdvisorApi_GetManagedSlowMsExecute_Call {
 	return &PerformanceAdvisorApi_GetManagedSlowMsExecute_Call{Call: _e.mock.On("GetManagedSlowMsExecute", r)}
 }
 
@@ -460,7 +460,7 @@ type PerformanceAdvisorApi_GetManagedSlowMsWithParams_Call struct {
 // GetManagedSlowMsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetManagedSlowMsApiParams
-func (_e *PerformanceAdvisorApi_Expecter) GetManagedSlowMsWithParams(ctx interface{}, args interface{}) *PerformanceAdvisorApi_GetManagedSlowMsWithParams_Call {
+func (_e *PerformanceAdvisorApi_Expecter) GetManagedSlowMsWithParams(ctx any, args any) *PerformanceAdvisorApi_GetManagedSlowMsWithParams_Call {
 	return &PerformanceAdvisorApi_GetManagedSlowMsWithParams_Call{Call: _e.mock.On("GetManagedSlowMsWithParams", ctx, args)}
 }
 
@@ -508,7 +508,7 @@ type PerformanceAdvisorApi_GetServerlessAutoIndexing_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *PerformanceAdvisorApi_Expecter) GetServerlessAutoIndexing(ctx interface{}, groupId interface{}, clusterName interface{}) *PerformanceAdvisorApi_GetServerlessAutoIndexing_Call {
+func (_e *PerformanceAdvisorApi_Expecter) GetServerlessAutoIndexing(ctx any, groupId any, clusterName any) *PerformanceAdvisorApi_GetServerlessAutoIndexing_Call {
 	return &PerformanceAdvisorApi_GetServerlessAutoIndexing_Call{Call: _e.mock.On("GetServerlessAutoIndexing", ctx, groupId, clusterName)}
 }
 
@@ -573,7 +573,7 @@ type PerformanceAdvisorApi_GetServerlessAutoIndexingExecute_Call struct {
 
 // GetServerlessAutoIndexingExecute is a helper method to define mock.On call
 //   - r admin.GetServerlessAutoIndexingApiRequest
-func (_e *PerformanceAdvisorApi_Expecter) GetServerlessAutoIndexingExecute(r interface{}) *PerformanceAdvisorApi_GetServerlessAutoIndexingExecute_Call {
+func (_e *PerformanceAdvisorApi_Expecter) GetServerlessAutoIndexingExecute(r any) *PerformanceAdvisorApi_GetServerlessAutoIndexingExecute_Call {
 	return &PerformanceAdvisorApi_GetServerlessAutoIndexingExecute_Call{Call: _e.mock.On("GetServerlessAutoIndexingExecute", r)}
 }
 
@@ -620,7 +620,7 @@ type PerformanceAdvisorApi_GetServerlessAutoIndexingWithParams_Call struct {
 // GetServerlessAutoIndexingWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetServerlessAutoIndexingApiParams
-func (_e *PerformanceAdvisorApi_Expecter) GetServerlessAutoIndexingWithParams(ctx interface{}, args interface{}) *PerformanceAdvisorApi_GetServerlessAutoIndexingWithParams_Call {
+func (_e *PerformanceAdvisorApi_Expecter) GetServerlessAutoIndexingWithParams(ctx any, args any) *PerformanceAdvisorApi_GetServerlessAutoIndexingWithParams_Call {
 	return &PerformanceAdvisorApi_GetServerlessAutoIndexingWithParams_Call{Call: _e.mock.On("GetServerlessAutoIndexingWithParams", ctx, args)}
 }
 
@@ -668,7 +668,7 @@ type PerformanceAdvisorApi_ListSlowQueries_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - processId string
-func (_e *PerformanceAdvisorApi_Expecter) ListSlowQueries(ctx interface{}, groupId interface{}, processId interface{}) *PerformanceAdvisorApi_ListSlowQueries_Call {
+func (_e *PerformanceAdvisorApi_Expecter) ListSlowQueries(ctx any, groupId any, processId any) *PerformanceAdvisorApi_ListSlowQueries_Call {
 	return &PerformanceAdvisorApi_ListSlowQueries_Call{Call: _e.mock.On("ListSlowQueries", ctx, groupId, processId)}
 }
 
@@ -735,7 +735,7 @@ type PerformanceAdvisorApi_ListSlowQueriesExecute_Call struct {
 
 // ListSlowQueriesExecute is a helper method to define mock.On call
 //   - r admin.ListSlowQueriesApiRequest
-func (_e *PerformanceAdvisorApi_Expecter) ListSlowQueriesExecute(r interface{}) *PerformanceAdvisorApi_ListSlowQueriesExecute_Call {
+func (_e *PerformanceAdvisorApi_Expecter) ListSlowQueriesExecute(r any) *PerformanceAdvisorApi_ListSlowQueriesExecute_Call {
 	return &PerformanceAdvisorApi_ListSlowQueriesExecute_Call{Call: _e.mock.On("ListSlowQueriesExecute", r)}
 }
 
@@ -782,7 +782,7 @@ type PerformanceAdvisorApi_ListSlowQueriesWithParams_Call struct {
 // ListSlowQueriesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListSlowQueriesApiParams
-func (_e *PerformanceAdvisorApi_Expecter) ListSlowQueriesWithParams(ctx interface{}, args interface{}) *PerformanceAdvisorApi_ListSlowQueriesWithParams_Call {
+func (_e *PerformanceAdvisorApi_Expecter) ListSlowQueriesWithParams(ctx any, args any) *PerformanceAdvisorApi_ListSlowQueriesWithParams_Call {
 	return &PerformanceAdvisorApi_ListSlowQueriesWithParams_Call{Call: _e.mock.On("ListSlowQueriesWithParams", ctx, args)}
 }
 
@@ -830,7 +830,7 @@ type PerformanceAdvisorApi_ListSlowQueryNamespaces_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - processId string
-func (_e *PerformanceAdvisorApi_Expecter) ListSlowQueryNamespaces(ctx interface{}, groupId interface{}, processId interface{}) *PerformanceAdvisorApi_ListSlowQueryNamespaces_Call {
+func (_e *PerformanceAdvisorApi_Expecter) ListSlowQueryNamespaces(ctx any, groupId any, processId any) *PerformanceAdvisorApi_ListSlowQueryNamespaces_Call {
 	return &PerformanceAdvisorApi_ListSlowQueryNamespaces_Call{Call: _e.mock.On("ListSlowQueryNamespaces", ctx, groupId, processId)}
 }
 
@@ -897,7 +897,7 @@ type PerformanceAdvisorApi_ListSlowQueryNamespacesExecute_Call struct {
 
 // ListSlowQueryNamespacesExecute is a helper method to define mock.On call
 //   - r admin.ListSlowQueryNamespacesApiRequest
-func (_e *PerformanceAdvisorApi_Expecter) ListSlowQueryNamespacesExecute(r interface{}) *PerformanceAdvisorApi_ListSlowQueryNamespacesExecute_Call {
+func (_e *PerformanceAdvisorApi_Expecter) ListSlowQueryNamespacesExecute(r any) *PerformanceAdvisorApi_ListSlowQueryNamespacesExecute_Call {
 	return &PerformanceAdvisorApi_ListSlowQueryNamespacesExecute_Call{Call: _e.mock.On("ListSlowQueryNamespacesExecute", r)}
 }
 
@@ -944,7 +944,7 @@ type PerformanceAdvisorApi_ListSlowQueryNamespacesWithParams_Call struct {
 // ListSlowQueryNamespacesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListSlowQueryNamespacesApiParams
-func (_e *PerformanceAdvisorApi_Expecter) ListSlowQueryNamespacesWithParams(ctx interface{}, args interface{}) *PerformanceAdvisorApi_ListSlowQueryNamespacesWithParams_Call {
+func (_e *PerformanceAdvisorApi_Expecter) ListSlowQueryNamespacesWithParams(ctx any, args any) *PerformanceAdvisorApi_ListSlowQueryNamespacesWithParams_Call {
 	return &PerformanceAdvisorApi_ListSlowQueryNamespacesWithParams_Call{Call: _e.mock.On("ListSlowQueryNamespacesWithParams", ctx, args)}
 }
 
@@ -992,7 +992,7 @@ type PerformanceAdvisorApi_ListSuggestedIndexes_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - processId string
-func (_e *PerformanceAdvisorApi_Expecter) ListSuggestedIndexes(ctx interface{}, groupId interface{}, processId interface{}) *PerformanceAdvisorApi_ListSuggestedIndexes_Call {
+func (_e *PerformanceAdvisorApi_Expecter) ListSuggestedIndexes(ctx any, groupId any, processId any) *PerformanceAdvisorApi_ListSuggestedIndexes_Call {
 	return &PerformanceAdvisorApi_ListSuggestedIndexes_Call{Call: _e.mock.On("ListSuggestedIndexes", ctx, groupId, processId)}
 }
 
@@ -1059,7 +1059,7 @@ type PerformanceAdvisorApi_ListSuggestedIndexesExecute_Call struct {
 
 // ListSuggestedIndexesExecute is a helper method to define mock.On call
 //   - r admin.ListSuggestedIndexesApiRequest
-func (_e *PerformanceAdvisorApi_Expecter) ListSuggestedIndexesExecute(r interface{}) *PerformanceAdvisorApi_ListSuggestedIndexesExecute_Call {
+func (_e *PerformanceAdvisorApi_Expecter) ListSuggestedIndexesExecute(r any) *PerformanceAdvisorApi_ListSuggestedIndexesExecute_Call {
 	return &PerformanceAdvisorApi_ListSuggestedIndexesExecute_Call{Call: _e.mock.On("ListSuggestedIndexesExecute", r)}
 }
 
@@ -1106,7 +1106,7 @@ type PerformanceAdvisorApi_ListSuggestedIndexesWithParams_Call struct {
 // ListSuggestedIndexesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListSuggestedIndexesApiParams
-func (_e *PerformanceAdvisorApi_Expecter) ListSuggestedIndexesWithParams(ctx interface{}, args interface{}) *PerformanceAdvisorApi_ListSuggestedIndexesWithParams_Call {
+func (_e *PerformanceAdvisorApi_Expecter) ListSuggestedIndexesWithParams(ctx any, args any) *PerformanceAdvisorApi_ListSuggestedIndexesWithParams_Call {
 	return &PerformanceAdvisorApi_ListSuggestedIndexesWithParams_Call{Call: _e.mock.On("ListSuggestedIndexesWithParams", ctx, args)}
 }
 
@@ -1154,7 +1154,7 @@ type PerformanceAdvisorApi_SetServerlessAutoIndexing_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *PerformanceAdvisorApi_Expecter) SetServerlessAutoIndexing(ctx interface{}, groupId interface{}, clusterName interface{}) *PerformanceAdvisorApi_SetServerlessAutoIndexing_Call {
+func (_e *PerformanceAdvisorApi_Expecter) SetServerlessAutoIndexing(ctx any, groupId any, clusterName any) *PerformanceAdvisorApi_SetServerlessAutoIndexing_Call {
 	return &PerformanceAdvisorApi_SetServerlessAutoIndexing_Call{Call: _e.mock.On("SetServerlessAutoIndexing", ctx, groupId, clusterName)}
 }
 
@@ -1176,24 +1176,24 @@ func (_c *PerformanceAdvisorApi_SetServerlessAutoIndexing_Call) RunAndReturn(run
 }
 
 // SetServerlessAutoIndexingExecute provides a mock function with given fields: r
-func (_m *PerformanceAdvisorApi) SetServerlessAutoIndexingExecute(r admin.SetServerlessAutoIndexingApiRequest) (interface{}, *http.Response, error) {
+func (_m *PerformanceAdvisorApi) SetServerlessAutoIndexingExecute(r admin.SetServerlessAutoIndexingApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetServerlessAutoIndexingExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.SetServerlessAutoIndexingApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.SetServerlessAutoIndexingApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.SetServerlessAutoIndexingApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.SetServerlessAutoIndexingApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -1221,7 +1221,7 @@ type PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call struct {
 
 // SetServerlessAutoIndexingExecute is a helper method to define mock.On call
 //   - r admin.SetServerlessAutoIndexingApiRequest
-func (_e *PerformanceAdvisorApi_Expecter) SetServerlessAutoIndexingExecute(r interface{}) *PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call {
+func (_e *PerformanceAdvisorApi_Expecter) SetServerlessAutoIndexingExecute(r any) *PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call {
 	return &PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call{Call: _e.mock.On("SetServerlessAutoIndexingExecute", r)}
 }
 
@@ -1232,12 +1232,12 @@ func (_c *PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call) Run(run f
 	return _c
 }
 
-func (_c *PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call {
+func (_c *PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call) RunAndReturn(run func(admin.SetServerlessAutoIndexingApiRequest) (interface{}, *http.Response, error)) *PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call {
+func (_c *PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call) RunAndReturn(run func(admin.SetServerlessAutoIndexingApiRequest) (any, *http.Response, error)) *PerformanceAdvisorApi_SetServerlessAutoIndexingExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1268,7 +1268,7 @@ type PerformanceAdvisorApi_SetServerlessAutoIndexingWithParams_Call struct {
 // SetServerlessAutoIndexingWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.SetServerlessAutoIndexingApiParams
-func (_e *PerformanceAdvisorApi_Expecter) SetServerlessAutoIndexingWithParams(ctx interface{}, args interface{}) *PerformanceAdvisorApi_SetServerlessAutoIndexingWithParams_Call {
+func (_e *PerformanceAdvisorApi_Expecter) SetServerlessAutoIndexingWithParams(ctx any, args any) *PerformanceAdvisorApi_SetServerlessAutoIndexingWithParams_Call {
 	return &PerformanceAdvisorApi_SetServerlessAutoIndexingWithParams_Call{Call: _e.mock.On("SetServerlessAutoIndexingWithParams", ctx, args)}
 }
 

--- a/mockadmin/private_endpoint_services_api.go
+++ b/mockadmin/private_endpoint_services_api.go
@@ -54,7 +54,7 @@ type PrivateEndpointServicesApi_CreatePrivateEndpoint_Call struct {
 //   - cloudProvider string
 //   - endpointServiceId string
 //   - createEndpointRequest *admin.CreateEndpointRequest
-func (_e *PrivateEndpointServicesApi_Expecter) CreatePrivateEndpoint(ctx interface{}, groupId interface{}, cloudProvider interface{}, endpointServiceId interface{}, createEndpointRequest interface{}) *PrivateEndpointServicesApi_CreatePrivateEndpoint_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) CreatePrivateEndpoint(ctx any, groupId any, cloudProvider any, endpointServiceId any, createEndpointRequest any) *PrivateEndpointServicesApi_CreatePrivateEndpoint_Call {
 	return &PrivateEndpointServicesApi_CreatePrivateEndpoint_Call{Call: _e.mock.On("CreatePrivateEndpoint", ctx, groupId, cloudProvider, endpointServiceId, createEndpointRequest)}
 }
 
@@ -121,7 +121,7 @@ type PrivateEndpointServicesApi_CreatePrivateEndpointExecute_Call struct {
 
 // CreatePrivateEndpointExecute is a helper method to define mock.On call
 //   - r admin.CreatePrivateEndpointApiRequest
-func (_e *PrivateEndpointServicesApi_Expecter) CreatePrivateEndpointExecute(r interface{}) *PrivateEndpointServicesApi_CreatePrivateEndpointExecute_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) CreatePrivateEndpointExecute(r any) *PrivateEndpointServicesApi_CreatePrivateEndpointExecute_Call {
 	return &PrivateEndpointServicesApi_CreatePrivateEndpointExecute_Call{Call: _e.mock.On("CreatePrivateEndpointExecute", r)}
 }
 
@@ -169,7 +169,7 @@ type PrivateEndpointServicesApi_CreatePrivateEndpointService_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - cloudProviderEndpointServiceRequest *admin.CloudProviderEndpointServiceRequest
-func (_e *PrivateEndpointServicesApi_Expecter) CreatePrivateEndpointService(ctx interface{}, groupId interface{}, cloudProviderEndpointServiceRequest interface{}) *PrivateEndpointServicesApi_CreatePrivateEndpointService_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) CreatePrivateEndpointService(ctx any, groupId any, cloudProviderEndpointServiceRequest any) *PrivateEndpointServicesApi_CreatePrivateEndpointService_Call {
 	return &PrivateEndpointServicesApi_CreatePrivateEndpointService_Call{Call: _e.mock.On("CreatePrivateEndpointService", ctx, groupId, cloudProviderEndpointServiceRequest)}
 }
 
@@ -236,7 +236,7 @@ type PrivateEndpointServicesApi_CreatePrivateEndpointServiceExecute_Call struct 
 
 // CreatePrivateEndpointServiceExecute is a helper method to define mock.On call
 //   - r admin.CreatePrivateEndpointServiceApiRequest
-func (_e *PrivateEndpointServicesApi_Expecter) CreatePrivateEndpointServiceExecute(r interface{}) *PrivateEndpointServicesApi_CreatePrivateEndpointServiceExecute_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) CreatePrivateEndpointServiceExecute(r any) *PrivateEndpointServicesApi_CreatePrivateEndpointServiceExecute_Call {
 	return &PrivateEndpointServicesApi_CreatePrivateEndpointServiceExecute_Call{Call: _e.mock.On("CreatePrivateEndpointServiceExecute", r)}
 }
 
@@ -283,7 +283,7 @@ type PrivateEndpointServicesApi_CreatePrivateEndpointServiceWithParams_Call stru
 // CreatePrivateEndpointServiceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreatePrivateEndpointServiceApiParams
-func (_e *PrivateEndpointServicesApi_Expecter) CreatePrivateEndpointServiceWithParams(ctx interface{}, args interface{}) *PrivateEndpointServicesApi_CreatePrivateEndpointServiceWithParams_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) CreatePrivateEndpointServiceWithParams(ctx any, args any) *PrivateEndpointServicesApi_CreatePrivateEndpointServiceWithParams_Call {
 	return &PrivateEndpointServicesApi_CreatePrivateEndpointServiceWithParams_Call{Call: _e.mock.On("CreatePrivateEndpointServiceWithParams", ctx, args)}
 }
 
@@ -330,7 +330,7 @@ type PrivateEndpointServicesApi_CreatePrivateEndpointWithParams_Call struct {
 // CreatePrivateEndpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreatePrivateEndpointApiParams
-func (_e *PrivateEndpointServicesApi_Expecter) CreatePrivateEndpointWithParams(ctx interface{}, args interface{}) *PrivateEndpointServicesApi_CreatePrivateEndpointWithParams_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) CreatePrivateEndpointWithParams(ctx any, args any) *PrivateEndpointServicesApi_CreatePrivateEndpointWithParams_Call {
 	return &PrivateEndpointServicesApi_CreatePrivateEndpointWithParams_Call{Call: _e.mock.On("CreatePrivateEndpointWithParams", ctx, args)}
 }
 
@@ -380,7 +380,7 @@ type PrivateEndpointServicesApi_DeletePrivateEndpoint_Call struct {
 //   - cloudProvider string
 //   - endpointId string
 //   - endpointServiceId string
-func (_e *PrivateEndpointServicesApi_Expecter) DeletePrivateEndpoint(ctx interface{}, groupId interface{}, cloudProvider interface{}, endpointId interface{}, endpointServiceId interface{}) *PrivateEndpointServicesApi_DeletePrivateEndpoint_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) DeletePrivateEndpoint(ctx any, groupId any, cloudProvider any, endpointId any, endpointServiceId any) *PrivateEndpointServicesApi_DeletePrivateEndpoint_Call {
 	return &PrivateEndpointServicesApi_DeletePrivateEndpoint_Call{Call: _e.mock.On("DeletePrivateEndpoint", ctx, groupId, cloudProvider, endpointId, endpointServiceId)}
 }
 
@@ -402,24 +402,24 @@ func (_c *PrivateEndpointServicesApi_DeletePrivateEndpoint_Call) RunAndReturn(ru
 }
 
 // DeletePrivateEndpointExecute provides a mock function with given fields: r
-func (_m *PrivateEndpointServicesApi) DeletePrivateEndpointExecute(r admin.DeletePrivateEndpointApiRequest) (interface{}, *http.Response, error) {
+func (_m *PrivateEndpointServicesApi) DeletePrivateEndpointExecute(r admin.DeletePrivateEndpointApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeletePrivateEndpointExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeletePrivateEndpointApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeletePrivateEndpointApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeletePrivateEndpointApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeletePrivateEndpointApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -447,7 +447,7 @@ type PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call struct {
 
 // DeletePrivateEndpointExecute is a helper method to define mock.On call
 //   - r admin.DeletePrivateEndpointApiRequest
-func (_e *PrivateEndpointServicesApi_Expecter) DeletePrivateEndpointExecute(r interface{}) *PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) DeletePrivateEndpointExecute(r any) *PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call {
 	return &PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call{Call: _e.mock.On("DeletePrivateEndpointExecute", r)}
 }
 
@@ -458,12 +458,12 @@ func (_c *PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call) Run(run 
 	return _c
 }
 
-func (_c *PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call {
+func (_c *PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call) RunAndReturn(run func(admin.DeletePrivateEndpointApiRequest) (interface{}, *http.Response, error)) *PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call {
+func (_c *PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call) RunAndReturn(run func(admin.DeletePrivateEndpointApiRequest) (any, *http.Response, error)) *PrivateEndpointServicesApi_DeletePrivateEndpointExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -496,7 +496,7 @@ type PrivateEndpointServicesApi_DeletePrivateEndpointService_Call struct {
 //   - groupId string
 //   - cloudProvider string
 //   - endpointServiceId string
-func (_e *PrivateEndpointServicesApi_Expecter) DeletePrivateEndpointService(ctx interface{}, groupId interface{}, cloudProvider interface{}, endpointServiceId interface{}) *PrivateEndpointServicesApi_DeletePrivateEndpointService_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) DeletePrivateEndpointService(ctx any, groupId any, cloudProvider any, endpointServiceId any) *PrivateEndpointServicesApi_DeletePrivateEndpointService_Call {
 	return &PrivateEndpointServicesApi_DeletePrivateEndpointService_Call{Call: _e.mock.On("DeletePrivateEndpointService", ctx, groupId, cloudProvider, endpointServiceId)}
 }
 
@@ -518,24 +518,24 @@ func (_c *PrivateEndpointServicesApi_DeletePrivateEndpointService_Call) RunAndRe
 }
 
 // DeletePrivateEndpointServiceExecute provides a mock function with given fields: r
-func (_m *PrivateEndpointServicesApi) DeletePrivateEndpointServiceExecute(r admin.DeletePrivateEndpointServiceApiRequest) (interface{}, *http.Response, error) {
+func (_m *PrivateEndpointServicesApi) DeletePrivateEndpointServiceExecute(r admin.DeletePrivateEndpointServiceApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeletePrivateEndpointServiceExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeletePrivateEndpointServiceApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeletePrivateEndpointServiceApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeletePrivateEndpointServiceApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeletePrivateEndpointServiceApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -563,7 +563,7 @@ type PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call struct 
 
 // DeletePrivateEndpointServiceExecute is a helper method to define mock.On call
 //   - r admin.DeletePrivateEndpointServiceApiRequest
-func (_e *PrivateEndpointServicesApi_Expecter) DeletePrivateEndpointServiceExecute(r interface{}) *PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) DeletePrivateEndpointServiceExecute(r any) *PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call {
 	return &PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call{Call: _e.mock.On("DeletePrivateEndpointServiceExecute", r)}
 }
 
@@ -574,12 +574,12 @@ func (_c *PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call) R
 	return _c
 }
 
-func (_c *PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call {
+func (_c *PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call) RunAndReturn(run func(admin.DeletePrivateEndpointServiceApiRequest) (interface{}, *http.Response, error)) *PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call {
+func (_c *PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call) RunAndReturn(run func(admin.DeletePrivateEndpointServiceApiRequest) (any, *http.Response, error)) *PrivateEndpointServicesApi_DeletePrivateEndpointServiceExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -610,7 +610,7 @@ type PrivateEndpointServicesApi_DeletePrivateEndpointServiceWithParams_Call stru
 // DeletePrivateEndpointServiceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeletePrivateEndpointServiceApiParams
-func (_e *PrivateEndpointServicesApi_Expecter) DeletePrivateEndpointServiceWithParams(ctx interface{}, args interface{}) *PrivateEndpointServicesApi_DeletePrivateEndpointServiceWithParams_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) DeletePrivateEndpointServiceWithParams(ctx any, args any) *PrivateEndpointServicesApi_DeletePrivateEndpointServiceWithParams_Call {
 	return &PrivateEndpointServicesApi_DeletePrivateEndpointServiceWithParams_Call{Call: _e.mock.On("DeletePrivateEndpointServiceWithParams", ctx, args)}
 }
 
@@ -657,7 +657,7 @@ type PrivateEndpointServicesApi_DeletePrivateEndpointWithParams_Call struct {
 // DeletePrivateEndpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeletePrivateEndpointApiParams
-func (_e *PrivateEndpointServicesApi_Expecter) DeletePrivateEndpointWithParams(ctx interface{}, args interface{}) *PrivateEndpointServicesApi_DeletePrivateEndpointWithParams_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) DeletePrivateEndpointWithParams(ctx any, args any) *PrivateEndpointServicesApi_DeletePrivateEndpointWithParams_Call {
 	return &PrivateEndpointServicesApi_DeletePrivateEndpointWithParams_Call{Call: _e.mock.On("DeletePrivateEndpointWithParams", ctx, args)}
 }
 
@@ -707,7 +707,7 @@ type PrivateEndpointServicesApi_GetPrivateEndpoint_Call struct {
 //   - cloudProvider string
 //   - endpointId string
 //   - endpointServiceId string
-func (_e *PrivateEndpointServicesApi_Expecter) GetPrivateEndpoint(ctx interface{}, groupId interface{}, cloudProvider interface{}, endpointId interface{}, endpointServiceId interface{}) *PrivateEndpointServicesApi_GetPrivateEndpoint_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) GetPrivateEndpoint(ctx any, groupId any, cloudProvider any, endpointId any, endpointServiceId any) *PrivateEndpointServicesApi_GetPrivateEndpoint_Call {
 	return &PrivateEndpointServicesApi_GetPrivateEndpoint_Call{Call: _e.mock.On("GetPrivateEndpoint", ctx, groupId, cloudProvider, endpointId, endpointServiceId)}
 }
 
@@ -774,7 +774,7 @@ type PrivateEndpointServicesApi_GetPrivateEndpointExecute_Call struct {
 
 // GetPrivateEndpointExecute is a helper method to define mock.On call
 //   - r admin.GetPrivateEndpointApiRequest
-func (_e *PrivateEndpointServicesApi_Expecter) GetPrivateEndpointExecute(r interface{}) *PrivateEndpointServicesApi_GetPrivateEndpointExecute_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) GetPrivateEndpointExecute(r any) *PrivateEndpointServicesApi_GetPrivateEndpointExecute_Call {
 	return &PrivateEndpointServicesApi_GetPrivateEndpointExecute_Call{Call: _e.mock.On("GetPrivateEndpointExecute", r)}
 }
 
@@ -823,7 +823,7 @@ type PrivateEndpointServicesApi_GetPrivateEndpointService_Call struct {
 //   - groupId string
 //   - cloudProvider string
 //   - endpointServiceId string
-func (_e *PrivateEndpointServicesApi_Expecter) GetPrivateEndpointService(ctx interface{}, groupId interface{}, cloudProvider interface{}, endpointServiceId interface{}) *PrivateEndpointServicesApi_GetPrivateEndpointService_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) GetPrivateEndpointService(ctx any, groupId any, cloudProvider any, endpointServiceId any) *PrivateEndpointServicesApi_GetPrivateEndpointService_Call {
 	return &PrivateEndpointServicesApi_GetPrivateEndpointService_Call{Call: _e.mock.On("GetPrivateEndpointService", ctx, groupId, cloudProvider, endpointServiceId)}
 }
 
@@ -890,7 +890,7 @@ type PrivateEndpointServicesApi_GetPrivateEndpointServiceExecute_Call struct {
 
 // GetPrivateEndpointServiceExecute is a helper method to define mock.On call
 //   - r admin.GetPrivateEndpointServiceApiRequest
-func (_e *PrivateEndpointServicesApi_Expecter) GetPrivateEndpointServiceExecute(r interface{}) *PrivateEndpointServicesApi_GetPrivateEndpointServiceExecute_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) GetPrivateEndpointServiceExecute(r any) *PrivateEndpointServicesApi_GetPrivateEndpointServiceExecute_Call {
 	return &PrivateEndpointServicesApi_GetPrivateEndpointServiceExecute_Call{Call: _e.mock.On("GetPrivateEndpointServiceExecute", r)}
 }
 
@@ -937,7 +937,7 @@ type PrivateEndpointServicesApi_GetPrivateEndpointServiceWithParams_Call struct 
 // GetPrivateEndpointServiceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetPrivateEndpointServiceApiParams
-func (_e *PrivateEndpointServicesApi_Expecter) GetPrivateEndpointServiceWithParams(ctx interface{}, args interface{}) *PrivateEndpointServicesApi_GetPrivateEndpointServiceWithParams_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) GetPrivateEndpointServiceWithParams(ctx any, args any) *PrivateEndpointServicesApi_GetPrivateEndpointServiceWithParams_Call {
 	return &PrivateEndpointServicesApi_GetPrivateEndpointServiceWithParams_Call{Call: _e.mock.On("GetPrivateEndpointServiceWithParams", ctx, args)}
 }
 
@@ -984,7 +984,7 @@ type PrivateEndpointServicesApi_GetPrivateEndpointWithParams_Call struct {
 // GetPrivateEndpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetPrivateEndpointApiParams
-func (_e *PrivateEndpointServicesApi_Expecter) GetPrivateEndpointWithParams(ctx interface{}, args interface{}) *PrivateEndpointServicesApi_GetPrivateEndpointWithParams_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) GetPrivateEndpointWithParams(ctx any, args any) *PrivateEndpointServicesApi_GetPrivateEndpointWithParams_Call {
 	return &PrivateEndpointServicesApi_GetPrivateEndpointWithParams_Call{Call: _e.mock.On("GetPrivateEndpointWithParams", ctx, args)}
 }
 
@@ -1031,7 +1031,7 @@ type PrivateEndpointServicesApi_GetRegionalizedPrivateEndpointSetting_Call struc
 // GetRegionalizedPrivateEndpointSetting is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *PrivateEndpointServicesApi_Expecter) GetRegionalizedPrivateEndpointSetting(ctx interface{}, groupId interface{}) *PrivateEndpointServicesApi_GetRegionalizedPrivateEndpointSetting_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) GetRegionalizedPrivateEndpointSetting(ctx any, groupId any) *PrivateEndpointServicesApi_GetRegionalizedPrivateEndpointSetting_Call {
 	return &PrivateEndpointServicesApi_GetRegionalizedPrivateEndpointSetting_Call{Call: _e.mock.On("GetRegionalizedPrivateEndpointSetting", ctx, groupId)}
 }
 
@@ -1098,7 +1098,7 @@ type PrivateEndpointServicesApi_GetRegionalizedPrivateEndpointSettingExecute_Cal
 
 // GetRegionalizedPrivateEndpointSettingExecute is a helper method to define mock.On call
 //   - r admin.GetRegionalizedPrivateEndpointSettingApiRequest
-func (_e *PrivateEndpointServicesApi_Expecter) GetRegionalizedPrivateEndpointSettingExecute(r interface{}) *PrivateEndpointServicesApi_GetRegionalizedPrivateEndpointSettingExecute_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) GetRegionalizedPrivateEndpointSettingExecute(r any) *PrivateEndpointServicesApi_GetRegionalizedPrivateEndpointSettingExecute_Call {
 	return &PrivateEndpointServicesApi_GetRegionalizedPrivateEndpointSettingExecute_Call{Call: _e.mock.On("GetRegionalizedPrivateEndpointSettingExecute", r)}
 }
 
@@ -1145,7 +1145,7 @@ type PrivateEndpointServicesApi_GetRegionalizedPrivateEndpointSettingWithParams_
 // GetRegionalizedPrivateEndpointSettingWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetRegionalizedPrivateEndpointSettingApiParams
-func (_e *PrivateEndpointServicesApi_Expecter) GetRegionalizedPrivateEndpointSettingWithParams(ctx interface{}, args interface{}) *PrivateEndpointServicesApi_GetRegionalizedPrivateEndpointSettingWithParams_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) GetRegionalizedPrivateEndpointSettingWithParams(ctx any, args any) *PrivateEndpointServicesApi_GetRegionalizedPrivateEndpointSettingWithParams_Call {
 	return &PrivateEndpointServicesApi_GetRegionalizedPrivateEndpointSettingWithParams_Call{Call: _e.mock.On("GetRegionalizedPrivateEndpointSettingWithParams", ctx, args)}
 }
 
@@ -1193,7 +1193,7 @@ type PrivateEndpointServicesApi_ListPrivateEndpointServices_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - cloudProvider string
-func (_e *PrivateEndpointServicesApi_Expecter) ListPrivateEndpointServices(ctx interface{}, groupId interface{}, cloudProvider interface{}) *PrivateEndpointServicesApi_ListPrivateEndpointServices_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) ListPrivateEndpointServices(ctx any, groupId any, cloudProvider any) *PrivateEndpointServicesApi_ListPrivateEndpointServices_Call {
 	return &PrivateEndpointServicesApi_ListPrivateEndpointServices_Call{Call: _e.mock.On("ListPrivateEndpointServices", ctx, groupId, cloudProvider)}
 }
 
@@ -1260,7 +1260,7 @@ type PrivateEndpointServicesApi_ListPrivateEndpointServicesExecute_Call struct {
 
 // ListPrivateEndpointServicesExecute is a helper method to define mock.On call
 //   - r admin.ListPrivateEndpointServicesApiRequest
-func (_e *PrivateEndpointServicesApi_Expecter) ListPrivateEndpointServicesExecute(r interface{}) *PrivateEndpointServicesApi_ListPrivateEndpointServicesExecute_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) ListPrivateEndpointServicesExecute(r any) *PrivateEndpointServicesApi_ListPrivateEndpointServicesExecute_Call {
 	return &PrivateEndpointServicesApi_ListPrivateEndpointServicesExecute_Call{Call: _e.mock.On("ListPrivateEndpointServicesExecute", r)}
 }
 
@@ -1307,7 +1307,7 @@ type PrivateEndpointServicesApi_ListPrivateEndpointServicesWithParams_Call struc
 // ListPrivateEndpointServicesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListPrivateEndpointServicesApiParams
-func (_e *PrivateEndpointServicesApi_Expecter) ListPrivateEndpointServicesWithParams(ctx interface{}, args interface{}) *PrivateEndpointServicesApi_ListPrivateEndpointServicesWithParams_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) ListPrivateEndpointServicesWithParams(ctx any, args any) *PrivateEndpointServicesApi_ListPrivateEndpointServicesWithParams_Call {
 	return &PrivateEndpointServicesApi_ListPrivateEndpointServicesWithParams_Call{Call: _e.mock.On("ListPrivateEndpointServicesWithParams", ctx, args)}
 }
 
@@ -1355,7 +1355,7 @@ type PrivateEndpointServicesApi_ToggleRegionalizedPrivateEndpointSetting_Call st
 //   - ctx context.Context
 //   - groupId string
 //   - projectSettingItem *admin.ProjectSettingItem
-func (_e *PrivateEndpointServicesApi_Expecter) ToggleRegionalizedPrivateEndpointSetting(ctx interface{}, groupId interface{}, projectSettingItem interface{}) *PrivateEndpointServicesApi_ToggleRegionalizedPrivateEndpointSetting_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) ToggleRegionalizedPrivateEndpointSetting(ctx any, groupId any, projectSettingItem any) *PrivateEndpointServicesApi_ToggleRegionalizedPrivateEndpointSetting_Call {
 	return &PrivateEndpointServicesApi_ToggleRegionalizedPrivateEndpointSetting_Call{Call: _e.mock.On("ToggleRegionalizedPrivateEndpointSetting", ctx, groupId, projectSettingItem)}
 }
 
@@ -1422,7 +1422,7 @@ type PrivateEndpointServicesApi_ToggleRegionalizedPrivateEndpointSettingExecute_
 
 // ToggleRegionalizedPrivateEndpointSettingExecute is a helper method to define mock.On call
 //   - r admin.ToggleRegionalizedPrivateEndpointSettingApiRequest
-func (_e *PrivateEndpointServicesApi_Expecter) ToggleRegionalizedPrivateEndpointSettingExecute(r interface{}) *PrivateEndpointServicesApi_ToggleRegionalizedPrivateEndpointSettingExecute_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) ToggleRegionalizedPrivateEndpointSettingExecute(r any) *PrivateEndpointServicesApi_ToggleRegionalizedPrivateEndpointSettingExecute_Call {
 	return &PrivateEndpointServicesApi_ToggleRegionalizedPrivateEndpointSettingExecute_Call{Call: _e.mock.On("ToggleRegionalizedPrivateEndpointSettingExecute", r)}
 }
 
@@ -1469,7 +1469,7 @@ type PrivateEndpointServicesApi_ToggleRegionalizedPrivateEndpointSettingWithPara
 // ToggleRegionalizedPrivateEndpointSettingWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ToggleRegionalizedPrivateEndpointSettingApiParams
-func (_e *PrivateEndpointServicesApi_Expecter) ToggleRegionalizedPrivateEndpointSettingWithParams(ctx interface{}, args interface{}) *PrivateEndpointServicesApi_ToggleRegionalizedPrivateEndpointSettingWithParams_Call {
+func (_e *PrivateEndpointServicesApi_Expecter) ToggleRegionalizedPrivateEndpointSettingWithParams(ctx any, args any) *PrivateEndpointServicesApi_ToggleRegionalizedPrivateEndpointSettingWithParams_Call {
 	return &PrivateEndpointServicesApi_ToggleRegionalizedPrivateEndpointSettingWithParams_Call{Call: _e.mock.On("ToggleRegionalizedPrivateEndpointSettingWithParams", ctx, args)}
 }
 

--- a/mockadmin/programmatic_api_keys_api.go
+++ b/mockadmin/programmatic_api_keys_api.go
@@ -53,7 +53,7 @@ type ProgrammaticAPIKeysApi_AddProjectApiKey_Call struct {
 //   - groupId string
 //   - apiUserId string
 //   - userAccessRoleAssignment *[]admin.UserAccessRoleAssignment
-func (_e *ProgrammaticAPIKeysApi_Expecter) AddProjectApiKey(ctx interface{}, groupId interface{}, apiUserId interface{}, userAccessRoleAssignment interface{}) *ProgrammaticAPIKeysApi_AddProjectApiKey_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) AddProjectApiKey(ctx any, groupId any, apiUserId any, userAccessRoleAssignment any) *ProgrammaticAPIKeysApi_AddProjectApiKey_Call {
 	return &ProgrammaticAPIKeysApi_AddProjectApiKey_Call{Call: _e.mock.On("AddProjectApiKey", ctx, groupId, apiUserId, userAccessRoleAssignment)}
 }
 
@@ -75,24 +75,24 @@ func (_c *ProgrammaticAPIKeysApi_AddProjectApiKey_Call) RunAndReturn(run func(co
 }
 
 // AddProjectApiKeyExecute provides a mock function with given fields: r
-func (_m *ProgrammaticAPIKeysApi) AddProjectApiKeyExecute(r admin.AddProjectApiKeyApiRequest) (interface{}, *http.Response, error) {
+func (_m *ProgrammaticAPIKeysApi) AddProjectApiKeyExecute(r admin.AddProjectApiKeyApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddProjectApiKeyExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.AddProjectApiKeyApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.AddProjectApiKeyApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.AddProjectApiKeyApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.AddProjectApiKeyApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -120,7 +120,7 @@ type ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call struct {
 
 // AddProjectApiKeyExecute is a helper method to define mock.On call
 //   - r admin.AddProjectApiKeyApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) AddProjectApiKeyExecute(r interface{}) *ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) AddProjectApiKeyExecute(r any) *ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call {
 	return &ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call{Call: _e.mock.On("AddProjectApiKeyExecute", r)}
 }
 
@@ -131,12 +131,12 @@ func (_c *ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call) Run(run func(r ad
 	return _c
 }
 
-func (_c *ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call {
+func (_c *ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call) RunAndReturn(run func(admin.AddProjectApiKeyApiRequest) (interface{}, *http.Response, error)) *ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call {
+func (_c *ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call) RunAndReturn(run func(admin.AddProjectApiKeyApiRequest) (any, *http.Response, error)) *ProgrammaticAPIKeysApi_AddProjectApiKeyExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -167,7 +167,7 @@ type ProgrammaticAPIKeysApi_AddProjectApiKeyWithParams_Call struct {
 // AddProjectApiKeyWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.AddProjectApiKeyApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) AddProjectApiKeyWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_AddProjectApiKeyWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) AddProjectApiKeyWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_AddProjectApiKeyWithParams_Call {
 	return &ProgrammaticAPIKeysApi_AddProjectApiKeyWithParams_Call{Call: _e.mock.On("AddProjectApiKeyWithParams", ctx, args)}
 }
 
@@ -215,7 +215,7 @@ type ProgrammaticAPIKeysApi_CreateApiKey_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - createAtlasOrganizationApiKey *admin.CreateAtlasOrganizationApiKey
-func (_e *ProgrammaticAPIKeysApi_Expecter) CreateApiKey(ctx interface{}, orgId interface{}, createAtlasOrganizationApiKey interface{}) *ProgrammaticAPIKeysApi_CreateApiKey_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) CreateApiKey(ctx any, orgId any, createAtlasOrganizationApiKey any) *ProgrammaticAPIKeysApi_CreateApiKey_Call {
 	return &ProgrammaticAPIKeysApi_CreateApiKey_Call{Call: _e.mock.On("CreateApiKey", ctx, orgId, createAtlasOrganizationApiKey)}
 }
 
@@ -264,7 +264,7 @@ type ProgrammaticAPIKeysApi_CreateApiKeyAccessList_Call struct {
 //   - orgId string
 //   - apiUserId string
 //   - userAccessListRequest *[]admin.UserAccessListRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) CreateApiKeyAccessList(ctx interface{}, orgId interface{}, apiUserId interface{}, userAccessListRequest interface{}) *ProgrammaticAPIKeysApi_CreateApiKeyAccessList_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) CreateApiKeyAccessList(ctx any, orgId any, apiUserId any, userAccessListRequest any) *ProgrammaticAPIKeysApi_CreateApiKeyAccessList_Call {
 	return &ProgrammaticAPIKeysApi_CreateApiKeyAccessList_Call{Call: _e.mock.On("CreateApiKeyAccessList", ctx, orgId, apiUserId, userAccessListRequest)}
 }
 
@@ -331,7 +331,7 @@ type ProgrammaticAPIKeysApi_CreateApiKeyAccessListExecute_Call struct {
 
 // CreateApiKeyAccessListExecute is a helper method to define mock.On call
 //   - r admin.CreateApiKeyAccessListApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) CreateApiKeyAccessListExecute(r interface{}) *ProgrammaticAPIKeysApi_CreateApiKeyAccessListExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) CreateApiKeyAccessListExecute(r any) *ProgrammaticAPIKeysApi_CreateApiKeyAccessListExecute_Call {
 	return &ProgrammaticAPIKeysApi_CreateApiKeyAccessListExecute_Call{Call: _e.mock.On("CreateApiKeyAccessListExecute", r)}
 }
 
@@ -378,7 +378,7 @@ type ProgrammaticAPIKeysApi_CreateApiKeyAccessListWithParams_Call struct {
 // CreateApiKeyAccessListWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateApiKeyAccessListApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) CreateApiKeyAccessListWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_CreateApiKeyAccessListWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) CreateApiKeyAccessListWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_CreateApiKeyAccessListWithParams_Call {
 	return &ProgrammaticAPIKeysApi_CreateApiKeyAccessListWithParams_Call{Call: _e.mock.On("CreateApiKeyAccessListWithParams", ctx, args)}
 }
 
@@ -445,7 +445,7 @@ type ProgrammaticAPIKeysApi_CreateApiKeyExecute_Call struct {
 
 // CreateApiKeyExecute is a helper method to define mock.On call
 //   - r admin.CreateApiKeyApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) CreateApiKeyExecute(r interface{}) *ProgrammaticAPIKeysApi_CreateApiKeyExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) CreateApiKeyExecute(r any) *ProgrammaticAPIKeysApi_CreateApiKeyExecute_Call {
 	return &ProgrammaticAPIKeysApi_CreateApiKeyExecute_Call{Call: _e.mock.On("CreateApiKeyExecute", r)}
 }
 
@@ -492,7 +492,7 @@ type ProgrammaticAPIKeysApi_CreateApiKeyWithParams_Call struct {
 // CreateApiKeyWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateApiKeyApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) CreateApiKeyWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_CreateApiKeyWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) CreateApiKeyWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_CreateApiKeyWithParams_Call {
 	return &ProgrammaticAPIKeysApi_CreateApiKeyWithParams_Call{Call: _e.mock.On("CreateApiKeyWithParams", ctx, args)}
 }
 
@@ -540,7 +540,7 @@ type ProgrammaticAPIKeysApi_CreateProjectApiKey_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - createAtlasProjectApiKey *admin.CreateAtlasProjectApiKey
-func (_e *ProgrammaticAPIKeysApi_Expecter) CreateProjectApiKey(ctx interface{}, groupId interface{}, createAtlasProjectApiKey interface{}) *ProgrammaticAPIKeysApi_CreateProjectApiKey_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) CreateProjectApiKey(ctx any, groupId any, createAtlasProjectApiKey any) *ProgrammaticAPIKeysApi_CreateProjectApiKey_Call {
 	return &ProgrammaticAPIKeysApi_CreateProjectApiKey_Call{Call: _e.mock.On("CreateProjectApiKey", ctx, groupId, createAtlasProjectApiKey)}
 }
 
@@ -607,7 +607,7 @@ type ProgrammaticAPIKeysApi_CreateProjectApiKeyExecute_Call struct {
 
 // CreateProjectApiKeyExecute is a helper method to define mock.On call
 //   - r admin.CreateProjectApiKeyApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) CreateProjectApiKeyExecute(r interface{}) *ProgrammaticAPIKeysApi_CreateProjectApiKeyExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) CreateProjectApiKeyExecute(r any) *ProgrammaticAPIKeysApi_CreateProjectApiKeyExecute_Call {
 	return &ProgrammaticAPIKeysApi_CreateProjectApiKeyExecute_Call{Call: _e.mock.On("CreateProjectApiKeyExecute", r)}
 }
 
@@ -654,7 +654,7 @@ type ProgrammaticAPIKeysApi_CreateProjectApiKeyWithParams_Call struct {
 // CreateProjectApiKeyWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateProjectApiKeyApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) CreateProjectApiKeyWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_CreateProjectApiKeyWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) CreateProjectApiKeyWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_CreateProjectApiKeyWithParams_Call {
 	return &ProgrammaticAPIKeysApi_CreateProjectApiKeyWithParams_Call{Call: _e.mock.On("CreateProjectApiKeyWithParams", ctx, args)}
 }
 
@@ -702,7 +702,7 @@ type ProgrammaticAPIKeysApi_DeleteApiKey_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - apiUserId string
-func (_e *ProgrammaticAPIKeysApi_Expecter) DeleteApiKey(ctx interface{}, orgId interface{}, apiUserId interface{}) *ProgrammaticAPIKeysApi_DeleteApiKey_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) DeleteApiKey(ctx any, orgId any, apiUserId any) *ProgrammaticAPIKeysApi_DeleteApiKey_Call {
 	return &ProgrammaticAPIKeysApi_DeleteApiKey_Call{Call: _e.mock.On("DeleteApiKey", ctx, orgId, apiUserId)}
 }
 
@@ -751,7 +751,7 @@ type ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntry_Call struct {
 //   - orgId string
 //   - apiUserId string
 //   - ipAddress string
-func (_e *ProgrammaticAPIKeysApi_Expecter) DeleteApiKeyAccessListEntry(ctx interface{}, orgId interface{}, apiUserId interface{}, ipAddress interface{}) *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntry_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) DeleteApiKeyAccessListEntry(ctx any, orgId any, apiUserId any, ipAddress any) *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntry_Call {
 	return &ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntry_Call{Call: _e.mock.On("DeleteApiKeyAccessListEntry", ctx, orgId, apiUserId, ipAddress)}
 }
 
@@ -773,24 +773,24 @@ func (_c *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntry_Call) RunAndReturn(
 }
 
 // DeleteApiKeyAccessListEntryExecute provides a mock function with given fields: r
-func (_m *ProgrammaticAPIKeysApi) DeleteApiKeyAccessListEntryExecute(r admin.DeleteApiKeyAccessListEntryApiRequest) (interface{}, *http.Response, error) {
+func (_m *ProgrammaticAPIKeysApi) DeleteApiKeyAccessListEntryExecute(r admin.DeleteApiKeyAccessListEntryApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteApiKeyAccessListEntryExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteApiKeyAccessListEntryApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteApiKeyAccessListEntryApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteApiKeyAccessListEntryApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteApiKeyAccessListEntryApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -818,7 +818,7 @@ type ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call struct {
 
 // DeleteApiKeyAccessListEntryExecute is a helper method to define mock.On call
 //   - r admin.DeleteApiKeyAccessListEntryApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) DeleteApiKeyAccessListEntryExecute(r interface{}) *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) DeleteApiKeyAccessListEntryExecute(r any) *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call {
 	return &ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call{Call: _e.mock.On("DeleteApiKeyAccessListEntryExecute", r)}
 }
 
@@ -829,12 +829,12 @@ func (_c *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call) Run(ru
 	return _c
 }
 
-func (_c *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call {
+func (_c *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call) RunAndReturn(run func(admin.DeleteApiKeyAccessListEntryApiRequest) (interface{}, *http.Response, error)) *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call {
+func (_c *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call) RunAndReturn(run func(admin.DeleteApiKeyAccessListEntryApiRequest) (any, *http.Response, error)) *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -865,7 +865,7 @@ type ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryWithParams_Call struct {
 // DeleteApiKeyAccessListEntryWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteApiKeyAccessListEntryApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) DeleteApiKeyAccessListEntryWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) DeleteApiKeyAccessListEntryWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryWithParams_Call {
 	return &ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryWithParams_Call{Call: _e.mock.On("DeleteApiKeyAccessListEntryWithParams", ctx, args)}
 }
 
@@ -887,24 +887,24 @@ func (_c *ProgrammaticAPIKeysApi_DeleteApiKeyAccessListEntryWithParams_Call) Run
 }
 
 // DeleteApiKeyExecute provides a mock function with given fields: r
-func (_m *ProgrammaticAPIKeysApi) DeleteApiKeyExecute(r admin.DeleteApiKeyApiRequest) (interface{}, *http.Response, error) {
+func (_m *ProgrammaticAPIKeysApi) DeleteApiKeyExecute(r admin.DeleteApiKeyApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteApiKeyExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteApiKeyApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteApiKeyApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteApiKeyApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteApiKeyApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -932,7 +932,7 @@ type ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call struct {
 
 // DeleteApiKeyExecute is a helper method to define mock.On call
 //   - r admin.DeleteApiKeyApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) DeleteApiKeyExecute(r interface{}) *ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) DeleteApiKeyExecute(r any) *ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call {
 	return &ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call{Call: _e.mock.On("DeleteApiKeyExecute", r)}
 }
 
@@ -943,12 +943,12 @@ func (_c *ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call) Run(run func(r admin.
 	return _c
 }
 
-func (_c *ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call {
+func (_c *ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call) RunAndReturn(run func(admin.DeleteApiKeyApiRequest) (interface{}, *http.Response, error)) *ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call {
+func (_c *ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call) RunAndReturn(run func(admin.DeleteApiKeyApiRequest) (any, *http.Response, error)) *ProgrammaticAPIKeysApi_DeleteApiKeyExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -979,7 +979,7 @@ type ProgrammaticAPIKeysApi_DeleteApiKeyWithParams_Call struct {
 // DeleteApiKeyWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteApiKeyApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) DeleteApiKeyWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_DeleteApiKeyWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) DeleteApiKeyWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_DeleteApiKeyWithParams_Call {
 	return &ProgrammaticAPIKeysApi_DeleteApiKeyWithParams_Call{Call: _e.mock.On("DeleteApiKeyWithParams", ctx, args)}
 }
 
@@ -1027,7 +1027,7 @@ type ProgrammaticAPIKeysApi_GetApiKey_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - apiUserId string
-func (_e *ProgrammaticAPIKeysApi_Expecter) GetApiKey(ctx interface{}, orgId interface{}, apiUserId interface{}) *ProgrammaticAPIKeysApi_GetApiKey_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) GetApiKey(ctx any, orgId any, apiUserId any) *ProgrammaticAPIKeysApi_GetApiKey_Call {
 	return &ProgrammaticAPIKeysApi_GetApiKey_Call{Call: _e.mock.On("GetApiKey", ctx, orgId, apiUserId)}
 }
 
@@ -1076,7 +1076,7 @@ type ProgrammaticAPIKeysApi_GetApiKeyAccessList_Call struct {
 //   - orgId string
 //   - ipAddress string
 //   - apiUserId string
-func (_e *ProgrammaticAPIKeysApi_Expecter) GetApiKeyAccessList(ctx interface{}, orgId interface{}, ipAddress interface{}, apiUserId interface{}) *ProgrammaticAPIKeysApi_GetApiKeyAccessList_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) GetApiKeyAccessList(ctx any, orgId any, ipAddress any, apiUserId any) *ProgrammaticAPIKeysApi_GetApiKeyAccessList_Call {
 	return &ProgrammaticAPIKeysApi_GetApiKeyAccessList_Call{Call: _e.mock.On("GetApiKeyAccessList", ctx, orgId, ipAddress, apiUserId)}
 }
 
@@ -1143,7 +1143,7 @@ type ProgrammaticAPIKeysApi_GetApiKeyAccessListExecute_Call struct {
 
 // GetApiKeyAccessListExecute is a helper method to define mock.On call
 //   - r admin.GetApiKeyAccessListApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) GetApiKeyAccessListExecute(r interface{}) *ProgrammaticAPIKeysApi_GetApiKeyAccessListExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) GetApiKeyAccessListExecute(r any) *ProgrammaticAPIKeysApi_GetApiKeyAccessListExecute_Call {
 	return &ProgrammaticAPIKeysApi_GetApiKeyAccessListExecute_Call{Call: _e.mock.On("GetApiKeyAccessListExecute", r)}
 }
 
@@ -1190,7 +1190,7 @@ type ProgrammaticAPIKeysApi_GetApiKeyAccessListWithParams_Call struct {
 // GetApiKeyAccessListWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetApiKeyAccessListApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) GetApiKeyAccessListWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_GetApiKeyAccessListWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) GetApiKeyAccessListWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_GetApiKeyAccessListWithParams_Call {
 	return &ProgrammaticAPIKeysApi_GetApiKeyAccessListWithParams_Call{Call: _e.mock.On("GetApiKeyAccessListWithParams", ctx, args)}
 }
 
@@ -1257,7 +1257,7 @@ type ProgrammaticAPIKeysApi_GetApiKeyExecute_Call struct {
 
 // GetApiKeyExecute is a helper method to define mock.On call
 //   - r admin.GetApiKeyApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) GetApiKeyExecute(r interface{}) *ProgrammaticAPIKeysApi_GetApiKeyExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) GetApiKeyExecute(r any) *ProgrammaticAPIKeysApi_GetApiKeyExecute_Call {
 	return &ProgrammaticAPIKeysApi_GetApiKeyExecute_Call{Call: _e.mock.On("GetApiKeyExecute", r)}
 }
 
@@ -1304,7 +1304,7 @@ type ProgrammaticAPIKeysApi_GetApiKeyWithParams_Call struct {
 // GetApiKeyWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetApiKeyApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) GetApiKeyWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_GetApiKeyWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) GetApiKeyWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_GetApiKeyWithParams_Call {
 	return &ProgrammaticAPIKeysApi_GetApiKeyWithParams_Call{Call: _e.mock.On("GetApiKeyWithParams", ctx, args)}
 }
 
@@ -1352,7 +1352,7 @@ type ProgrammaticAPIKeysApi_ListApiKeyAccessListsEntries_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - apiUserId string
-func (_e *ProgrammaticAPIKeysApi_Expecter) ListApiKeyAccessListsEntries(ctx interface{}, orgId interface{}, apiUserId interface{}) *ProgrammaticAPIKeysApi_ListApiKeyAccessListsEntries_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) ListApiKeyAccessListsEntries(ctx any, orgId any, apiUserId any) *ProgrammaticAPIKeysApi_ListApiKeyAccessListsEntries_Call {
 	return &ProgrammaticAPIKeysApi_ListApiKeyAccessListsEntries_Call{Call: _e.mock.On("ListApiKeyAccessListsEntries", ctx, orgId, apiUserId)}
 }
 
@@ -1419,7 +1419,7 @@ type ProgrammaticAPIKeysApi_ListApiKeyAccessListsEntriesExecute_Call struct {
 
 // ListApiKeyAccessListsEntriesExecute is a helper method to define mock.On call
 //   - r admin.ListApiKeyAccessListsEntriesApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) ListApiKeyAccessListsEntriesExecute(r interface{}) *ProgrammaticAPIKeysApi_ListApiKeyAccessListsEntriesExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) ListApiKeyAccessListsEntriesExecute(r any) *ProgrammaticAPIKeysApi_ListApiKeyAccessListsEntriesExecute_Call {
 	return &ProgrammaticAPIKeysApi_ListApiKeyAccessListsEntriesExecute_Call{Call: _e.mock.On("ListApiKeyAccessListsEntriesExecute", r)}
 }
 
@@ -1466,7 +1466,7 @@ type ProgrammaticAPIKeysApi_ListApiKeyAccessListsEntriesWithParams_Call struct {
 // ListApiKeyAccessListsEntriesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListApiKeyAccessListsEntriesApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) ListApiKeyAccessListsEntriesWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_ListApiKeyAccessListsEntriesWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) ListApiKeyAccessListsEntriesWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_ListApiKeyAccessListsEntriesWithParams_Call {
 	return &ProgrammaticAPIKeysApi_ListApiKeyAccessListsEntriesWithParams_Call{Call: _e.mock.On("ListApiKeyAccessListsEntriesWithParams", ctx, args)}
 }
 
@@ -1513,7 +1513,7 @@ type ProgrammaticAPIKeysApi_ListApiKeys_Call struct {
 // ListApiKeys is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *ProgrammaticAPIKeysApi_Expecter) ListApiKeys(ctx interface{}, orgId interface{}) *ProgrammaticAPIKeysApi_ListApiKeys_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) ListApiKeys(ctx any, orgId any) *ProgrammaticAPIKeysApi_ListApiKeys_Call {
 	return &ProgrammaticAPIKeysApi_ListApiKeys_Call{Call: _e.mock.On("ListApiKeys", ctx, orgId)}
 }
 
@@ -1580,7 +1580,7 @@ type ProgrammaticAPIKeysApi_ListApiKeysExecute_Call struct {
 
 // ListApiKeysExecute is a helper method to define mock.On call
 //   - r admin.ListApiKeysApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) ListApiKeysExecute(r interface{}) *ProgrammaticAPIKeysApi_ListApiKeysExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) ListApiKeysExecute(r any) *ProgrammaticAPIKeysApi_ListApiKeysExecute_Call {
 	return &ProgrammaticAPIKeysApi_ListApiKeysExecute_Call{Call: _e.mock.On("ListApiKeysExecute", r)}
 }
 
@@ -1627,7 +1627,7 @@ type ProgrammaticAPIKeysApi_ListApiKeysWithParams_Call struct {
 // ListApiKeysWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListApiKeysApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) ListApiKeysWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_ListApiKeysWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) ListApiKeysWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_ListApiKeysWithParams_Call {
 	return &ProgrammaticAPIKeysApi_ListApiKeysWithParams_Call{Call: _e.mock.On("ListApiKeysWithParams", ctx, args)}
 }
 
@@ -1674,7 +1674,7 @@ type ProgrammaticAPIKeysApi_ListProjectApiKeys_Call struct {
 // ListProjectApiKeys is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ProgrammaticAPIKeysApi_Expecter) ListProjectApiKeys(ctx interface{}, groupId interface{}) *ProgrammaticAPIKeysApi_ListProjectApiKeys_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) ListProjectApiKeys(ctx any, groupId any) *ProgrammaticAPIKeysApi_ListProjectApiKeys_Call {
 	return &ProgrammaticAPIKeysApi_ListProjectApiKeys_Call{Call: _e.mock.On("ListProjectApiKeys", ctx, groupId)}
 }
 
@@ -1741,7 +1741,7 @@ type ProgrammaticAPIKeysApi_ListProjectApiKeysExecute_Call struct {
 
 // ListProjectApiKeysExecute is a helper method to define mock.On call
 //   - r admin.ListProjectApiKeysApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) ListProjectApiKeysExecute(r interface{}) *ProgrammaticAPIKeysApi_ListProjectApiKeysExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) ListProjectApiKeysExecute(r any) *ProgrammaticAPIKeysApi_ListProjectApiKeysExecute_Call {
 	return &ProgrammaticAPIKeysApi_ListProjectApiKeysExecute_Call{Call: _e.mock.On("ListProjectApiKeysExecute", r)}
 }
 
@@ -1788,7 +1788,7 @@ type ProgrammaticAPIKeysApi_ListProjectApiKeysWithParams_Call struct {
 // ListProjectApiKeysWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListProjectApiKeysApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) ListProjectApiKeysWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_ListProjectApiKeysWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) ListProjectApiKeysWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_ListProjectApiKeysWithParams_Call {
 	return &ProgrammaticAPIKeysApi_ListProjectApiKeysWithParams_Call{Call: _e.mock.On("ListProjectApiKeysWithParams", ctx, args)}
 }
 
@@ -1836,7 +1836,7 @@ type ProgrammaticAPIKeysApi_RemoveProjectApiKey_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - apiUserId string
-func (_e *ProgrammaticAPIKeysApi_Expecter) RemoveProjectApiKey(ctx interface{}, groupId interface{}, apiUserId interface{}) *ProgrammaticAPIKeysApi_RemoveProjectApiKey_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) RemoveProjectApiKey(ctx any, groupId any, apiUserId any) *ProgrammaticAPIKeysApi_RemoveProjectApiKey_Call {
 	return &ProgrammaticAPIKeysApi_RemoveProjectApiKey_Call{Call: _e.mock.On("RemoveProjectApiKey", ctx, groupId, apiUserId)}
 }
 
@@ -1858,24 +1858,24 @@ func (_c *ProgrammaticAPIKeysApi_RemoveProjectApiKey_Call) RunAndReturn(run func
 }
 
 // RemoveProjectApiKeyExecute provides a mock function with given fields: r
-func (_m *ProgrammaticAPIKeysApi) RemoveProjectApiKeyExecute(r admin.RemoveProjectApiKeyApiRequest) (interface{}, *http.Response, error) {
+func (_m *ProgrammaticAPIKeysApi) RemoveProjectApiKeyExecute(r admin.RemoveProjectApiKeyApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RemoveProjectApiKeyExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.RemoveProjectApiKeyApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.RemoveProjectApiKeyApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.RemoveProjectApiKeyApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.RemoveProjectApiKeyApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -1903,7 +1903,7 @@ type ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call struct {
 
 // RemoveProjectApiKeyExecute is a helper method to define mock.On call
 //   - r admin.RemoveProjectApiKeyApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) RemoveProjectApiKeyExecute(r interface{}) *ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) RemoveProjectApiKeyExecute(r any) *ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call {
 	return &ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call{Call: _e.mock.On("RemoveProjectApiKeyExecute", r)}
 }
 
@@ -1914,12 +1914,12 @@ func (_c *ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call) Run(run func(r
 	return _c
 }
 
-func (_c *ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call {
+func (_c *ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call) RunAndReturn(run func(admin.RemoveProjectApiKeyApiRequest) (interface{}, *http.Response, error)) *ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call {
+func (_c *ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call) RunAndReturn(run func(admin.RemoveProjectApiKeyApiRequest) (any, *http.Response, error)) *ProgrammaticAPIKeysApi_RemoveProjectApiKeyExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1950,7 +1950,7 @@ type ProgrammaticAPIKeysApi_RemoveProjectApiKeyWithParams_Call struct {
 // RemoveProjectApiKeyWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.RemoveProjectApiKeyApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) RemoveProjectApiKeyWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_RemoveProjectApiKeyWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) RemoveProjectApiKeyWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_RemoveProjectApiKeyWithParams_Call {
 	return &ProgrammaticAPIKeysApi_RemoveProjectApiKeyWithParams_Call{Call: _e.mock.On("RemoveProjectApiKeyWithParams", ctx, args)}
 }
 
@@ -1999,7 +1999,7 @@ type ProgrammaticAPIKeysApi_UpdateApiKey_Call struct {
 //   - orgId string
 //   - apiUserId string
 //   - updateAtlasOrganizationApiKey *admin.UpdateAtlasOrganizationApiKey
-func (_e *ProgrammaticAPIKeysApi_Expecter) UpdateApiKey(ctx interface{}, orgId interface{}, apiUserId interface{}, updateAtlasOrganizationApiKey interface{}) *ProgrammaticAPIKeysApi_UpdateApiKey_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) UpdateApiKey(ctx any, orgId any, apiUserId any, updateAtlasOrganizationApiKey any) *ProgrammaticAPIKeysApi_UpdateApiKey_Call {
 	return &ProgrammaticAPIKeysApi_UpdateApiKey_Call{Call: _e.mock.On("UpdateApiKey", ctx, orgId, apiUserId, updateAtlasOrganizationApiKey)}
 }
 
@@ -2066,7 +2066,7 @@ type ProgrammaticAPIKeysApi_UpdateApiKeyExecute_Call struct {
 
 // UpdateApiKeyExecute is a helper method to define mock.On call
 //   - r admin.UpdateApiKeyApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) UpdateApiKeyExecute(r interface{}) *ProgrammaticAPIKeysApi_UpdateApiKeyExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) UpdateApiKeyExecute(r any) *ProgrammaticAPIKeysApi_UpdateApiKeyExecute_Call {
 	return &ProgrammaticAPIKeysApi_UpdateApiKeyExecute_Call{Call: _e.mock.On("UpdateApiKeyExecute", r)}
 }
 
@@ -2115,7 +2115,7 @@ type ProgrammaticAPIKeysApi_UpdateApiKeyRoles_Call struct {
 //   - groupId string
 //   - apiUserId string
 //   - updateAtlasProjectApiKey *admin.UpdateAtlasProjectApiKey
-func (_e *ProgrammaticAPIKeysApi_Expecter) UpdateApiKeyRoles(ctx interface{}, groupId interface{}, apiUserId interface{}, updateAtlasProjectApiKey interface{}) *ProgrammaticAPIKeysApi_UpdateApiKeyRoles_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) UpdateApiKeyRoles(ctx any, groupId any, apiUserId any, updateAtlasProjectApiKey any) *ProgrammaticAPIKeysApi_UpdateApiKeyRoles_Call {
 	return &ProgrammaticAPIKeysApi_UpdateApiKeyRoles_Call{Call: _e.mock.On("UpdateApiKeyRoles", ctx, groupId, apiUserId, updateAtlasProjectApiKey)}
 }
 
@@ -2182,7 +2182,7 @@ type ProgrammaticAPIKeysApi_UpdateApiKeyRolesExecute_Call struct {
 
 // UpdateApiKeyRolesExecute is a helper method to define mock.On call
 //   - r admin.UpdateApiKeyRolesApiRequest
-func (_e *ProgrammaticAPIKeysApi_Expecter) UpdateApiKeyRolesExecute(r interface{}) *ProgrammaticAPIKeysApi_UpdateApiKeyRolesExecute_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) UpdateApiKeyRolesExecute(r any) *ProgrammaticAPIKeysApi_UpdateApiKeyRolesExecute_Call {
 	return &ProgrammaticAPIKeysApi_UpdateApiKeyRolesExecute_Call{Call: _e.mock.On("UpdateApiKeyRolesExecute", r)}
 }
 
@@ -2229,7 +2229,7 @@ type ProgrammaticAPIKeysApi_UpdateApiKeyRolesWithParams_Call struct {
 // UpdateApiKeyRolesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateApiKeyRolesApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) UpdateApiKeyRolesWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_UpdateApiKeyRolesWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) UpdateApiKeyRolesWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_UpdateApiKeyRolesWithParams_Call {
 	return &ProgrammaticAPIKeysApi_UpdateApiKeyRolesWithParams_Call{Call: _e.mock.On("UpdateApiKeyRolesWithParams", ctx, args)}
 }
 
@@ -2276,7 +2276,7 @@ type ProgrammaticAPIKeysApi_UpdateApiKeyWithParams_Call struct {
 // UpdateApiKeyWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateApiKeyApiParams
-func (_e *ProgrammaticAPIKeysApi_Expecter) UpdateApiKeyWithParams(ctx interface{}, args interface{}) *ProgrammaticAPIKeysApi_UpdateApiKeyWithParams_Call {
+func (_e *ProgrammaticAPIKeysApi_Expecter) UpdateApiKeyWithParams(ctx any, args any) *ProgrammaticAPIKeysApi_UpdateApiKeyWithParams_Call {
 	return &ProgrammaticAPIKeysApi_UpdateApiKeyWithParams_Call{Call: _e.mock.On("UpdateApiKeyWithParams", ctx, args)}
 }
 

--- a/mockadmin/project_ip_access_list_api.go
+++ b/mockadmin/project_ip_access_list_api.go
@@ -52,7 +52,7 @@ type ProjectIPAccessListApi_CreateProjectIpAccessList_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - networkPermissionEntry *[]admin.NetworkPermissionEntry
-func (_e *ProjectIPAccessListApi_Expecter) CreateProjectIpAccessList(ctx interface{}, groupId interface{}, networkPermissionEntry interface{}) *ProjectIPAccessListApi_CreateProjectIpAccessList_Call {
+func (_e *ProjectIPAccessListApi_Expecter) CreateProjectIpAccessList(ctx any, groupId any, networkPermissionEntry any) *ProjectIPAccessListApi_CreateProjectIpAccessList_Call {
 	return &ProjectIPAccessListApi_CreateProjectIpAccessList_Call{Call: _e.mock.On("CreateProjectIpAccessList", ctx, groupId, networkPermissionEntry)}
 }
 
@@ -119,7 +119,7 @@ type ProjectIPAccessListApi_CreateProjectIpAccessListExecute_Call struct {
 
 // CreateProjectIpAccessListExecute is a helper method to define mock.On call
 //   - r admin.CreateProjectIpAccessListApiRequest
-func (_e *ProjectIPAccessListApi_Expecter) CreateProjectIpAccessListExecute(r interface{}) *ProjectIPAccessListApi_CreateProjectIpAccessListExecute_Call {
+func (_e *ProjectIPAccessListApi_Expecter) CreateProjectIpAccessListExecute(r any) *ProjectIPAccessListApi_CreateProjectIpAccessListExecute_Call {
 	return &ProjectIPAccessListApi_CreateProjectIpAccessListExecute_Call{Call: _e.mock.On("CreateProjectIpAccessListExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type ProjectIPAccessListApi_CreateProjectIpAccessListWithParams_Call struct {
 // CreateProjectIpAccessListWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateProjectIpAccessListApiParams
-func (_e *ProjectIPAccessListApi_Expecter) CreateProjectIpAccessListWithParams(ctx interface{}, args interface{}) *ProjectIPAccessListApi_CreateProjectIpAccessListWithParams_Call {
+func (_e *ProjectIPAccessListApi_Expecter) CreateProjectIpAccessListWithParams(ctx any, args any) *ProjectIPAccessListApi_CreateProjectIpAccessListWithParams_Call {
 	return &ProjectIPAccessListApi_CreateProjectIpAccessListWithParams_Call{Call: _e.mock.On("CreateProjectIpAccessListWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type ProjectIPAccessListApi_DeleteProjectIpAccessList_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - entryValue string
-func (_e *ProjectIPAccessListApi_Expecter) DeleteProjectIpAccessList(ctx interface{}, groupId interface{}, entryValue interface{}) *ProjectIPAccessListApi_DeleteProjectIpAccessList_Call {
+func (_e *ProjectIPAccessListApi_Expecter) DeleteProjectIpAccessList(ctx any, groupId any, entryValue any) *ProjectIPAccessListApi_DeleteProjectIpAccessList_Call {
 	return &ProjectIPAccessListApi_DeleteProjectIpAccessList_Call{Call: _e.mock.On("DeleteProjectIpAccessList", ctx, groupId, entryValue)}
 }
 
@@ -236,24 +236,24 @@ func (_c *ProjectIPAccessListApi_DeleteProjectIpAccessList_Call) RunAndReturn(ru
 }
 
 // DeleteProjectIpAccessListExecute provides a mock function with given fields: r
-func (_m *ProjectIPAccessListApi) DeleteProjectIpAccessListExecute(r admin.DeleteProjectIpAccessListApiRequest) (interface{}, *http.Response, error) {
+func (_m *ProjectIPAccessListApi) DeleteProjectIpAccessListExecute(r admin.DeleteProjectIpAccessListApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteProjectIpAccessListExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteProjectIpAccessListApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteProjectIpAccessListApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteProjectIpAccessListApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteProjectIpAccessListApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -281,7 +281,7 @@ type ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call struct {
 
 // DeleteProjectIpAccessListExecute is a helper method to define mock.On call
 //   - r admin.DeleteProjectIpAccessListApiRequest
-func (_e *ProjectIPAccessListApi_Expecter) DeleteProjectIpAccessListExecute(r interface{}) *ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call {
+func (_e *ProjectIPAccessListApi_Expecter) DeleteProjectIpAccessListExecute(r any) *ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call {
 	return &ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call{Call: _e.mock.On("DeleteProjectIpAccessListExecute", r)}
 }
 
@@ -292,12 +292,12 @@ func (_c *ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call) Run(run 
 	return _c
 }
 
-func (_c *ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call {
+func (_c *ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call) RunAndReturn(run func(admin.DeleteProjectIpAccessListApiRequest) (interface{}, *http.Response, error)) *ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call {
+func (_c *ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call) RunAndReturn(run func(admin.DeleteProjectIpAccessListApiRequest) (any, *http.Response, error)) *ProjectIPAccessListApi_DeleteProjectIpAccessListExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -328,7 +328,7 @@ type ProjectIPAccessListApi_DeleteProjectIpAccessListWithParams_Call struct {
 // DeleteProjectIpAccessListWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteProjectIpAccessListApiParams
-func (_e *ProjectIPAccessListApi_Expecter) DeleteProjectIpAccessListWithParams(ctx interface{}, args interface{}) *ProjectIPAccessListApi_DeleteProjectIpAccessListWithParams_Call {
+func (_e *ProjectIPAccessListApi_Expecter) DeleteProjectIpAccessListWithParams(ctx any, args any) *ProjectIPAccessListApi_DeleteProjectIpAccessListWithParams_Call {
 	return &ProjectIPAccessListApi_DeleteProjectIpAccessListWithParams_Call{Call: _e.mock.On("DeleteProjectIpAccessListWithParams", ctx, args)}
 }
 
@@ -376,7 +376,7 @@ type ProjectIPAccessListApi_GetProjectIpAccessListStatus_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - entryValue string
-func (_e *ProjectIPAccessListApi_Expecter) GetProjectIpAccessListStatus(ctx interface{}, groupId interface{}, entryValue interface{}) *ProjectIPAccessListApi_GetProjectIpAccessListStatus_Call {
+func (_e *ProjectIPAccessListApi_Expecter) GetProjectIpAccessListStatus(ctx any, groupId any, entryValue any) *ProjectIPAccessListApi_GetProjectIpAccessListStatus_Call {
 	return &ProjectIPAccessListApi_GetProjectIpAccessListStatus_Call{Call: _e.mock.On("GetProjectIpAccessListStatus", ctx, groupId, entryValue)}
 }
 
@@ -443,7 +443,7 @@ type ProjectIPAccessListApi_GetProjectIpAccessListStatusExecute_Call struct {
 
 // GetProjectIpAccessListStatusExecute is a helper method to define mock.On call
 //   - r admin.GetProjectIpAccessListStatusApiRequest
-func (_e *ProjectIPAccessListApi_Expecter) GetProjectIpAccessListStatusExecute(r interface{}) *ProjectIPAccessListApi_GetProjectIpAccessListStatusExecute_Call {
+func (_e *ProjectIPAccessListApi_Expecter) GetProjectIpAccessListStatusExecute(r any) *ProjectIPAccessListApi_GetProjectIpAccessListStatusExecute_Call {
 	return &ProjectIPAccessListApi_GetProjectIpAccessListStatusExecute_Call{Call: _e.mock.On("GetProjectIpAccessListStatusExecute", r)}
 }
 
@@ -490,7 +490,7 @@ type ProjectIPAccessListApi_GetProjectIpAccessListStatusWithParams_Call struct {
 // GetProjectIpAccessListStatusWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetProjectIpAccessListStatusApiParams
-func (_e *ProjectIPAccessListApi_Expecter) GetProjectIpAccessListStatusWithParams(ctx interface{}, args interface{}) *ProjectIPAccessListApi_GetProjectIpAccessListStatusWithParams_Call {
+func (_e *ProjectIPAccessListApi_Expecter) GetProjectIpAccessListStatusWithParams(ctx any, args any) *ProjectIPAccessListApi_GetProjectIpAccessListStatusWithParams_Call {
 	return &ProjectIPAccessListApi_GetProjectIpAccessListStatusWithParams_Call{Call: _e.mock.On("GetProjectIpAccessListStatusWithParams", ctx, args)}
 }
 
@@ -538,7 +538,7 @@ type ProjectIPAccessListApi_GetProjectIpList_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - entryValue string
-func (_e *ProjectIPAccessListApi_Expecter) GetProjectIpList(ctx interface{}, groupId interface{}, entryValue interface{}) *ProjectIPAccessListApi_GetProjectIpList_Call {
+func (_e *ProjectIPAccessListApi_Expecter) GetProjectIpList(ctx any, groupId any, entryValue any) *ProjectIPAccessListApi_GetProjectIpList_Call {
 	return &ProjectIPAccessListApi_GetProjectIpList_Call{Call: _e.mock.On("GetProjectIpList", ctx, groupId, entryValue)}
 }
 
@@ -605,7 +605,7 @@ type ProjectIPAccessListApi_GetProjectIpListExecute_Call struct {
 
 // GetProjectIpListExecute is a helper method to define mock.On call
 //   - r admin.GetProjectIpListApiRequest
-func (_e *ProjectIPAccessListApi_Expecter) GetProjectIpListExecute(r interface{}) *ProjectIPAccessListApi_GetProjectIpListExecute_Call {
+func (_e *ProjectIPAccessListApi_Expecter) GetProjectIpListExecute(r any) *ProjectIPAccessListApi_GetProjectIpListExecute_Call {
 	return &ProjectIPAccessListApi_GetProjectIpListExecute_Call{Call: _e.mock.On("GetProjectIpListExecute", r)}
 }
 
@@ -652,7 +652,7 @@ type ProjectIPAccessListApi_GetProjectIpListWithParams_Call struct {
 // GetProjectIpListWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetProjectIpListApiParams
-func (_e *ProjectIPAccessListApi_Expecter) GetProjectIpListWithParams(ctx interface{}, args interface{}) *ProjectIPAccessListApi_GetProjectIpListWithParams_Call {
+func (_e *ProjectIPAccessListApi_Expecter) GetProjectIpListWithParams(ctx any, args any) *ProjectIPAccessListApi_GetProjectIpListWithParams_Call {
 	return &ProjectIPAccessListApi_GetProjectIpListWithParams_Call{Call: _e.mock.On("GetProjectIpListWithParams", ctx, args)}
 }
 
@@ -699,7 +699,7 @@ type ProjectIPAccessListApi_ListProjectIpAccessLists_Call struct {
 // ListProjectIpAccessLists is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ProjectIPAccessListApi_Expecter) ListProjectIpAccessLists(ctx interface{}, groupId interface{}) *ProjectIPAccessListApi_ListProjectIpAccessLists_Call {
+func (_e *ProjectIPAccessListApi_Expecter) ListProjectIpAccessLists(ctx any, groupId any) *ProjectIPAccessListApi_ListProjectIpAccessLists_Call {
 	return &ProjectIPAccessListApi_ListProjectIpAccessLists_Call{Call: _e.mock.On("ListProjectIpAccessLists", ctx, groupId)}
 }
 
@@ -766,7 +766,7 @@ type ProjectIPAccessListApi_ListProjectIpAccessListsExecute_Call struct {
 
 // ListProjectIpAccessListsExecute is a helper method to define mock.On call
 //   - r admin.ListProjectIpAccessListsApiRequest
-func (_e *ProjectIPAccessListApi_Expecter) ListProjectIpAccessListsExecute(r interface{}) *ProjectIPAccessListApi_ListProjectIpAccessListsExecute_Call {
+func (_e *ProjectIPAccessListApi_Expecter) ListProjectIpAccessListsExecute(r any) *ProjectIPAccessListApi_ListProjectIpAccessListsExecute_Call {
 	return &ProjectIPAccessListApi_ListProjectIpAccessListsExecute_Call{Call: _e.mock.On("ListProjectIpAccessListsExecute", r)}
 }
 
@@ -813,7 +813,7 @@ type ProjectIPAccessListApi_ListProjectIpAccessListsWithParams_Call struct {
 // ListProjectIpAccessListsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListProjectIpAccessListsApiParams
-func (_e *ProjectIPAccessListApi_Expecter) ListProjectIpAccessListsWithParams(ctx interface{}, args interface{}) *ProjectIPAccessListApi_ListProjectIpAccessListsWithParams_Call {
+func (_e *ProjectIPAccessListApi_Expecter) ListProjectIpAccessListsWithParams(ctx any, args any) *ProjectIPAccessListApi_ListProjectIpAccessListsWithParams_Call {
 	return &ProjectIPAccessListApi_ListProjectIpAccessListsWithParams_Call{Call: _e.mock.On("ListProjectIpAccessListsWithParams", ctx, args)}
 }
 

--- a/mockadmin/projects_api.go
+++ b/mockadmin/projects_api.go
@@ -52,7 +52,7 @@ type ProjectsApi_AddUserToProject_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - groupInvitationRequest *admin.GroupInvitationRequest
-func (_e *ProjectsApi_Expecter) AddUserToProject(ctx interface{}, groupId interface{}, groupInvitationRequest interface{}) *ProjectsApi_AddUserToProject_Call {
+func (_e *ProjectsApi_Expecter) AddUserToProject(ctx any, groupId any, groupInvitationRequest any) *ProjectsApi_AddUserToProject_Call {
 	return &ProjectsApi_AddUserToProject_Call{Call: _e.mock.On("AddUserToProject", ctx, groupId, groupInvitationRequest)}
 }
 
@@ -119,7 +119,7 @@ type ProjectsApi_AddUserToProjectExecute_Call struct {
 
 // AddUserToProjectExecute is a helper method to define mock.On call
 //   - r admin.AddUserToProjectApiRequest
-func (_e *ProjectsApi_Expecter) AddUserToProjectExecute(r interface{}) *ProjectsApi_AddUserToProjectExecute_Call {
+func (_e *ProjectsApi_Expecter) AddUserToProjectExecute(r any) *ProjectsApi_AddUserToProjectExecute_Call {
 	return &ProjectsApi_AddUserToProjectExecute_Call{Call: _e.mock.On("AddUserToProjectExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type ProjectsApi_AddUserToProjectWithParams_Call struct {
 // AddUserToProjectWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.AddUserToProjectApiParams
-func (_e *ProjectsApi_Expecter) AddUserToProjectWithParams(ctx interface{}, args interface{}) *ProjectsApi_AddUserToProjectWithParams_Call {
+func (_e *ProjectsApi_Expecter) AddUserToProjectWithParams(ctx any, args any) *ProjectsApi_AddUserToProjectWithParams_Call {
 	return &ProjectsApi_AddUserToProjectWithParams_Call{Call: _e.mock.On("AddUserToProjectWithParams", ctx, args)}
 }
 
@@ -213,7 +213,7 @@ type ProjectsApi_CreateProject_Call struct {
 // CreateProject is a helper method to define mock.On call
 //   - ctx context.Context
 //   - group *admin.Group
-func (_e *ProjectsApi_Expecter) CreateProject(ctx interface{}, group interface{}) *ProjectsApi_CreateProject_Call {
+func (_e *ProjectsApi_Expecter) CreateProject(ctx any, group any) *ProjectsApi_CreateProject_Call {
 	return &ProjectsApi_CreateProject_Call{Call: _e.mock.On("CreateProject", ctx, group)}
 }
 
@@ -280,7 +280,7 @@ type ProjectsApi_CreateProjectExecute_Call struct {
 
 // CreateProjectExecute is a helper method to define mock.On call
 //   - r admin.CreateProjectApiRequest
-func (_e *ProjectsApi_Expecter) CreateProjectExecute(r interface{}) *ProjectsApi_CreateProjectExecute_Call {
+func (_e *ProjectsApi_Expecter) CreateProjectExecute(r any) *ProjectsApi_CreateProjectExecute_Call {
 	return &ProjectsApi_CreateProjectExecute_Call{Call: _e.mock.On("CreateProjectExecute", r)}
 }
 
@@ -328,7 +328,7 @@ type ProjectsApi_CreateProjectInvitation_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - groupInvitationRequest *admin.GroupInvitationRequest
-func (_e *ProjectsApi_Expecter) CreateProjectInvitation(ctx interface{}, groupId interface{}, groupInvitationRequest interface{}) *ProjectsApi_CreateProjectInvitation_Call {
+func (_e *ProjectsApi_Expecter) CreateProjectInvitation(ctx any, groupId any, groupInvitationRequest any) *ProjectsApi_CreateProjectInvitation_Call {
 	return &ProjectsApi_CreateProjectInvitation_Call{Call: _e.mock.On("CreateProjectInvitation", ctx, groupId, groupInvitationRequest)}
 }
 
@@ -395,7 +395,7 @@ type ProjectsApi_CreateProjectInvitationExecute_Call struct {
 
 // CreateProjectInvitationExecute is a helper method to define mock.On call
 //   - r admin.CreateProjectInvitationApiRequest
-func (_e *ProjectsApi_Expecter) CreateProjectInvitationExecute(r interface{}) *ProjectsApi_CreateProjectInvitationExecute_Call {
+func (_e *ProjectsApi_Expecter) CreateProjectInvitationExecute(r any) *ProjectsApi_CreateProjectInvitationExecute_Call {
 	return &ProjectsApi_CreateProjectInvitationExecute_Call{Call: _e.mock.On("CreateProjectInvitationExecute", r)}
 }
 
@@ -442,7 +442,7 @@ type ProjectsApi_CreateProjectInvitationWithParams_Call struct {
 // CreateProjectInvitationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateProjectInvitationApiParams
-func (_e *ProjectsApi_Expecter) CreateProjectInvitationWithParams(ctx interface{}, args interface{}) *ProjectsApi_CreateProjectInvitationWithParams_Call {
+func (_e *ProjectsApi_Expecter) CreateProjectInvitationWithParams(ctx any, args any) *ProjectsApi_CreateProjectInvitationWithParams_Call {
 	return &ProjectsApi_CreateProjectInvitationWithParams_Call{Call: _e.mock.On("CreateProjectInvitationWithParams", ctx, args)}
 }
 
@@ -489,7 +489,7 @@ type ProjectsApi_CreateProjectWithParams_Call struct {
 // CreateProjectWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateProjectApiParams
-func (_e *ProjectsApi_Expecter) CreateProjectWithParams(ctx interface{}, args interface{}) *ProjectsApi_CreateProjectWithParams_Call {
+func (_e *ProjectsApi_Expecter) CreateProjectWithParams(ctx any, args any) *ProjectsApi_CreateProjectWithParams_Call {
 	return &ProjectsApi_CreateProjectWithParams_Call{Call: _e.mock.On("CreateProjectWithParams", ctx, args)}
 }
 
@@ -536,7 +536,7 @@ type ProjectsApi_DeleteProject_Call struct {
 // DeleteProject is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ProjectsApi_Expecter) DeleteProject(ctx interface{}, groupId interface{}) *ProjectsApi_DeleteProject_Call {
+func (_e *ProjectsApi_Expecter) DeleteProject(ctx any, groupId any) *ProjectsApi_DeleteProject_Call {
 	return &ProjectsApi_DeleteProject_Call{Call: _e.mock.On("DeleteProject", ctx, groupId)}
 }
 
@@ -558,24 +558,24 @@ func (_c *ProjectsApi_DeleteProject_Call) RunAndReturn(run func(context.Context,
 }
 
 // DeleteProjectExecute provides a mock function with given fields: r
-func (_m *ProjectsApi) DeleteProjectExecute(r admin.DeleteProjectApiRequest) (interface{}, *http.Response, error) {
+func (_m *ProjectsApi) DeleteProjectExecute(r admin.DeleteProjectApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteProjectExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteProjectApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteProjectApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteProjectApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteProjectApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -603,7 +603,7 @@ type ProjectsApi_DeleteProjectExecute_Call struct {
 
 // DeleteProjectExecute is a helper method to define mock.On call
 //   - r admin.DeleteProjectApiRequest
-func (_e *ProjectsApi_Expecter) DeleteProjectExecute(r interface{}) *ProjectsApi_DeleteProjectExecute_Call {
+func (_e *ProjectsApi_Expecter) DeleteProjectExecute(r any) *ProjectsApi_DeleteProjectExecute_Call {
 	return &ProjectsApi_DeleteProjectExecute_Call{Call: _e.mock.On("DeleteProjectExecute", r)}
 }
 
@@ -614,12 +614,12 @@ func (_c *ProjectsApi_DeleteProjectExecute_Call) Run(run func(r admin.DeleteProj
 	return _c
 }
 
-func (_c *ProjectsApi_DeleteProjectExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ProjectsApi_DeleteProjectExecute_Call {
+func (_c *ProjectsApi_DeleteProjectExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ProjectsApi_DeleteProjectExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ProjectsApi_DeleteProjectExecute_Call) RunAndReturn(run func(admin.DeleteProjectApiRequest) (interface{}, *http.Response, error)) *ProjectsApi_DeleteProjectExecute_Call {
+func (_c *ProjectsApi_DeleteProjectExecute_Call) RunAndReturn(run func(admin.DeleteProjectApiRequest) (any, *http.Response, error)) *ProjectsApi_DeleteProjectExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -651,7 +651,7 @@ type ProjectsApi_DeleteProjectInvitation_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - invitationId string
-func (_e *ProjectsApi_Expecter) DeleteProjectInvitation(ctx interface{}, groupId interface{}, invitationId interface{}) *ProjectsApi_DeleteProjectInvitation_Call {
+func (_e *ProjectsApi_Expecter) DeleteProjectInvitation(ctx any, groupId any, invitationId any) *ProjectsApi_DeleteProjectInvitation_Call {
 	return &ProjectsApi_DeleteProjectInvitation_Call{Call: _e.mock.On("DeleteProjectInvitation", ctx, groupId, invitationId)}
 }
 
@@ -673,24 +673,24 @@ func (_c *ProjectsApi_DeleteProjectInvitation_Call) RunAndReturn(run func(contex
 }
 
 // DeleteProjectInvitationExecute provides a mock function with given fields: r
-func (_m *ProjectsApi) DeleteProjectInvitationExecute(r admin.DeleteProjectInvitationApiRequest) (interface{}, *http.Response, error) {
+func (_m *ProjectsApi) DeleteProjectInvitationExecute(r admin.DeleteProjectInvitationApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteProjectInvitationExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteProjectInvitationApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteProjectInvitationApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteProjectInvitationApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteProjectInvitationApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -718,7 +718,7 @@ type ProjectsApi_DeleteProjectInvitationExecute_Call struct {
 
 // DeleteProjectInvitationExecute is a helper method to define mock.On call
 //   - r admin.DeleteProjectInvitationApiRequest
-func (_e *ProjectsApi_Expecter) DeleteProjectInvitationExecute(r interface{}) *ProjectsApi_DeleteProjectInvitationExecute_Call {
+func (_e *ProjectsApi_Expecter) DeleteProjectInvitationExecute(r any) *ProjectsApi_DeleteProjectInvitationExecute_Call {
 	return &ProjectsApi_DeleteProjectInvitationExecute_Call{Call: _e.mock.On("DeleteProjectInvitationExecute", r)}
 }
 
@@ -729,12 +729,12 @@ func (_c *ProjectsApi_DeleteProjectInvitationExecute_Call) Run(run func(r admin.
 	return _c
 }
 
-func (_c *ProjectsApi_DeleteProjectInvitationExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ProjectsApi_DeleteProjectInvitationExecute_Call {
+func (_c *ProjectsApi_DeleteProjectInvitationExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ProjectsApi_DeleteProjectInvitationExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ProjectsApi_DeleteProjectInvitationExecute_Call) RunAndReturn(run func(admin.DeleteProjectInvitationApiRequest) (interface{}, *http.Response, error)) *ProjectsApi_DeleteProjectInvitationExecute_Call {
+func (_c *ProjectsApi_DeleteProjectInvitationExecute_Call) RunAndReturn(run func(admin.DeleteProjectInvitationApiRequest) (any, *http.Response, error)) *ProjectsApi_DeleteProjectInvitationExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -765,7 +765,7 @@ type ProjectsApi_DeleteProjectInvitationWithParams_Call struct {
 // DeleteProjectInvitationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteProjectInvitationApiParams
-func (_e *ProjectsApi_Expecter) DeleteProjectInvitationWithParams(ctx interface{}, args interface{}) *ProjectsApi_DeleteProjectInvitationWithParams_Call {
+func (_e *ProjectsApi_Expecter) DeleteProjectInvitationWithParams(ctx any, args any) *ProjectsApi_DeleteProjectInvitationWithParams_Call {
 	return &ProjectsApi_DeleteProjectInvitationWithParams_Call{Call: _e.mock.On("DeleteProjectInvitationWithParams", ctx, args)}
 }
 
@@ -813,7 +813,7 @@ type ProjectsApi_DeleteProjectLimit_Call struct {
 //   - ctx context.Context
 //   - limitName string
 //   - groupId string
-func (_e *ProjectsApi_Expecter) DeleteProjectLimit(ctx interface{}, limitName interface{}, groupId interface{}) *ProjectsApi_DeleteProjectLimit_Call {
+func (_e *ProjectsApi_Expecter) DeleteProjectLimit(ctx any, limitName any, groupId any) *ProjectsApi_DeleteProjectLimit_Call {
 	return &ProjectsApi_DeleteProjectLimit_Call{Call: _e.mock.On("DeleteProjectLimit", ctx, limitName, groupId)}
 }
 
@@ -835,24 +835,24 @@ func (_c *ProjectsApi_DeleteProjectLimit_Call) RunAndReturn(run func(context.Con
 }
 
 // DeleteProjectLimitExecute provides a mock function with given fields: r
-func (_m *ProjectsApi) DeleteProjectLimitExecute(r admin.DeleteProjectLimitApiRequest) (interface{}, *http.Response, error) {
+func (_m *ProjectsApi) DeleteProjectLimitExecute(r admin.DeleteProjectLimitApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteProjectLimitExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteProjectLimitApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteProjectLimitApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteProjectLimitApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteProjectLimitApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -880,7 +880,7 @@ type ProjectsApi_DeleteProjectLimitExecute_Call struct {
 
 // DeleteProjectLimitExecute is a helper method to define mock.On call
 //   - r admin.DeleteProjectLimitApiRequest
-func (_e *ProjectsApi_Expecter) DeleteProjectLimitExecute(r interface{}) *ProjectsApi_DeleteProjectLimitExecute_Call {
+func (_e *ProjectsApi_Expecter) DeleteProjectLimitExecute(r any) *ProjectsApi_DeleteProjectLimitExecute_Call {
 	return &ProjectsApi_DeleteProjectLimitExecute_Call{Call: _e.mock.On("DeleteProjectLimitExecute", r)}
 }
 
@@ -891,12 +891,12 @@ func (_c *ProjectsApi_DeleteProjectLimitExecute_Call) Run(run func(r admin.Delet
 	return _c
 }
 
-func (_c *ProjectsApi_DeleteProjectLimitExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ProjectsApi_DeleteProjectLimitExecute_Call {
+func (_c *ProjectsApi_DeleteProjectLimitExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ProjectsApi_DeleteProjectLimitExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ProjectsApi_DeleteProjectLimitExecute_Call) RunAndReturn(run func(admin.DeleteProjectLimitApiRequest) (interface{}, *http.Response, error)) *ProjectsApi_DeleteProjectLimitExecute_Call {
+func (_c *ProjectsApi_DeleteProjectLimitExecute_Call) RunAndReturn(run func(admin.DeleteProjectLimitApiRequest) (any, *http.Response, error)) *ProjectsApi_DeleteProjectLimitExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -927,7 +927,7 @@ type ProjectsApi_DeleteProjectLimitWithParams_Call struct {
 // DeleteProjectLimitWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteProjectLimitApiParams
-func (_e *ProjectsApi_Expecter) DeleteProjectLimitWithParams(ctx interface{}, args interface{}) *ProjectsApi_DeleteProjectLimitWithParams_Call {
+func (_e *ProjectsApi_Expecter) DeleteProjectLimitWithParams(ctx any, args any) *ProjectsApi_DeleteProjectLimitWithParams_Call {
 	return &ProjectsApi_DeleteProjectLimitWithParams_Call{Call: _e.mock.On("DeleteProjectLimitWithParams", ctx, args)}
 }
 
@@ -974,7 +974,7 @@ type ProjectsApi_DeleteProjectWithParams_Call struct {
 // DeleteProjectWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteProjectApiParams
-func (_e *ProjectsApi_Expecter) DeleteProjectWithParams(ctx interface{}, args interface{}) *ProjectsApi_DeleteProjectWithParams_Call {
+func (_e *ProjectsApi_Expecter) DeleteProjectWithParams(ctx any, args any) *ProjectsApi_DeleteProjectWithParams_Call {
 	return &ProjectsApi_DeleteProjectWithParams_Call{Call: _e.mock.On("DeleteProjectWithParams", ctx, args)}
 }
 
@@ -1021,7 +1021,7 @@ type ProjectsApi_GetProject_Call struct {
 // GetProject is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ProjectsApi_Expecter) GetProject(ctx interface{}, groupId interface{}) *ProjectsApi_GetProject_Call {
+func (_e *ProjectsApi_Expecter) GetProject(ctx any, groupId any) *ProjectsApi_GetProject_Call {
 	return &ProjectsApi_GetProject_Call{Call: _e.mock.On("GetProject", ctx, groupId)}
 }
 
@@ -1068,7 +1068,7 @@ type ProjectsApi_GetProjectByName_Call struct {
 // GetProjectByName is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupName string
-func (_e *ProjectsApi_Expecter) GetProjectByName(ctx interface{}, groupName interface{}) *ProjectsApi_GetProjectByName_Call {
+func (_e *ProjectsApi_Expecter) GetProjectByName(ctx any, groupName any) *ProjectsApi_GetProjectByName_Call {
 	return &ProjectsApi_GetProjectByName_Call{Call: _e.mock.On("GetProjectByName", ctx, groupName)}
 }
 
@@ -1135,7 +1135,7 @@ type ProjectsApi_GetProjectByNameExecute_Call struct {
 
 // GetProjectByNameExecute is a helper method to define mock.On call
 //   - r admin.GetProjectByNameApiRequest
-func (_e *ProjectsApi_Expecter) GetProjectByNameExecute(r interface{}) *ProjectsApi_GetProjectByNameExecute_Call {
+func (_e *ProjectsApi_Expecter) GetProjectByNameExecute(r any) *ProjectsApi_GetProjectByNameExecute_Call {
 	return &ProjectsApi_GetProjectByNameExecute_Call{Call: _e.mock.On("GetProjectByNameExecute", r)}
 }
 
@@ -1182,7 +1182,7 @@ type ProjectsApi_GetProjectByNameWithParams_Call struct {
 // GetProjectByNameWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetProjectByNameApiParams
-func (_e *ProjectsApi_Expecter) GetProjectByNameWithParams(ctx interface{}, args interface{}) *ProjectsApi_GetProjectByNameWithParams_Call {
+func (_e *ProjectsApi_Expecter) GetProjectByNameWithParams(ctx any, args any) *ProjectsApi_GetProjectByNameWithParams_Call {
 	return &ProjectsApi_GetProjectByNameWithParams_Call{Call: _e.mock.On("GetProjectByNameWithParams", ctx, args)}
 }
 
@@ -1249,7 +1249,7 @@ type ProjectsApi_GetProjectExecute_Call struct {
 
 // GetProjectExecute is a helper method to define mock.On call
 //   - r admin.GetProjectApiRequest
-func (_e *ProjectsApi_Expecter) GetProjectExecute(r interface{}) *ProjectsApi_GetProjectExecute_Call {
+func (_e *ProjectsApi_Expecter) GetProjectExecute(r any) *ProjectsApi_GetProjectExecute_Call {
 	return &ProjectsApi_GetProjectExecute_Call{Call: _e.mock.On("GetProjectExecute", r)}
 }
 
@@ -1297,7 +1297,7 @@ type ProjectsApi_GetProjectInvitation_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - invitationId string
-func (_e *ProjectsApi_Expecter) GetProjectInvitation(ctx interface{}, groupId interface{}, invitationId interface{}) *ProjectsApi_GetProjectInvitation_Call {
+func (_e *ProjectsApi_Expecter) GetProjectInvitation(ctx any, groupId any, invitationId any) *ProjectsApi_GetProjectInvitation_Call {
 	return &ProjectsApi_GetProjectInvitation_Call{Call: _e.mock.On("GetProjectInvitation", ctx, groupId, invitationId)}
 }
 
@@ -1364,7 +1364,7 @@ type ProjectsApi_GetProjectInvitationExecute_Call struct {
 
 // GetProjectInvitationExecute is a helper method to define mock.On call
 //   - r admin.GetProjectInvitationApiRequest
-func (_e *ProjectsApi_Expecter) GetProjectInvitationExecute(r interface{}) *ProjectsApi_GetProjectInvitationExecute_Call {
+func (_e *ProjectsApi_Expecter) GetProjectInvitationExecute(r any) *ProjectsApi_GetProjectInvitationExecute_Call {
 	return &ProjectsApi_GetProjectInvitationExecute_Call{Call: _e.mock.On("GetProjectInvitationExecute", r)}
 }
 
@@ -1411,7 +1411,7 @@ type ProjectsApi_GetProjectInvitationWithParams_Call struct {
 // GetProjectInvitationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetProjectInvitationApiParams
-func (_e *ProjectsApi_Expecter) GetProjectInvitationWithParams(ctx interface{}, args interface{}) *ProjectsApi_GetProjectInvitationWithParams_Call {
+func (_e *ProjectsApi_Expecter) GetProjectInvitationWithParams(ctx any, args any) *ProjectsApi_GetProjectInvitationWithParams_Call {
 	return &ProjectsApi_GetProjectInvitationWithParams_Call{Call: _e.mock.On("GetProjectInvitationWithParams", ctx, args)}
 }
 
@@ -1458,7 +1458,7 @@ type ProjectsApi_GetProjectLTSVersions_Call struct {
 // GetProjectLTSVersions is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ProjectsApi_Expecter) GetProjectLTSVersions(ctx interface{}, groupId interface{}) *ProjectsApi_GetProjectLTSVersions_Call {
+func (_e *ProjectsApi_Expecter) GetProjectLTSVersions(ctx any, groupId any) *ProjectsApi_GetProjectLTSVersions_Call {
 	return &ProjectsApi_GetProjectLTSVersions_Call{Call: _e.mock.On("GetProjectLTSVersions", ctx, groupId)}
 }
 
@@ -1525,7 +1525,7 @@ type ProjectsApi_GetProjectLTSVersionsExecute_Call struct {
 
 // GetProjectLTSVersionsExecute is a helper method to define mock.On call
 //   - r admin.GetProjectLTSVersionsApiRequest
-func (_e *ProjectsApi_Expecter) GetProjectLTSVersionsExecute(r interface{}) *ProjectsApi_GetProjectLTSVersionsExecute_Call {
+func (_e *ProjectsApi_Expecter) GetProjectLTSVersionsExecute(r any) *ProjectsApi_GetProjectLTSVersionsExecute_Call {
 	return &ProjectsApi_GetProjectLTSVersionsExecute_Call{Call: _e.mock.On("GetProjectLTSVersionsExecute", r)}
 }
 
@@ -1572,7 +1572,7 @@ type ProjectsApi_GetProjectLTSVersionsWithParams_Call struct {
 // GetProjectLTSVersionsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetProjectLTSVersionsApiParams
-func (_e *ProjectsApi_Expecter) GetProjectLTSVersionsWithParams(ctx interface{}, args interface{}) *ProjectsApi_GetProjectLTSVersionsWithParams_Call {
+func (_e *ProjectsApi_Expecter) GetProjectLTSVersionsWithParams(ctx any, args any) *ProjectsApi_GetProjectLTSVersionsWithParams_Call {
 	return &ProjectsApi_GetProjectLTSVersionsWithParams_Call{Call: _e.mock.On("GetProjectLTSVersionsWithParams", ctx, args)}
 }
 
@@ -1620,7 +1620,7 @@ type ProjectsApi_GetProjectLimit_Call struct {
 //   - ctx context.Context
 //   - limitName string
 //   - groupId string
-func (_e *ProjectsApi_Expecter) GetProjectLimit(ctx interface{}, limitName interface{}, groupId interface{}) *ProjectsApi_GetProjectLimit_Call {
+func (_e *ProjectsApi_Expecter) GetProjectLimit(ctx any, limitName any, groupId any) *ProjectsApi_GetProjectLimit_Call {
 	return &ProjectsApi_GetProjectLimit_Call{Call: _e.mock.On("GetProjectLimit", ctx, limitName, groupId)}
 }
 
@@ -1687,7 +1687,7 @@ type ProjectsApi_GetProjectLimitExecute_Call struct {
 
 // GetProjectLimitExecute is a helper method to define mock.On call
 //   - r admin.GetProjectLimitApiRequest
-func (_e *ProjectsApi_Expecter) GetProjectLimitExecute(r interface{}) *ProjectsApi_GetProjectLimitExecute_Call {
+func (_e *ProjectsApi_Expecter) GetProjectLimitExecute(r any) *ProjectsApi_GetProjectLimitExecute_Call {
 	return &ProjectsApi_GetProjectLimitExecute_Call{Call: _e.mock.On("GetProjectLimitExecute", r)}
 }
 
@@ -1734,7 +1734,7 @@ type ProjectsApi_GetProjectLimitWithParams_Call struct {
 // GetProjectLimitWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetProjectLimitApiParams
-func (_e *ProjectsApi_Expecter) GetProjectLimitWithParams(ctx interface{}, args interface{}) *ProjectsApi_GetProjectLimitWithParams_Call {
+func (_e *ProjectsApi_Expecter) GetProjectLimitWithParams(ctx any, args any) *ProjectsApi_GetProjectLimitWithParams_Call {
 	return &ProjectsApi_GetProjectLimitWithParams_Call{Call: _e.mock.On("GetProjectLimitWithParams", ctx, args)}
 }
 
@@ -1781,7 +1781,7 @@ type ProjectsApi_GetProjectSettings_Call struct {
 // GetProjectSettings is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ProjectsApi_Expecter) GetProjectSettings(ctx interface{}, groupId interface{}) *ProjectsApi_GetProjectSettings_Call {
+func (_e *ProjectsApi_Expecter) GetProjectSettings(ctx any, groupId any) *ProjectsApi_GetProjectSettings_Call {
 	return &ProjectsApi_GetProjectSettings_Call{Call: _e.mock.On("GetProjectSettings", ctx, groupId)}
 }
 
@@ -1848,7 +1848,7 @@ type ProjectsApi_GetProjectSettingsExecute_Call struct {
 
 // GetProjectSettingsExecute is a helper method to define mock.On call
 //   - r admin.GetProjectSettingsApiRequest
-func (_e *ProjectsApi_Expecter) GetProjectSettingsExecute(r interface{}) *ProjectsApi_GetProjectSettingsExecute_Call {
+func (_e *ProjectsApi_Expecter) GetProjectSettingsExecute(r any) *ProjectsApi_GetProjectSettingsExecute_Call {
 	return &ProjectsApi_GetProjectSettingsExecute_Call{Call: _e.mock.On("GetProjectSettingsExecute", r)}
 }
 
@@ -1895,7 +1895,7 @@ type ProjectsApi_GetProjectSettingsWithParams_Call struct {
 // GetProjectSettingsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetProjectSettingsApiParams
-func (_e *ProjectsApi_Expecter) GetProjectSettingsWithParams(ctx interface{}, args interface{}) *ProjectsApi_GetProjectSettingsWithParams_Call {
+func (_e *ProjectsApi_Expecter) GetProjectSettingsWithParams(ctx any, args any) *ProjectsApi_GetProjectSettingsWithParams_Call {
 	return &ProjectsApi_GetProjectSettingsWithParams_Call{Call: _e.mock.On("GetProjectSettingsWithParams", ctx, args)}
 }
 
@@ -1942,7 +1942,7 @@ type ProjectsApi_GetProjectWithParams_Call struct {
 // GetProjectWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetProjectApiParams
-func (_e *ProjectsApi_Expecter) GetProjectWithParams(ctx interface{}, args interface{}) *ProjectsApi_GetProjectWithParams_Call {
+func (_e *ProjectsApi_Expecter) GetProjectWithParams(ctx any, args any) *ProjectsApi_GetProjectWithParams_Call {
 	return &ProjectsApi_GetProjectWithParams_Call{Call: _e.mock.On("GetProjectWithParams", ctx, args)}
 }
 
@@ -1989,7 +1989,7 @@ type ProjectsApi_ListProjectInvitations_Call struct {
 // ListProjectInvitations is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ProjectsApi_Expecter) ListProjectInvitations(ctx interface{}, groupId interface{}) *ProjectsApi_ListProjectInvitations_Call {
+func (_e *ProjectsApi_Expecter) ListProjectInvitations(ctx any, groupId any) *ProjectsApi_ListProjectInvitations_Call {
 	return &ProjectsApi_ListProjectInvitations_Call{Call: _e.mock.On("ListProjectInvitations", ctx, groupId)}
 }
 
@@ -2056,7 +2056,7 @@ type ProjectsApi_ListProjectInvitationsExecute_Call struct {
 
 // ListProjectInvitationsExecute is a helper method to define mock.On call
 //   - r admin.ListProjectInvitationsApiRequest
-func (_e *ProjectsApi_Expecter) ListProjectInvitationsExecute(r interface{}) *ProjectsApi_ListProjectInvitationsExecute_Call {
+func (_e *ProjectsApi_Expecter) ListProjectInvitationsExecute(r any) *ProjectsApi_ListProjectInvitationsExecute_Call {
 	return &ProjectsApi_ListProjectInvitationsExecute_Call{Call: _e.mock.On("ListProjectInvitationsExecute", r)}
 }
 
@@ -2103,7 +2103,7 @@ type ProjectsApi_ListProjectInvitationsWithParams_Call struct {
 // ListProjectInvitationsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListProjectInvitationsApiParams
-func (_e *ProjectsApi_Expecter) ListProjectInvitationsWithParams(ctx interface{}, args interface{}) *ProjectsApi_ListProjectInvitationsWithParams_Call {
+func (_e *ProjectsApi_Expecter) ListProjectInvitationsWithParams(ctx any, args any) *ProjectsApi_ListProjectInvitationsWithParams_Call {
 	return &ProjectsApi_ListProjectInvitationsWithParams_Call{Call: _e.mock.On("ListProjectInvitationsWithParams", ctx, args)}
 }
 
@@ -2150,7 +2150,7 @@ type ProjectsApi_ListProjectLimits_Call struct {
 // ListProjectLimits is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ProjectsApi_Expecter) ListProjectLimits(ctx interface{}, groupId interface{}) *ProjectsApi_ListProjectLimits_Call {
+func (_e *ProjectsApi_Expecter) ListProjectLimits(ctx any, groupId any) *ProjectsApi_ListProjectLimits_Call {
 	return &ProjectsApi_ListProjectLimits_Call{Call: _e.mock.On("ListProjectLimits", ctx, groupId)}
 }
 
@@ -2217,7 +2217,7 @@ type ProjectsApi_ListProjectLimitsExecute_Call struct {
 
 // ListProjectLimitsExecute is a helper method to define mock.On call
 //   - r admin.ListProjectLimitsApiRequest
-func (_e *ProjectsApi_Expecter) ListProjectLimitsExecute(r interface{}) *ProjectsApi_ListProjectLimitsExecute_Call {
+func (_e *ProjectsApi_Expecter) ListProjectLimitsExecute(r any) *ProjectsApi_ListProjectLimitsExecute_Call {
 	return &ProjectsApi_ListProjectLimitsExecute_Call{Call: _e.mock.On("ListProjectLimitsExecute", r)}
 }
 
@@ -2264,7 +2264,7 @@ type ProjectsApi_ListProjectLimitsWithParams_Call struct {
 // ListProjectLimitsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListProjectLimitsApiParams
-func (_e *ProjectsApi_Expecter) ListProjectLimitsWithParams(ctx interface{}, args interface{}) *ProjectsApi_ListProjectLimitsWithParams_Call {
+func (_e *ProjectsApi_Expecter) ListProjectLimitsWithParams(ctx any, args any) *ProjectsApi_ListProjectLimitsWithParams_Call {
 	return &ProjectsApi_ListProjectLimitsWithParams_Call{Call: _e.mock.On("ListProjectLimitsWithParams", ctx, args)}
 }
 
@@ -2311,7 +2311,7 @@ type ProjectsApi_ListProjectUsers_Call struct {
 // ListProjectUsers is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ProjectsApi_Expecter) ListProjectUsers(ctx interface{}, groupId interface{}) *ProjectsApi_ListProjectUsers_Call {
+func (_e *ProjectsApi_Expecter) ListProjectUsers(ctx any, groupId any) *ProjectsApi_ListProjectUsers_Call {
 	return &ProjectsApi_ListProjectUsers_Call{Call: _e.mock.On("ListProjectUsers", ctx, groupId)}
 }
 
@@ -2378,7 +2378,7 @@ type ProjectsApi_ListProjectUsersExecute_Call struct {
 
 // ListProjectUsersExecute is a helper method to define mock.On call
 //   - r admin.ListProjectUsersApiRequest
-func (_e *ProjectsApi_Expecter) ListProjectUsersExecute(r interface{}) *ProjectsApi_ListProjectUsersExecute_Call {
+func (_e *ProjectsApi_Expecter) ListProjectUsersExecute(r any) *ProjectsApi_ListProjectUsersExecute_Call {
 	return &ProjectsApi_ListProjectUsersExecute_Call{Call: _e.mock.On("ListProjectUsersExecute", r)}
 }
 
@@ -2425,7 +2425,7 @@ type ProjectsApi_ListProjectUsersWithParams_Call struct {
 // ListProjectUsersWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListProjectUsersApiParams
-func (_e *ProjectsApi_Expecter) ListProjectUsersWithParams(ctx interface{}, args interface{}) *ProjectsApi_ListProjectUsersWithParams_Call {
+func (_e *ProjectsApi_Expecter) ListProjectUsersWithParams(ctx any, args any) *ProjectsApi_ListProjectUsersWithParams_Call {
 	return &ProjectsApi_ListProjectUsersWithParams_Call{Call: _e.mock.On("ListProjectUsersWithParams", ctx, args)}
 }
 
@@ -2471,7 +2471,7 @@ type ProjectsApi_ListProjects_Call struct {
 
 // ListProjects is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *ProjectsApi_Expecter) ListProjects(ctx interface{}) *ProjectsApi_ListProjects_Call {
+func (_e *ProjectsApi_Expecter) ListProjects(ctx any) *ProjectsApi_ListProjects_Call {
 	return &ProjectsApi_ListProjects_Call{Call: _e.mock.On("ListProjects", ctx)}
 }
 
@@ -2538,7 +2538,7 @@ type ProjectsApi_ListProjectsExecute_Call struct {
 
 // ListProjectsExecute is a helper method to define mock.On call
 //   - r admin.ListProjectsApiRequest
-func (_e *ProjectsApi_Expecter) ListProjectsExecute(r interface{}) *ProjectsApi_ListProjectsExecute_Call {
+func (_e *ProjectsApi_Expecter) ListProjectsExecute(r any) *ProjectsApi_ListProjectsExecute_Call {
 	return &ProjectsApi_ListProjectsExecute_Call{Call: _e.mock.On("ListProjectsExecute", r)}
 }
 
@@ -2585,7 +2585,7 @@ type ProjectsApi_ListProjectsWithParams_Call struct {
 // ListProjectsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListProjectsApiParams
-func (_e *ProjectsApi_Expecter) ListProjectsWithParams(ctx interface{}, args interface{}) *ProjectsApi_ListProjectsWithParams_Call {
+func (_e *ProjectsApi_Expecter) ListProjectsWithParams(ctx any, args any) *ProjectsApi_ListProjectsWithParams_Call {
 	return &ProjectsApi_ListProjectsWithParams_Call{Call: _e.mock.On("ListProjectsWithParams", ctx, args)}
 }
 
@@ -2633,7 +2633,7 @@ type ProjectsApi_MigrateProjectToAnotherOrg_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - groupMigrationRequest *admin.GroupMigrationRequest
-func (_e *ProjectsApi_Expecter) MigrateProjectToAnotherOrg(ctx interface{}, groupId interface{}, groupMigrationRequest interface{}) *ProjectsApi_MigrateProjectToAnotherOrg_Call {
+func (_e *ProjectsApi_Expecter) MigrateProjectToAnotherOrg(ctx any, groupId any, groupMigrationRequest any) *ProjectsApi_MigrateProjectToAnotherOrg_Call {
 	return &ProjectsApi_MigrateProjectToAnotherOrg_Call{Call: _e.mock.On("MigrateProjectToAnotherOrg", ctx, groupId, groupMigrationRequest)}
 }
 
@@ -2700,7 +2700,7 @@ type ProjectsApi_MigrateProjectToAnotherOrgExecute_Call struct {
 
 // MigrateProjectToAnotherOrgExecute is a helper method to define mock.On call
 //   - r admin.MigrateProjectToAnotherOrgApiRequest
-func (_e *ProjectsApi_Expecter) MigrateProjectToAnotherOrgExecute(r interface{}) *ProjectsApi_MigrateProjectToAnotherOrgExecute_Call {
+func (_e *ProjectsApi_Expecter) MigrateProjectToAnotherOrgExecute(r any) *ProjectsApi_MigrateProjectToAnotherOrgExecute_Call {
 	return &ProjectsApi_MigrateProjectToAnotherOrgExecute_Call{Call: _e.mock.On("MigrateProjectToAnotherOrgExecute", r)}
 }
 
@@ -2747,7 +2747,7 @@ type ProjectsApi_MigrateProjectToAnotherOrgWithParams_Call struct {
 // MigrateProjectToAnotherOrgWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.MigrateProjectToAnotherOrgApiParams
-func (_e *ProjectsApi_Expecter) MigrateProjectToAnotherOrgWithParams(ctx interface{}, args interface{}) *ProjectsApi_MigrateProjectToAnotherOrgWithParams_Call {
+func (_e *ProjectsApi_Expecter) MigrateProjectToAnotherOrgWithParams(ctx any, args any) *ProjectsApi_MigrateProjectToAnotherOrgWithParams_Call {
 	return &ProjectsApi_MigrateProjectToAnotherOrgWithParams_Call{Call: _e.mock.On("MigrateProjectToAnotherOrgWithParams", ctx, args)}
 }
 
@@ -2795,7 +2795,7 @@ type ProjectsApi_RemoveProjectUser_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - userId string
-func (_e *ProjectsApi_Expecter) RemoveProjectUser(ctx interface{}, groupId interface{}, userId interface{}) *ProjectsApi_RemoveProjectUser_Call {
+func (_e *ProjectsApi_Expecter) RemoveProjectUser(ctx any, groupId any, userId any) *ProjectsApi_RemoveProjectUser_Call {
 	return &ProjectsApi_RemoveProjectUser_Call{Call: _e.mock.On("RemoveProjectUser", ctx, groupId, userId)}
 }
 
@@ -2853,7 +2853,7 @@ type ProjectsApi_RemoveProjectUserExecute_Call struct {
 
 // RemoveProjectUserExecute is a helper method to define mock.On call
 //   - r admin.RemoveProjectUserApiRequest
-func (_e *ProjectsApi_Expecter) RemoveProjectUserExecute(r interface{}) *ProjectsApi_RemoveProjectUserExecute_Call {
+func (_e *ProjectsApi_Expecter) RemoveProjectUserExecute(r any) *ProjectsApi_RemoveProjectUserExecute_Call {
 	return &ProjectsApi_RemoveProjectUserExecute_Call{Call: _e.mock.On("RemoveProjectUserExecute", r)}
 }
 
@@ -2900,7 +2900,7 @@ type ProjectsApi_RemoveProjectUserWithParams_Call struct {
 // RemoveProjectUserWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.RemoveProjectUserApiParams
-func (_e *ProjectsApi_Expecter) RemoveProjectUserWithParams(ctx interface{}, args interface{}) *ProjectsApi_RemoveProjectUserWithParams_Call {
+func (_e *ProjectsApi_Expecter) RemoveProjectUserWithParams(ctx any, args any) *ProjectsApi_RemoveProjectUserWithParams_Call {
 	return &ProjectsApi_RemoveProjectUserWithParams_Call{Call: _e.mock.On("RemoveProjectUserWithParams", ctx, args)}
 }
 
@@ -2947,7 +2947,7 @@ type ProjectsApi_ReturnAllIPAddresses_Call struct {
 // ReturnAllIPAddresses is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ProjectsApi_Expecter) ReturnAllIPAddresses(ctx interface{}, groupId interface{}) *ProjectsApi_ReturnAllIPAddresses_Call {
+func (_e *ProjectsApi_Expecter) ReturnAllIPAddresses(ctx any, groupId any) *ProjectsApi_ReturnAllIPAddresses_Call {
 	return &ProjectsApi_ReturnAllIPAddresses_Call{Call: _e.mock.On("ReturnAllIPAddresses", ctx, groupId)}
 }
 
@@ -3014,7 +3014,7 @@ type ProjectsApi_ReturnAllIPAddressesExecute_Call struct {
 
 // ReturnAllIPAddressesExecute is a helper method to define mock.On call
 //   - r admin.ReturnAllIPAddressesApiRequest
-func (_e *ProjectsApi_Expecter) ReturnAllIPAddressesExecute(r interface{}) *ProjectsApi_ReturnAllIPAddressesExecute_Call {
+func (_e *ProjectsApi_Expecter) ReturnAllIPAddressesExecute(r any) *ProjectsApi_ReturnAllIPAddressesExecute_Call {
 	return &ProjectsApi_ReturnAllIPAddressesExecute_Call{Call: _e.mock.On("ReturnAllIPAddressesExecute", r)}
 }
 
@@ -3061,7 +3061,7 @@ type ProjectsApi_ReturnAllIPAddressesWithParams_Call struct {
 // ReturnAllIPAddressesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ReturnAllIPAddressesApiParams
-func (_e *ProjectsApi_Expecter) ReturnAllIPAddressesWithParams(ctx interface{}, args interface{}) *ProjectsApi_ReturnAllIPAddressesWithParams_Call {
+func (_e *ProjectsApi_Expecter) ReturnAllIPAddressesWithParams(ctx any, args any) *ProjectsApi_ReturnAllIPAddressesWithParams_Call {
 	return &ProjectsApi_ReturnAllIPAddressesWithParams_Call{Call: _e.mock.On("ReturnAllIPAddressesWithParams", ctx, args)}
 }
 
@@ -3110,7 +3110,7 @@ type ProjectsApi_SetProjectLimit_Call struct {
 //   - limitName string
 //   - groupId string
 //   - dataFederationLimit *admin.DataFederationLimit
-func (_e *ProjectsApi_Expecter) SetProjectLimit(ctx interface{}, limitName interface{}, groupId interface{}, dataFederationLimit interface{}) *ProjectsApi_SetProjectLimit_Call {
+func (_e *ProjectsApi_Expecter) SetProjectLimit(ctx any, limitName any, groupId any, dataFederationLimit any) *ProjectsApi_SetProjectLimit_Call {
 	return &ProjectsApi_SetProjectLimit_Call{Call: _e.mock.On("SetProjectLimit", ctx, limitName, groupId, dataFederationLimit)}
 }
 
@@ -3177,7 +3177,7 @@ type ProjectsApi_SetProjectLimitExecute_Call struct {
 
 // SetProjectLimitExecute is a helper method to define mock.On call
 //   - r admin.SetProjectLimitApiRequest
-func (_e *ProjectsApi_Expecter) SetProjectLimitExecute(r interface{}) *ProjectsApi_SetProjectLimitExecute_Call {
+func (_e *ProjectsApi_Expecter) SetProjectLimitExecute(r any) *ProjectsApi_SetProjectLimitExecute_Call {
 	return &ProjectsApi_SetProjectLimitExecute_Call{Call: _e.mock.On("SetProjectLimitExecute", r)}
 }
 
@@ -3224,7 +3224,7 @@ type ProjectsApi_SetProjectLimitWithParams_Call struct {
 // SetProjectLimitWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.SetProjectLimitApiParams
-func (_e *ProjectsApi_Expecter) SetProjectLimitWithParams(ctx interface{}, args interface{}) *ProjectsApi_SetProjectLimitWithParams_Call {
+func (_e *ProjectsApi_Expecter) SetProjectLimitWithParams(ctx any, args any) *ProjectsApi_SetProjectLimitWithParams_Call {
 	return &ProjectsApi_SetProjectLimitWithParams_Call{Call: _e.mock.On("SetProjectLimitWithParams", ctx, args)}
 }
 
@@ -3272,7 +3272,7 @@ type ProjectsApi_UpdateProject_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - groupUpdate *admin.GroupUpdate
-func (_e *ProjectsApi_Expecter) UpdateProject(ctx interface{}, groupId interface{}, groupUpdate interface{}) *ProjectsApi_UpdateProject_Call {
+func (_e *ProjectsApi_Expecter) UpdateProject(ctx any, groupId any, groupUpdate any) *ProjectsApi_UpdateProject_Call {
 	return &ProjectsApi_UpdateProject_Call{Call: _e.mock.On("UpdateProject", ctx, groupId, groupUpdate)}
 }
 
@@ -3339,7 +3339,7 @@ type ProjectsApi_UpdateProjectExecute_Call struct {
 
 // UpdateProjectExecute is a helper method to define mock.On call
 //   - r admin.UpdateProjectApiRequest
-func (_e *ProjectsApi_Expecter) UpdateProjectExecute(r interface{}) *ProjectsApi_UpdateProjectExecute_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectExecute(r any) *ProjectsApi_UpdateProjectExecute_Call {
 	return &ProjectsApi_UpdateProjectExecute_Call{Call: _e.mock.On("UpdateProjectExecute", r)}
 }
 
@@ -3387,7 +3387,7 @@ type ProjectsApi_UpdateProjectInvitation_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - groupInvitationRequest *admin.GroupInvitationRequest
-func (_e *ProjectsApi_Expecter) UpdateProjectInvitation(ctx interface{}, groupId interface{}, groupInvitationRequest interface{}) *ProjectsApi_UpdateProjectInvitation_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectInvitation(ctx any, groupId any, groupInvitationRequest any) *ProjectsApi_UpdateProjectInvitation_Call {
 	return &ProjectsApi_UpdateProjectInvitation_Call{Call: _e.mock.On("UpdateProjectInvitation", ctx, groupId, groupInvitationRequest)}
 }
 
@@ -3436,7 +3436,7 @@ type ProjectsApi_UpdateProjectInvitationById_Call struct {
 //   - groupId string
 //   - invitationId string
 //   - groupInvitationUpdateRequest *admin.GroupInvitationUpdateRequest
-func (_e *ProjectsApi_Expecter) UpdateProjectInvitationById(ctx interface{}, groupId interface{}, invitationId interface{}, groupInvitationUpdateRequest interface{}) *ProjectsApi_UpdateProjectInvitationById_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectInvitationById(ctx any, groupId any, invitationId any, groupInvitationUpdateRequest any) *ProjectsApi_UpdateProjectInvitationById_Call {
 	return &ProjectsApi_UpdateProjectInvitationById_Call{Call: _e.mock.On("UpdateProjectInvitationById", ctx, groupId, invitationId, groupInvitationUpdateRequest)}
 }
 
@@ -3503,7 +3503,7 @@ type ProjectsApi_UpdateProjectInvitationByIdExecute_Call struct {
 
 // UpdateProjectInvitationByIdExecute is a helper method to define mock.On call
 //   - r admin.UpdateProjectInvitationByIdApiRequest
-func (_e *ProjectsApi_Expecter) UpdateProjectInvitationByIdExecute(r interface{}) *ProjectsApi_UpdateProjectInvitationByIdExecute_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectInvitationByIdExecute(r any) *ProjectsApi_UpdateProjectInvitationByIdExecute_Call {
 	return &ProjectsApi_UpdateProjectInvitationByIdExecute_Call{Call: _e.mock.On("UpdateProjectInvitationByIdExecute", r)}
 }
 
@@ -3550,7 +3550,7 @@ type ProjectsApi_UpdateProjectInvitationByIdWithParams_Call struct {
 // UpdateProjectInvitationByIdWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateProjectInvitationByIdApiParams
-func (_e *ProjectsApi_Expecter) UpdateProjectInvitationByIdWithParams(ctx interface{}, args interface{}) *ProjectsApi_UpdateProjectInvitationByIdWithParams_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectInvitationByIdWithParams(ctx any, args any) *ProjectsApi_UpdateProjectInvitationByIdWithParams_Call {
 	return &ProjectsApi_UpdateProjectInvitationByIdWithParams_Call{Call: _e.mock.On("UpdateProjectInvitationByIdWithParams", ctx, args)}
 }
 
@@ -3617,7 +3617,7 @@ type ProjectsApi_UpdateProjectInvitationExecute_Call struct {
 
 // UpdateProjectInvitationExecute is a helper method to define mock.On call
 //   - r admin.UpdateProjectInvitationApiRequest
-func (_e *ProjectsApi_Expecter) UpdateProjectInvitationExecute(r interface{}) *ProjectsApi_UpdateProjectInvitationExecute_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectInvitationExecute(r any) *ProjectsApi_UpdateProjectInvitationExecute_Call {
 	return &ProjectsApi_UpdateProjectInvitationExecute_Call{Call: _e.mock.On("UpdateProjectInvitationExecute", r)}
 }
 
@@ -3664,7 +3664,7 @@ type ProjectsApi_UpdateProjectInvitationWithParams_Call struct {
 // UpdateProjectInvitationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateProjectInvitationApiParams
-func (_e *ProjectsApi_Expecter) UpdateProjectInvitationWithParams(ctx interface{}, args interface{}) *ProjectsApi_UpdateProjectInvitationWithParams_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectInvitationWithParams(ctx any, args any) *ProjectsApi_UpdateProjectInvitationWithParams_Call {
 	return &ProjectsApi_UpdateProjectInvitationWithParams_Call{Call: _e.mock.On("UpdateProjectInvitationWithParams", ctx, args)}
 }
 
@@ -3713,7 +3713,7 @@ type ProjectsApi_UpdateProjectRoles_Call struct {
 //   - groupId string
 //   - userId string
 //   - updateGroupRolesForUser *admin.UpdateGroupRolesForUser
-func (_e *ProjectsApi_Expecter) UpdateProjectRoles(ctx interface{}, groupId interface{}, userId interface{}, updateGroupRolesForUser interface{}) *ProjectsApi_UpdateProjectRoles_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectRoles(ctx any, groupId any, userId any, updateGroupRolesForUser any) *ProjectsApi_UpdateProjectRoles_Call {
 	return &ProjectsApi_UpdateProjectRoles_Call{Call: _e.mock.On("UpdateProjectRoles", ctx, groupId, userId, updateGroupRolesForUser)}
 }
 
@@ -3780,7 +3780,7 @@ type ProjectsApi_UpdateProjectRolesExecute_Call struct {
 
 // UpdateProjectRolesExecute is a helper method to define mock.On call
 //   - r admin.UpdateProjectRolesApiRequest
-func (_e *ProjectsApi_Expecter) UpdateProjectRolesExecute(r interface{}) *ProjectsApi_UpdateProjectRolesExecute_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectRolesExecute(r any) *ProjectsApi_UpdateProjectRolesExecute_Call {
 	return &ProjectsApi_UpdateProjectRolesExecute_Call{Call: _e.mock.On("UpdateProjectRolesExecute", r)}
 }
 
@@ -3827,7 +3827,7 @@ type ProjectsApi_UpdateProjectRolesWithParams_Call struct {
 // UpdateProjectRolesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateProjectRolesApiParams
-func (_e *ProjectsApi_Expecter) UpdateProjectRolesWithParams(ctx interface{}, args interface{}) *ProjectsApi_UpdateProjectRolesWithParams_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectRolesWithParams(ctx any, args any) *ProjectsApi_UpdateProjectRolesWithParams_Call {
 	return &ProjectsApi_UpdateProjectRolesWithParams_Call{Call: _e.mock.On("UpdateProjectRolesWithParams", ctx, args)}
 }
 
@@ -3875,7 +3875,7 @@ type ProjectsApi_UpdateProjectSettings_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - groupSettings *admin.GroupSettings
-func (_e *ProjectsApi_Expecter) UpdateProjectSettings(ctx interface{}, groupId interface{}, groupSettings interface{}) *ProjectsApi_UpdateProjectSettings_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectSettings(ctx any, groupId any, groupSettings any) *ProjectsApi_UpdateProjectSettings_Call {
 	return &ProjectsApi_UpdateProjectSettings_Call{Call: _e.mock.On("UpdateProjectSettings", ctx, groupId, groupSettings)}
 }
 
@@ -3942,7 +3942,7 @@ type ProjectsApi_UpdateProjectSettingsExecute_Call struct {
 
 // UpdateProjectSettingsExecute is a helper method to define mock.On call
 //   - r admin.UpdateProjectSettingsApiRequest
-func (_e *ProjectsApi_Expecter) UpdateProjectSettingsExecute(r interface{}) *ProjectsApi_UpdateProjectSettingsExecute_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectSettingsExecute(r any) *ProjectsApi_UpdateProjectSettingsExecute_Call {
 	return &ProjectsApi_UpdateProjectSettingsExecute_Call{Call: _e.mock.On("UpdateProjectSettingsExecute", r)}
 }
 
@@ -3989,7 +3989,7 @@ type ProjectsApi_UpdateProjectSettingsWithParams_Call struct {
 // UpdateProjectSettingsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateProjectSettingsApiParams
-func (_e *ProjectsApi_Expecter) UpdateProjectSettingsWithParams(ctx interface{}, args interface{}) *ProjectsApi_UpdateProjectSettingsWithParams_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectSettingsWithParams(ctx any, args any) *ProjectsApi_UpdateProjectSettingsWithParams_Call {
 	return &ProjectsApi_UpdateProjectSettingsWithParams_Call{Call: _e.mock.On("UpdateProjectSettingsWithParams", ctx, args)}
 }
 
@@ -4036,7 +4036,7 @@ type ProjectsApi_UpdateProjectWithParams_Call struct {
 // UpdateProjectWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateProjectApiParams
-func (_e *ProjectsApi_Expecter) UpdateProjectWithParams(ctx interface{}, args interface{}) *ProjectsApi_UpdateProjectWithParams_Call {
+func (_e *ProjectsApi_Expecter) UpdateProjectWithParams(ctx any, args any) *ProjectsApi_UpdateProjectWithParams_Call {
 	return &ProjectsApi_UpdateProjectWithParams_Call{Call: _e.mock.On("UpdateProjectWithParams", ctx, args)}
 }
 

--- a/mockadmin/push_based_log_export_api.go
+++ b/mockadmin/push_based_log_export_api.go
@@ -52,7 +52,7 @@ type PushBasedLogExportApi_CreatePushBasedLogConfiguration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - createPushBasedLogExportProjectRequest *admin.CreatePushBasedLogExportProjectRequest
-func (_e *PushBasedLogExportApi_Expecter) CreatePushBasedLogConfiguration(ctx interface{}, groupId interface{}, createPushBasedLogExportProjectRequest interface{}) *PushBasedLogExportApi_CreatePushBasedLogConfiguration_Call {
+func (_e *PushBasedLogExportApi_Expecter) CreatePushBasedLogConfiguration(ctx any, groupId any, createPushBasedLogExportProjectRequest any) *PushBasedLogExportApi_CreatePushBasedLogConfiguration_Call {
 	return &PushBasedLogExportApi_CreatePushBasedLogConfiguration_Call{Call: _e.mock.On("CreatePushBasedLogConfiguration", ctx, groupId, createPushBasedLogExportProjectRequest)}
 }
 
@@ -110,7 +110,7 @@ type PushBasedLogExportApi_CreatePushBasedLogConfigurationExecute_Call struct {
 
 // CreatePushBasedLogConfigurationExecute is a helper method to define mock.On call
 //   - r admin.CreatePushBasedLogConfigurationApiRequest
-func (_e *PushBasedLogExportApi_Expecter) CreatePushBasedLogConfigurationExecute(r interface{}) *PushBasedLogExportApi_CreatePushBasedLogConfigurationExecute_Call {
+func (_e *PushBasedLogExportApi_Expecter) CreatePushBasedLogConfigurationExecute(r any) *PushBasedLogExportApi_CreatePushBasedLogConfigurationExecute_Call {
 	return &PushBasedLogExportApi_CreatePushBasedLogConfigurationExecute_Call{Call: _e.mock.On("CreatePushBasedLogConfigurationExecute", r)}
 }
 
@@ -157,7 +157,7 @@ type PushBasedLogExportApi_CreatePushBasedLogConfigurationWithParams_Call struct
 // CreatePushBasedLogConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreatePushBasedLogConfigurationApiParams
-func (_e *PushBasedLogExportApi_Expecter) CreatePushBasedLogConfigurationWithParams(ctx interface{}, args interface{}) *PushBasedLogExportApi_CreatePushBasedLogConfigurationWithParams_Call {
+func (_e *PushBasedLogExportApi_Expecter) CreatePushBasedLogConfigurationWithParams(ctx any, args any) *PushBasedLogExportApi_CreatePushBasedLogConfigurationWithParams_Call {
 	return &PushBasedLogExportApi_CreatePushBasedLogConfigurationWithParams_Call{Call: _e.mock.On("CreatePushBasedLogConfigurationWithParams", ctx, args)}
 }
 
@@ -204,7 +204,7 @@ type PushBasedLogExportApi_DeletePushBasedLogConfiguration_Call struct {
 // DeletePushBasedLogConfiguration is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *PushBasedLogExportApi_Expecter) DeletePushBasedLogConfiguration(ctx interface{}, groupId interface{}) *PushBasedLogExportApi_DeletePushBasedLogConfiguration_Call {
+func (_e *PushBasedLogExportApi_Expecter) DeletePushBasedLogConfiguration(ctx any, groupId any) *PushBasedLogExportApi_DeletePushBasedLogConfiguration_Call {
 	return &PushBasedLogExportApi_DeletePushBasedLogConfiguration_Call{Call: _e.mock.On("DeletePushBasedLogConfiguration", ctx, groupId)}
 }
 
@@ -262,7 +262,7 @@ type PushBasedLogExportApi_DeletePushBasedLogConfigurationExecute_Call struct {
 
 // DeletePushBasedLogConfigurationExecute is a helper method to define mock.On call
 //   - r admin.DeletePushBasedLogConfigurationApiRequest
-func (_e *PushBasedLogExportApi_Expecter) DeletePushBasedLogConfigurationExecute(r interface{}) *PushBasedLogExportApi_DeletePushBasedLogConfigurationExecute_Call {
+func (_e *PushBasedLogExportApi_Expecter) DeletePushBasedLogConfigurationExecute(r any) *PushBasedLogExportApi_DeletePushBasedLogConfigurationExecute_Call {
 	return &PushBasedLogExportApi_DeletePushBasedLogConfigurationExecute_Call{Call: _e.mock.On("DeletePushBasedLogConfigurationExecute", r)}
 }
 
@@ -309,7 +309,7 @@ type PushBasedLogExportApi_DeletePushBasedLogConfigurationWithParams_Call struct
 // DeletePushBasedLogConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeletePushBasedLogConfigurationApiParams
-func (_e *PushBasedLogExportApi_Expecter) DeletePushBasedLogConfigurationWithParams(ctx interface{}, args interface{}) *PushBasedLogExportApi_DeletePushBasedLogConfigurationWithParams_Call {
+func (_e *PushBasedLogExportApi_Expecter) DeletePushBasedLogConfigurationWithParams(ctx any, args any) *PushBasedLogExportApi_DeletePushBasedLogConfigurationWithParams_Call {
 	return &PushBasedLogExportApi_DeletePushBasedLogConfigurationWithParams_Call{Call: _e.mock.On("DeletePushBasedLogConfigurationWithParams", ctx, args)}
 }
 
@@ -356,7 +356,7 @@ type PushBasedLogExportApi_GetPushBasedLogConfiguration_Call struct {
 // GetPushBasedLogConfiguration is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *PushBasedLogExportApi_Expecter) GetPushBasedLogConfiguration(ctx interface{}, groupId interface{}) *PushBasedLogExportApi_GetPushBasedLogConfiguration_Call {
+func (_e *PushBasedLogExportApi_Expecter) GetPushBasedLogConfiguration(ctx any, groupId any) *PushBasedLogExportApi_GetPushBasedLogConfiguration_Call {
 	return &PushBasedLogExportApi_GetPushBasedLogConfiguration_Call{Call: _e.mock.On("GetPushBasedLogConfiguration", ctx, groupId)}
 }
 
@@ -423,7 +423,7 @@ type PushBasedLogExportApi_GetPushBasedLogConfigurationExecute_Call struct {
 
 // GetPushBasedLogConfigurationExecute is a helper method to define mock.On call
 //   - r admin.GetPushBasedLogConfigurationApiRequest
-func (_e *PushBasedLogExportApi_Expecter) GetPushBasedLogConfigurationExecute(r interface{}) *PushBasedLogExportApi_GetPushBasedLogConfigurationExecute_Call {
+func (_e *PushBasedLogExportApi_Expecter) GetPushBasedLogConfigurationExecute(r any) *PushBasedLogExportApi_GetPushBasedLogConfigurationExecute_Call {
 	return &PushBasedLogExportApi_GetPushBasedLogConfigurationExecute_Call{Call: _e.mock.On("GetPushBasedLogConfigurationExecute", r)}
 }
 
@@ -470,7 +470,7 @@ type PushBasedLogExportApi_GetPushBasedLogConfigurationWithParams_Call struct {
 // GetPushBasedLogConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetPushBasedLogConfigurationApiParams
-func (_e *PushBasedLogExportApi_Expecter) GetPushBasedLogConfigurationWithParams(ctx interface{}, args interface{}) *PushBasedLogExportApi_GetPushBasedLogConfigurationWithParams_Call {
+func (_e *PushBasedLogExportApi_Expecter) GetPushBasedLogConfigurationWithParams(ctx any, args any) *PushBasedLogExportApi_GetPushBasedLogConfigurationWithParams_Call {
 	return &PushBasedLogExportApi_GetPushBasedLogConfigurationWithParams_Call{Call: _e.mock.On("GetPushBasedLogConfigurationWithParams", ctx, args)}
 }
 
@@ -518,7 +518,7 @@ type PushBasedLogExportApi_UpdatePushBasedLogConfiguration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - pushBasedLogExportProject *admin.PushBasedLogExportProject
-func (_e *PushBasedLogExportApi_Expecter) UpdatePushBasedLogConfiguration(ctx interface{}, groupId interface{}, pushBasedLogExportProject interface{}) *PushBasedLogExportApi_UpdatePushBasedLogConfiguration_Call {
+func (_e *PushBasedLogExportApi_Expecter) UpdatePushBasedLogConfiguration(ctx any, groupId any, pushBasedLogExportProject any) *PushBasedLogExportApi_UpdatePushBasedLogConfiguration_Call {
 	return &PushBasedLogExportApi_UpdatePushBasedLogConfiguration_Call{Call: _e.mock.On("UpdatePushBasedLogConfiguration", ctx, groupId, pushBasedLogExportProject)}
 }
 
@@ -576,7 +576,7 @@ type PushBasedLogExportApi_UpdatePushBasedLogConfigurationExecute_Call struct {
 
 // UpdatePushBasedLogConfigurationExecute is a helper method to define mock.On call
 //   - r admin.UpdatePushBasedLogConfigurationApiRequest
-func (_e *PushBasedLogExportApi_Expecter) UpdatePushBasedLogConfigurationExecute(r interface{}) *PushBasedLogExportApi_UpdatePushBasedLogConfigurationExecute_Call {
+func (_e *PushBasedLogExportApi_Expecter) UpdatePushBasedLogConfigurationExecute(r any) *PushBasedLogExportApi_UpdatePushBasedLogConfigurationExecute_Call {
 	return &PushBasedLogExportApi_UpdatePushBasedLogConfigurationExecute_Call{Call: _e.mock.On("UpdatePushBasedLogConfigurationExecute", r)}
 }
 
@@ -623,7 +623,7 @@ type PushBasedLogExportApi_UpdatePushBasedLogConfigurationWithParams_Call struct
 // UpdatePushBasedLogConfigurationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdatePushBasedLogConfigurationApiParams
-func (_e *PushBasedLogExportApi_Expecter) UpdatePushBasedLogConfigurationWithParams(ctx interface{}, args interface{}) *PushBasedLogExportApi_UpdatePushBasedLogConfigurationWithParams_Call {
+func (_e *PushBasedLogExportApi_Expecter) UpdatePushBasedLogConfigurationWithParams(ctx any, args any) *PushBasedLogExportApi_UpdatePushBasedLogConfigurationWithParams_Call {
 	return &PushBasedLogExportApi_UpdatePushBasedLogConfigurationWithParams_Call{Call: _e.mock.On("UpdatePushBasedLogConfigurationWithParams", ctx, args)}
 }
 

--- a/mockadmin/resource_policies_api.go
+++ b/mockadmin/resource_policies_api.go
@@ -52,7 +52,7 @@ type ResourcePoliciesApi_CreateAtlasResourcePolicy_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - apiAtlasResourcePolicyCreate *admin.ApiAtlasResourcePolicyCreate
-func (_e *ResourcePoliciesApi_Expecter) CreateAtlasResourcePolicy(ctx interface{}, orgId interface{}, apiAtlasResourcePolicyCreate interface{}) *ResourcePoliciesApi_CreateAtlasResourcePolicy_Call {
+func (_e *ResourcePoliciesApi_Expecter) CreateAtlasResourcePolicy(ctx any, orgId any, apiAtlasResourcePolicyCreate any) *ResourcePoliciesApi_CreateAtlasResourcePolicy_Call {
 	return &ResourcePoliciesApi_CreateAtlasResourcePolicy_Call{Call: _e.mock.On("CreateAtlasResourcePolicy", ctx, orgId, apiAtlasResourcePolicyCreate)}
 }
 
@@ -119,7 +119,7 @@ type ResourcePoliciesApi_CreateAtlasResourcePolicyExecute_Call struct {
 
 // CreateAtlasResourcePolicyExecute is a helper method to define mock.On call
 //   - r admin.CreateAtlasResourcePolicyApiRequest
-func (_e *ResourcePoliciesApi_Expecter) CreateAtlasResourcePolicyExecute(r interface{}) *ResourcePoliciesApi_CreateAtlasResourcePolicyExecute_Call {
+func (_e *ResourcePoliciesApi_Expecter) CreateAtlasResourcePolicyExecute(r any) *ResourcePoliciesApi_CreateAtlasResourcePolicyExecute_Call {
 	return &ResourcePoliciesApi_CreateAtlasResourcePolicyExecute_Call{Call: _e.mock.On("CreateAtlasResourcePolicyExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type ResourcePoliciesApi_CreateAtlasResourcePolicyWithParams_Call struct {
 // CreateAtlasResourcePolicyWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateAtlasResourcePolicyApiParams
-func (_e *ResourcePoliciesApi_Expecter) CreateAtlasResourcePolicyWithParams(ctx interface{}, args interface{}) *ResourcePoliciesApi_CreateAtlasResourcePolicyWithParams_Call {
+func (_e *ResourcePoliciesApi_Expecter) CreateAtlasResourcePolicyWithParams(ctx any, args any) *ResourcePoliciesApi_CreateAtlasResourcePolicyWithParams_Call {
 	return &ResourcePoliciesApi_CreateAtlasResourcePolicyWithParams_Call{Call: _e.mock.On("CreateAtlasResourcePolicyWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type ResourcePoliciesApi_DeleteAtlasResourcePolicy_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - resourcePolicyId string
-func (_e *ResourcePoliciesApi_Expecter) DeleteAtlasResourcePolicy(ctx interface{}, orgId interface{}, resourcePolicyId interface{}) *ResourcePoliciesApi_DeleteAtlasResourcePolicy_Call {
+func (_e *ResourcePoliciesApi_Expecter) DeleteAtlasResourcePolicy(ctx any, orgId any, resourcePolicyId any) *ResourcePoliciesApi_DeleteAtlasResourcePolicy_Call {
 	return &ResourcePoliciesApi_DeleteAtlasResourcePolicy_Call{Call: _e.mock.On("DeleteAtlasResourcePolicy", ctx, orgId, resourcePolicyId)}
 }
 
@@ -236,24 +236,24 @@ func (_c *ResourcePoliciesApi_DeleteAtlasResourcePolicy_Call) RunAndReturn(run f
 }
 
 // DeleteAtlasResourcePolicyExecute provides a mock function with given fields: r
-func (_m *ResourcePoliciesApi) DeleteAtlasResourcePolicyExecute(r admin.DeleteAtlasResourcePolicyApiRequest) (interface{}, *http.Response, error) {
+func (_m *ResourcePoliciesApi) DeleteAtlasResourcePolicyExecute(r admin.DeleteAtlasResourcePolicyApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteAtlasResourcePolicyExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasResourcePolicyApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasResourcePolicyApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasResourcePolicyApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteAtlasResourcePolicyApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -281,7 +281,7 @@ type ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call struct {
 
 // DeleteAtlasResourcePolicyExecute is a helper method to define mock.On call
 //   - r admin.DeleteAtlasResourcePolicyApiRequest
-func (_e *ResourcePoliciesApi_Expecter) DeleteAtlasResourcePolicyExecute(r interface{}) *ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call {
+func (_e *ResourcePoliciesApi_Expecter) DeleteAtlasResourcePolicyExecute(r any) *ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call {
 	return &ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call{Call: _e.mock.On("DeleteAtlasResourcePolicyExecute", r)}
 }
 
@@ -292,12 +292,12 @@ func (_c *ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call) Run(run fun
 	return _c
 }
 
-func (_c *ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call {
+func (_c *ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call) RunAndReturn(run func(admin.DeleteAtlasResourcePolicyApiRequest) (interface{}, *http.Response, error)) *ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call {
+func (_c *ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call) RunAndReturn(run func(admin.DeleteAtlasResourcePolicyApiRequest) (any, *http.Response, error)) *ResourcePoliciesApi_DeleteAtlasResourcePolicyExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -328,7 +328,7 @@ type ResourcePoliciesApi_DeleteAtlasResourcePolicyWithParams_Call struct {
 // DeleteAtlasResourcePolicyWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteAtlasResourcePolicyApiParams
-func (_e *ResourcePoliciesApi_Expecter) DeleteAtlasResourcePolicyWithParams(ctx interface{}, args interface{}) *ResourcePoliciesApi_DeleteAtlasResourcePolicyWithParams_Call {
+func (_e *ResourcePoliciesApi_Expecter) DeleteAtlasResourcePolicyWithParams(ctx any, args any) *ResourcePoliciesApi_DeleteAtlasResourcePolicyWithParams_Call {
 	return &ResourcePoliciesApi_DeleteAtlasResourcePolicyWithParams_Call{Call: _e.mock.On("DeleteAtlasResourcePolicyWithParams", ctx, args)}
 }
 
@@ -375,7 +375,7 @@ type ResourcePoliciesApi_GetAtlasResourcePolicies_Call struct {
 // GetAtlasResourcePolicies is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *ResourcePoliciesApi_Expecter) GetAtlasResourcePolicies(ctx interface{}, orgId interface{}) *ResourcePoliciesApi_GetAtlasResourcePolicies_Call {
+func (_e *ResourcePoliciesApi_Expecter) GetAtlasResourcePolicies(ctx any, orgId any) *ResourcePoliciesApi_GetAtlasResourcePolicies_Call {
 	return &ResourcePoliciesApi_GetAtlasResourcePolicies_Call{Call: _e.mock.On("GetAtlasResourcePolicies", ctx, orgId)}
 }
 
@@ -442,7 +442,7 @@ type ResourcePoliciesApi_GetAtlasResourcePoliciesExecute_Call struct {
 
 // GetAtlasResourcePoliciesExecute is a helper method to define mock.On call
 //   - r admin.GetAtlasResourcePoliciesApiRequest
-func (_e *ResourcePoliciesApi_Expecter) GetAtlasResourcePoliciesExecute(r interface{}) *ResourcePoliciesApi_GetAtlasResourcePoliciesExecute_Call {
+func (_e *ResourcePoliciesApi_Expecter) GetAtlasResourcePoliciesExecute(r any) *ResourcePoliciesApi_GetAtlasResourcePoliciesExecute_Call {
 	return &ResourcePoliciesApi_GetAtlasResourcePoliciesExecute_Call{Call: _e.mock.On("GetAtlasResourcePoliciesExecute", r)}
 }
 
@@ -489,7 +489,7 @@ type ResourcePoliciesApi_GetAtlasResourcePoliciesWithParams_Call struct {
 // GetAtlasResourcePoliciesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetAtlasResourcePoliciesApiParams
-func (_e *ResourcePoliciesApi_Expecter) GetAtlasResourcePoliciesWithParams(ctx interface{}, args interface{}) *ResourcePoliciesApi_GetAtlasResourcePoliciesWithParams_Call {
+func (_e *ResourcePoliciesApi_Expecter) GetAtlasResourcePoliciesWithParams(ctx any, args any) *ResourcePoliciesApi_GetAtlasResourcePoliciesWithParams_Call {
 	return &ResourcePoliciesApi_GetAtlasResourcePoliciesWithParams_Call{Call: _e.mock.On("GetAtlasResourcePoliciesWithParams", ctx, args)}
 }
 
@@ -537,7 +537,7 @@ type ResourcePoliciesApi_GetAtlasResourcePolicy_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - resourcePolicyId string
-func (_e *ResourcePoliciesApi_Expecter) GetAtlasResourcePolicy(ctx interface{}, orgId interface{}, resourcePolicyId interface{}) *ResourcePoliciesApi_GetAtlasResourcePolicy_Call {
+func (_e *ResourcePoliciesApi_Expecter) GetAtlasResourcePolicy(ctx any, orgId any, resourcePolicyId any) *ResourcePoliciesApi_GetAtlasResourcePolicy_Call {
 	return &ResourcePoliciesApi_GetAtlasResourcePolicy_Call{Call: _e.mock.On("GetAtlasResourcePolicy", ctx, orgId, resourcePolicyId)}
 }
 
@@ -604,7 +604,7 @@ type ResourcePoliciesApi_GetAtlasResourcePolicyExecute_Call struct {
 
 // GetAtlasResourcePolicyExecute is a helper method to define mock.On call
 //   - r admin.GetAtlasResourcePolicyApiRequest
-func (_e *ResourcePoliciesApi_Expecter) GetAtlasResourcePolicyExecute(r interface{}) *ResourcePoliciesApi_GetAtlasResourcePolicyExecute_Call {
+func (_e *ResourcePoliciesApi_Expecter) GetAtlasResourcePolicyExecute(r any) *ResourcePoliciesApi_GetAtlasResourcePolicyExecute_Call {
 	return &ResourcePoliciesApi_GetAtlasResourcePolicyExecute_Call{Call: _e.mock.On("GetAtlasResourcePolicyExecute", r)}
 }
 
@@ -651,7 +651,7 @@ type ResourcePoliciesApi_GetAtlasResourcePolicyWithParams_Call struct {
 // GetAtlasResourcePolicyWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetAtlasResourcePolicyApiParams
-func (_e *ResourcePoliciesApi_Expecter) GetAtlasResourcePolicyWithParams(ctx interface{}, args interface{}) *ResourcePoliciesApi_GetAtlasResourcePolicyWithParams_Call {
+func (_e *ResourcePoliciesApi_Expecter) GetAtlasResourcePolicyWithParams(ctx any, args any) *ResourcePoliciesApi_GetAtlasResourcePolicyWithParams_Call {
 	return &ResourcePoliciesApi_GetAtlasResourcePolicyWithParams_Call{Call: _e.mock.On("GetAtlasResourcePolicyWithParams", ctx, args)}
 }
 
@@ -698,7 +698,7 @@ type ResourcePoliciesApi_GetResourcesNonCompliant_Call struct {
 // GetResourcesNonCompliant is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *ResourcePoliciesApi_Expecter) GetResourcesNonCompliant(ctx interface{}, orgId interface{}) *ResourcePoliciesApi_GetResourcesNonCompliant_Call {
+func (_e *ResourcePoliciesApi_Expecter) GetResourcesNonCompliant(ctx any, orgId any) *ResourcePoliciesApi_GetResourcesNonCompliant_Call {
 	return &ResourcePoliciesApi_GetResourcesNonCompliant_Call{Call: _e.mock.On("GetResourcesNonCompliant", ctx, orgId)}
 }
 
@@ -765,7 +765,7 @@ type ResourcePoliciesApi_GetResourcesNonCompliantExecute_Call struct {
 
 // GetResourcesNonCompliantExecute is a helper method to define mock.On call
 //   - r admin.GetResourcesNonCompliantApiRequest
-func (_e *ResourcePoliciesApi_Expecter) GetResourcesNonCompliantExecute(r interface{}) *ResourcePoliciesApi_GetResourcesNonCompliantExecute_Call {
+func (_e *ResourcePoliciesApi_Expecter) GetResourcesNonCompliantExecute(r any) *ResourcePoliciesApi_GetResourcesNonCompliantExecute_Call {
 	return &ResourcePoliciesApi_GetResourcesNonCompliantExecute_Call{Call: _e.mock.On("GetResourcesNonCompliantExecute", r)}
 }
 
@@ -812,7 +812,7 @@ type ResourcePoliciesApi_GetResourcesNonCompliantWithParams_Call struct {
 // GetResourcesNonCompliantWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetResourcesNonCompliantApiParams
-func (_e *ResourcePoliciesApi_Expecter) GetResourcesNonCompliantWithParams(ctx interface{}, args interface{}) *ResourcePoliciesApi_GetResourcesNonCompliantWithParams_Call {
+func (_e *ResourcePoliciesApi_Expecter) GetResourcesNonCompliantWithParams(ctx any, args any) *ResourcePoliciesApi_GetResourcesNonCompliantWithParams_Call {
 	return &ResourcePoliciesApi_GetResourcesNonCompliantWithParams_Call{Call: _e.mock.On("GetResourcesNonCompliantWithParams", ctx, args)}
 }
 
@@ -861,7 +861,7 @@ type ResourcePoliciesApi_UpdateAtlasResourcePolicy_Call struct {
 //   - orgId string
 //   - resourcePolicyId string
 //   - apiAtlasResourcePolicyEdit *admin.ApiAtlasResourcePolicyEdit
-func (_e *ResourcePoliciesApi_Expecter) UpdateAtlasResourcePolicy(ctx interface{}, orgId interface{}, resourcePolicyId interface{}, apiAtlasResourcePolicyEdit interface{}) *ResourcePoliciesApi_UpdateAtlasResourcePolicy_Call {
+func (_e *ResourcePoliciesApi_Expecter) UpdateAtlasResourcePolicy(ctx any, orgId any, resourcePolicyId any, apiAtlasResourcePolicyEdit any) *ResourcePoliciesApi_UpdateAtlasResourcePolicy_Call {
 	return &ResourcePoliciesApi_UpdateAtlasResourcePolicy_Call{Call: _e.mock.On("UpdateAtlasResourcePolicy", ctx, orgId, resourcePolicyId, apiAtlasResourcePolicyEdit)}
 }
 
@@ -928,7 +928,7 @@ type ResourcePoliciesApi_UpdateAtlasResourcePolicyExecute_Call struct {
 
 // UpdateAtlasResourcePolicyExecute is a helper method to define mock.On call
 //   - r admin.UpdateAtlasResourcePolicyApiRequest
-func (_e *ResourcePoliciesApi_Expecter) UpdateAtlasResourcePolicyExecute(r interface{}) *ResourcePoliciesApi_UpdateAtlasResourcePolicyExecute_Call {
+func (_e *ResourcePoliciesApi_Expecter) UpdateAtlasResourcePolicyExecute(r any) *ResourcePoliciesApi_UpdateAtlasResourcePolicyExecute_Call {
 	return &ResourcePoliciesApi_UpdateAtlasResourcePolicyExecute_Call{Call: _e.mock.On("UpdateAtlasResourcePolicyExecute", r)}
 }
 
@@ -975,7 +975,7 @@ type ResourcePoliciesApi_UpdateAtlasResourcePolicyWithParams_Call struct {
 // UpdateAtlasResourcePolicyWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateAtlasResourcePolicyApiParams
-func (_e *ResourcePoliciesApi_Expecter) UpdateAtlasResourcePolicyWithParams(ctx interface{}, args interface{}) *ResourcePoliciesApi_UpdateAtlasResourcePolicyWithParams_Call {
+func (_e *ResourcePoliciesApi_Expecter) UpdateAtlasResourcePolicyWithParams(ctx any, args any) *ResourcePoliciesApi_UpdateAtlasResourcePolicyWithParams_Call {
 	return &ResourcePoliciesApi_UpdateAtlasResourcePolicyWithParams_Call{Call: _e.mock.On("UpdateAtlasResourcePolicyWithParams", ctx, args)}
 }
 
@@ -1023,7 +1023,7 @@ type ResourcePoliciesApi_ValidateAtlasResourcePolicy_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - apiAtlasResourcePolicyCreate *admin.ApiAtlasResourcePolicyCreate
-func (_e *ResourcePoliciesApi_Expecter) ValidateAtlasResourcePolicy(ctx interface{}, orgId interface{}, apiAtlasResourcePolicyCreate interface{}) *ResourcePoliciesApi_ValidateAtlasResourcePolicy_Call {
+func (_e *ResourcePoliciesApi_Expecter) ValidateAtlasResourcePolicy(ctx any, orgId any, apiAtlasResourcePolicyCreate any) *ResourcePoliciesApi_ValidateAtlasResourcePolicy_Call {
 	return &ResourcePoliciesApi_ValidateAtlasResourcePolicy_Call{Call: _e.mock.On("ValidateAtlasResourcePolicy", ctx, orgId, apiAtlasResourcePolicyCreate)}
 }
 
@@ -1090,7 +1090,7 @@ type ResourcePoliciesApi_ValidateAtlasResourcePolicyExecute_Call struct {
 
 // ValidateAtlasResourcePolicyExecute is a helper method to define mock.On call
 //   - r admin.ValidateAtlasResourcePolicyApiRequest
-func (_e *ResourcePoliciesApi_Expecter) ValidateAtlasResourcePolicyExecute(r interface{}) *ResourcePoliciesApi_ValidateAtlasResourcePolicyExecute_Call {
+func (_e *ResourcePoliciesApi_Expecter) ValidateAtlasResourcePolicyExecute(r any) *ResourcePoliciesApi_ValidateAtlasResourcePolicyExecute_Call {
 	return &ResourcePoliciesApi_ValidateAtlasResourcePolicyExecute_Call{Call: _e.mock.On("ValidateAtlasResourcePolicyExecute", r)}
 }
 
@@ -1137,7 +1137,7 @@ type ResourcePoliciesApi_ValidateAtlasResourcePolicyWithParams_Call struct {
 // ValidateAtlasResourcePolicyWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ValidateAtlasResourcePolicyApiParams
-func (_e *ResourcePoliciesApi_Expecter) ValidateAtlasResourcePolicyWithParams(ctx interface{}, args interface{}) *ResourcePoliciesApi_ValidateAtlasResourcePolicyWithParams_Call {
+func (_e *ResourcePoliciesApi_Expecter) ValidateAtlasResourcePolicyWithParams(ctx any, args any) *ResourcePoliciesApi_ValidateAtlasResourcePolicyWithParams_Call {
 	return &ResourcePoliciesApi_ValidateAtlasResourcePolicyWithParams_Call{Call: _e.mock.On("ValidateAtlasResourcePolicyWithParams", ctx, args)}
 }
 

--- a/mockadmin/rolling_index_api.go
+++ b/mockadmin/rolling_index_api.go
@@ -53,7 +53,7 @@ type RollingIndexApi_CreateRollingIndex_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - databaseRollingIndexRequest *admin.DatabaseRollingIndexRequest
-func (_e *RollingIndexApi_Expecter) CreateRollingIndex(ctx interface{}, groupId interface{}, clusterName interface{}, databaseRollingIndexRequest interface{}) *RollingIndexApi_CreateRollingIndex_Call {
+func (_e *RollingIndexApi_Expecter) CreateRollingIndex(ctx any, groupId any, clusterName any, databaseRollingIndexRequest any) *RollingIndexApi_CreateRollingIndex_Call {
 	return &RollingIndexApi_CreateRollingIndex_Call{Call: _e.mock.On("CreateRollingIndex", ctx, groupId, clusterName, databaseRollingIndexRequest)}
 }
 
@@ -111,7 +111,7 @@ type RollingIndexApi_CreateRollingIndexExecute_Call struct {
 
 // CreateRollingIndexExecute is a helper method to define mock.On call
 //   - r admin.CreateRollingIndexApiRequest
-func (_e *RollingIndexApi_Expecter) CreateRollingIndexExecute(r interface{}) *RollingIndexApi_CreateRollingIndexExecute_Call {
+func (_e *RollingIndexApi_Expecter) CreateRollingIndexExecute(r any) *RollingIndexApi_CreateRollingIndexExecute_Call {
 	return &RollingIndexApi_CreateRollingIndexExecute_Call{Call: _e.mock.On("CreateRollingIndexExecute", r)}
 }
 
@@ -158,7 +158,7 @@ type RollingIndexApi_CreateRollingIndexWithParams_Call struct {
 // CreateRollingIndexWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateRollingIndexApiParams
-func (_e *RollingIndexApi_Expecter) CreateRollingIndexWithParams(ctx interface{}, args interface{}) *RollingIndexApi_CreateRollingIndexWithParams_Call {
+func (_e *RollingIndexApi_Expecter) CreateRollingIndexWithParams(ctx any, args any) *RollingIndexApi_CreateRollingIndexWithParams_Call {
 	return &RollingIndexApi_CreateRollingIndexWithParams_Call{Call: _e.mock.On("CreateRollingIndexWithParams", ctx, args)}
 }
 

--- a/mockadmin/root_api.go
+++ b/mockadmin/root_api.go
@@ -50,7 +50,7 @@ type RootApi_GetSystemStatus_Call struct {
 
 // GetSystemStatus is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *RootApi_Expecter) GetSystemStatus(ctx interface{}) *RootApi_GetSystemStatus_Call {
+func (_e *RootApi_Expecter) GetSystemStatus(ctx any) *RootApi_GetSystemStatus_Call {
 	return &RootApi_GetSystemStatus_Call{Call: _e.mock.On("GetSystemStatus", ctx)}
 }
 
@@ -117,7 +117,7 @@ type RootApi_GetSystemStatusExecute_Call struct {
 
 // GetSystemStatusExecute is a helper method to define mock.On call
 //   - r admin.GetSystemStatusApiRequest
-func (_e *RootApi_Expecter) GetSystemStatusExecute(r interface{}) *RootApi_GetSystemStatusExecute_Call {
+func (_e *RootApi_Expecter) GetSystemStatusExecute(r any) *RootApi_GetSystemStatusExecute_Call {
 	return &RootApi_GetSystemStatusExecute_Call{Call: _e.mock.On("GetSystemStatusExecute", r)}
 }
 
@@ -164,7 +164,7 @@ type RootApi_GetSystemStatusWithParams_Call struct {
 // GetSystemStatusWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetSystemStatusApiParams
-func (_e *RootApi_Expecter) GetSystemStatusWithParams(ctx interface{}, args interface{}) *RootApi_GetSystemStatusWithParams_Call {
+func (_e *RootApi_Expecter) GetSystemStatusWithParams(ctx any, args any) *RootApi_GetSystemStatusWithParams_Call {
 	return &RootApi_GetSystemStatusWithParams_Call{Call: _e.mock.On("GetSystemStatusWithParams", ctx, args)}
 }
 
@@ -210,7 +210,7 @@ type RootApi_ReturnAllControlPlaneIPAddresses_Call struct {
 
 // ReturnAllControlPlaneIPAddresses is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *RootApi_Expecter) ReturnAllControlPlaneIPAddresses(ctx interface{}) *RootApi_ReturnAllControlPlaneIPAddresses_Call {
+func (_e *RootApi_Expecter) ReturnAllControlPlaneIPAddresses(ctx any) *RootApi_ReturnAllControlPlaneIPAddresses_Call {
 	return &RootApi_ReturnAllControlPlaneIPAddresses_Call{Call: _e.mock.On("ReturnAllControlPlaneIPAddresses", ctx)}
 }
 
@@ -277,7 +277,7 @@ type RootApi_ReturnAllControlPlaneIPAddressesExecute_Call struct {
 
 // ReturnAllControlPlaneIPAddressesExecute is a helper method to define mock.On call
 //   - r admin.ReturnAllControlPlaneIPAddressesApiRequest
-func (_e *RootApi_Expecter) ReturnAllControlPlaneIPAddressesExecute(r interface{}) *RootApi_ReturnAllControlPlaneIPAddressesExecute_Call {
+func (_e *RootApi_Expecter) ReturnAllControlPlaneIPAddressesExecute(r any) *RootApi_ReturnAllControlPlaneIPAddressesExecute_Call {
 	return &RootApi_ReturnAllControlPlaneIPAddressesExecute_Call{Call: _e.mock.On("ReturnAllControlPlaneIPAddressesExecute", r)}
 }
 
@@ -324,7 +324,7 @@ type RootApi_ReturnAllControlPlaneIPAddressesWithParams_Call struct {
 // ReturnAllControlPlaneIPAddressesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ReturnAllControlPlaneIPAddressesApiParams
-func (_e *RootApi_Expecter) ReturnAllControlPlaneIPAddressesWithParams(ctx interface{}, args interface{}) *RootApi_ReturnAllControlPlaneIPAddressesWithParams_Call {
+func (_e *RootApi_Expecter) ReturnAllControlPlaneIPAddressesWithParams(ctx any, args any) *RootApi_ReturnAllControlPlaneIPAddressesWithParams_Call {
 	return &RootApi_ReturnAllControlPlaneIPAddressesWithParams_Call{Call: _e.mock.On("ReturnAllControlPlaneIPAddressesWithParams", ctx, args)}
 }
 

--- a/mockadmin/serverless_instances_api.go
+++ b/mockadmin/serverless_instances_api.go
@@ -52,7 +52,7 @@ type ServerlessInstancesApi_CreateServerlessInstance_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - serverlessInstanceDescriptionCreate *admin.ServerlessInstanceDescriptionCreate
-func (_e *ServerlessInstancesApi_Expecter) CreateServerlessInstance(ctx interface{}, groupId interface{}, serverlessInstanceDescriptionCreate interface{}) *ServerlessInstancesApi_CreateServerlessInstance_Call {
+func (_e *ServerlessInstancesApi_Expecter) CreateServerlessInstance(ctx any, groupId any, serverlessInstanceDescriptionCreate any) *ServerlessInstancesApi_CreateServerlessInstance_Call {
 	return &ServerlessInstancesApi_CreateServerlessInstance_Call{Call: _e.mock.On("CreateServerlessInstance", ctx, groupId, serverlessInstanceDescriptionCreate)}
 }
 
@@ -119,7 +119,7 @@ type ServerlessInstancesApi_CreateServerlessInstanceExecute_Call struct {
 
 // CreateServerlessInstanceExecute is a helper method to define mock.On call
 //   - r admin.CreateServerlessInstanceApiRequest
-func (_e *ServerlessInstancesApi_Expecter) CreateServerlessInstanceExecute(r interface{}) *ServerlessInstancesApi_CreateServerlessInstanceExecute_Call {
+func (_e *ServerlessInstancesApi_Expecter) CreateServerlessInstanceExecute(r any) *ServerlessInstancesApi_CreateServerlessInstanceExecute_Call {
 	return &ServerlessInstancesApi_CreateServerlessInstanceExecute_Call{Call: _e.mock.On("CreateServerlessInstanceExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type ServerlessInstancesApi_CreateServerlessInstanceWithParams_Call struct {
 // CreateServerlessInstanceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateServerlessInstanceApiParams
-func (_e *ServerlessInstancesApi_Expecter) CreateServerlessInstanceWithParams(ctx interface{}, args interface{}) *ServerlessInstancesApi_CreateServerlessInstanceWithParams_Call {
+func (_e *ServerlessInstancesApi_Expecter) CreateServerlessInstanceWithParams(ctx any, args any) *ServerlessInstancesApi_CreateServerlessInstanceWithParams_Call {
 	return &ServerlessInstancesApi_CreateServerlessInstanceWithParams_Call{Call: _e.mock.On("CreateServerlessInstanceWithParams", ctx, args)}
 }
 
@@ -214,7 +214,7 @@ type ServerlessInstancesApi_DeleteServerlessInstance_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - name string
-func (_e *ServerlessInstancesApi_Expecter) DeleteServerlessInstance(ctx interface{}, groupId interface{}, name interface{}) *ServerlessInstancesApi_DeleteServerlessInstance_Call {
+func (_e *ServerlessInstancesApi_Expecter) DeleteServerlessInstance(ctx any, groupId any, name any) *ServerlessInstancesApi_DeleteServerlessInstance_Call {
 	return &ServerlessInstancesApi_DeleteServerlessInstance_Call{Call: _e.mock.On("DeleteServerlessInstance", ctx, groupId, name)}
 }
 
@@ -236,24 +236,24 @@ func (_c *ServerlessInstancesApi_DeleteServerlessInstance_Call) RunAndReturn(run
 }
 
 // DeleteServerlessInstanceExecute provides a mock function with given fields: r
-func (_m *ServerlessInstancesApi) DeleteServerlessInstanceExecute(r admin.DeleteServerlessInstanceApiRequest) (interface{}, *http.Response, error) {
+func (_m *ServerlessInstancesApi) DeleteServerlessInstanceExecute(r admin.DeleteServerlessInstanceApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteServerlessInstanceExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteServerlessInstanceApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteServerlessInstanceApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteServerlessInstanceApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteServerlessInstanceApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -281,7 +281,7 @@ type ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call struct {
 
 // DeleteServerlessInstanceExecute is a helper method to define mock.On call
 //   - r admin.DeleteServerlessInstanceApiRequest
-func (_e *ServerlessInstancesApi_Expecter) DeleteServerlessInstanceExecute(r interface{}) *ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call {
+func (_e *ServerlessInstancesApi_Expecter) DeleteServerlessInstanceExecute(r any) *ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call {
 	return &ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call{Call: _e.mock.On("DeleteServerlessInstanceExecute", r)}
 }
 
@@ -292,12 +292,12 @@ func (_c *ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call) Run(run f
 	return _c
 }
 
-func (_c *ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call {
+func (_c *ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call) RunAndReturn(run func(admin.DeleteServerlessInstanceApiRequest) (interface{}, *http.Response, error)) *ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call {
+func (_c *ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call) RunAndReturn(run func(admin.DeleteServerlessInstanceApiRequest) (any, *http.Response, error)) *ServerlessInstancesApi_DeleteServerlessInstanceExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -328,7 +328,7 @@ type ServerlessInstancesApi_DeleteServerlessInstanceWithParams_Call struct {
 // DeleteServerlessInstanceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteServerlessInstanceApiParams
-func (_e *ServerlessInstancesApi_Expecter) DeleteServerlessInstanceWithParams(ctx interface{}, args interface{}) *ServerlessInstancesApi_DeleteServerlessInstanceWithParams_Call {
+func (_e *ServerlessInstancesApi_Expecter) DeleteServerlessInstanceWithParams(ctx any, args any) *ServerlessInstancesApi_DeleteServerlessInstanceWithParams_Call {
 	return &ServerlessInstancesApi_DeleteServerlessInstanceWithParams_Call{Call: _e.mock.On("DeleteServerlessInstanceWithParams", ctx, args)}
 }
 
@@ -376,7 +376,7 @@ type ServerlessInstancesApi_GetServerlessInstance_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - name string
-func (_e *ServerlessInstancesApi_Expecter) GetServerlessInstance(ctx interface{}, groupId interface{}, name interface{}) *ServerlessInstancesApi_GetServerlessInstance_Call {
+func (_e *ServerlessInstancesApi_Expecter) GetServerlessInstance(ctx any, groupId any, name any) *ServerlessInstancesApi_GetServerlessInstance_Call {
 	return &ServerlessInstancesApi_GetServerlessInstance_Call{Call: _e.mock.On("GetServerlessInstance", ctx, groupId, name)}
 }
 
@@ -443,7 +443,7 @@ type ServerlessInstancesApi_GetServerlessInstanceExecute_Call struct {
 
 // GetServerlessInstanceExecute is a helper method to define mock.On call
 //   - r admin.GetServerlessInstanceApiRequest
-func (_e *ServerlessInstancesApi_Expecter) GetServerlessInstanceExecute(r interface{}) *ServerlessInstancesApi_GetServerlessInstanceExecute_Call {
+func (_e *ServerlessInstancesApi_Expecter) GetServerlessInstanceExecute(r any) *ServerlessInstancesApi_GetServerlessInstanceExecute_Call {
 	return &ServerlessInstancesApi_GetServerlessInstanceExecute_Call{Call: _e.mock.On("GetServerlessInstanceExecute", r)}
 }
 
@@ -490,7 +490,7 @@ type ServerlessInstancesApi_GetServerlessInstanceWithParams_Call struct {
 // GetServerlessInstanceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetServerlessInstanceApiParams
-func (_e *ServerlessInstancesApi_Expecter) GetServerlessInstanceWithParams(ctx interface{}, args interface{}) *ServerlessInstancesApi_GetServerlessInstanceWithParams_Call {
+func (_e *ServerlessInstancesApi_Expecter) GetServerlessInstanceWithParams(ctx any, args any) *ServerlessInstancesApi_GetServerlessInstanceWithParams_Call {
 	return &ServerlessInstancesApi_GetServerlessInstanceWithParams_Call{Call: _e.mock.On("GetServerlessInstanceWithParams", ctx, args)}
 }
 
@@ -537,7 +537,7 @@ type ServerlessInstancesApi_ListServerlessInstances_Call struct {
 // ListServerlessInstances is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ServerlessInstancesApi_Expecter) ListServerlessInstances(ctx interface{}, groupId interface{}) *ServerlessInstancesApi_ListServerlessInstances_Call {
+func (_e *ServerlessInstancesApi_Expecter) ListServerlessInstances(ctx any, groupId any) *ServerlessInstancesApi_ListServerlessInstances_Call {
 	return &ServerlessInstancesApi_ListServerlessInstances_Call{Call: _e.mock.On("ListServerlessInstances", ctx, groupId)}
 }
 
@@ -604,7 +604,7 @@ type ServerlessInstancesApi_ListServerlessInstancesExecute_Call struct {
 
 // ListServerlessInstancesExecute is a helper method to define mock.On call
 //   - r admin.ListServerlessInstancesApiRequest
-func (_e *ServerlessInstancesApi_Expecter) ListServerlessInstancesExecute(r interface{}) *ServerlessInstancesApi_ListServerlessInstancesExecute_Call {
+func (_e *ServerlessInstancesApi_Expecter) ListServerlessInstancesExecute(r any) *ServerlessInstancesApi_ListServerlessInstancesExecute_Call {
 	return &ServerlessInstancesApi_ListServerlessInstancesExecute_Call{Call: _e.mock.On("ListServerlessInstancesExecute", r)}
 }
 
@@ -651,7 +651,7 @@ type ServerlessInstancesApi_ListServerlessInstancesWithParams_Call struct {
 // ListServerlessInstancesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListServerlessInstancesApiParams
-func (_e *ServerlessInstancesApi_Expecter) ListServerlessInstancesWithParams(ctx interface{}, args interface{}) *ServerlessInstancesApi_ListServerlessInstancesWithParams_Call {
+func (_e *ServerlessInstancesApi_Expecter) ListServerlessInstancesWithParams(ctx any, args any) *ServerlessInstancesApi_ListServerlessInstancesWithParams_Call {
 	return &ServerlessInstancesApi_ListServerlessInstancesWithParams_Call{Call: _e.mock.On("ListServerlessInstancesWithParams", ctx, args)}
 }
 
@@ -700,7 +700,7 @@ type ServerlessInstancesApi_UpdateServerlessInstance_Call struct {
 //   - groupId string
 //   - name string
 //   - serverlessInstanceDescriptionUpdate *admin.ServerlessInstanceDescriptionUpdate
-func (_e *ServerlessInstancesApi_Expecter) UpdateServerlessInstance(ctx interface{}, groupId interface{}, name interface{}, serverlessInstanceDescriptionUpdate interface{}) *ServerlessInstancesApi_UpdateServerlessInstance_Call {
+func (_e *ServerlessInstancesApi_Expecter) UpdateServerlessInstance(ctx any, groupId any, name any, serverlessInstanceDescriptionUpdate any) *ServerlessInstancesApi_UpdateServerlessInstance_Call {
 	return &ServerlessInstancesApi_UpdateServerlessInstance_Call{Call: _e.mock.On("UpdateServerlessInstance", ctx, groupId, name, serverlessInstanceDescriptionUpdate)}
 }
 
@@ -767,7 +767,7 @@ type ServerlessInstancesApi_UpdateServerlessInstanceExecute_Call struct {
 
 // UpdateServerlessInstanceExecute is a helper method to define mock.On call
 //   - r admin.UpdateServerlessInstanceApiRequest
-func (_e *ServerlessInstancesApi_Expecter) UpdateServerlessInstanceExecute(r interface{}) *ServerlessInstancesApi_UpdateServerlessInstanceExecute_Call {
+func (_e *ServerlessInstancesApi_Expecter) UpdateServerlessInstanceExecute(r any) *ServerlessInstancesApi_UpdateServerlessInstanceExecute_Call {
 	return &ServerlessInstancesApi_UpdateServerlessInstanceExecute_Call{Call: _e.mock.On("UpdateServerlessInstanceExecute", r)}
 }
 
@@ -814,7 +814,7 @@ type ServerlessInstancesApi_UpdateServerlessInstanceWithParams_Call struct {
 // UpdateServerlessInstanceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateServerlessInstanceApiParams
-func (_e *ServerlessInstancesApi_Expecter) UpdateServerlessInstanceWithParams(ctx interface{}, args interface{}) *ServerlessInstancesApi_UpdateServerlessInstanceWithParams_Call {
+func (_e *ServerlessInstancesApi_Expecter) UpdateServerlessInstanceWithParams(ctx any, args any) *ServerlessInstancesApi_UpdateServerlessInstanceWithParams_Call {
 	return &ServerlessInstancesApi_UpdateServerlessInstanceWithParams_Call{Call: _e.mock.On("UpdateServerlessInstanceWithParams", ctx, args)}
 }
 

--- a/mockadmin/serverless_private_endpoints_api.go
+++ b/mockadmin/serverless_private_endpoints_api.go
@@ -53,7 +53,7 @@ type ServerlessPrivateEndpointsApi_CreateServerlessPrivateEndpoint_Call struct {
 //   - groupId string
 //   - instanceName string
 //   - serverlessTenantCreateRequest *admin.ServerlessTenantCreateRequest
-func (_e *ServerlessPrivateEndpointsApi_Expecter) CreateServerlessPrivateEndpoint(ctx interface{}, groupId interface{}, instanceName interface{}, serverlessTenantCreateRequest interface{}) *ServerlessPrivateEndpointsApi_CreateServerlessPrivateEndpoint_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) CreateServerlessPrivateEndpoint(ctx any, groupId any, instanceName any, serverlessTenantCreateRequest any) *ServerlessPrivateEndpointsApi_CreateServerlessPrivateEndpoint_Call {
 	return &ServerlessPrivateEndpointsApi_CreateServerlessPrivateEndpoint_Call{Call: _e.mock.On("CreateServerlessPrivateEndpoint", ctx, groupId, instanceName, serverlessTenantCreateRequest)}
 }
 
@@ -120,7 +120,7 @@ type ServerlessPrivateEndpointsApi_CreateServerlessPrivateEndpointExecute_Call s
 
 // CreateServerlessPrivateEndpointExecute is a helper method to define mock.On call
 //   - r admin.CreateServerlessPrivateEndpointApiRequest
-func (_e *ServerlessPrivateEndpointsApi_Expecter) CreateServerlessPrivateEndpointExecute(r interface{}) *ServerlessPrivateEndpointsApi_CreateServerlessPrivateEndpointExecute_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) CreateServerlessPrivateEndpointExecute(r any) *ServerlessPrivateEndpointsApi_CreateServerlessPrivateEndpointExecute_Call {
 	return &ServerlessPrivateEndpointsApi_CreateServerlessPrivateEndpointExecute_Call{Call: _e.mock.On("CreateServerlessPrivateEndpointExecute", r)}
 }
 
@@ -167,7 +167,7 @@ type ServerlessPrivateEndpointsApi_CreateServerlessPrivateEndpointWithParams_Cal
 // CreateServerlessPrivateEndpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateServerlessPrivateEndpointApiParams
-func (_e *ServerlessPrivateEndpointsApi_Expecter) CreateServerlessPrivateEndpointWithParams(ctx interface{}, args interface{}) *ServerlessPrivateEndpointsApi_CreateServerlessPrivateEndpointWithParams_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) CreateServerlessPrivateEndpointWithParams(ctx any, args any) *ServerlessPrivateEndpointsApi_CreateServerlessPrivateEndpointWithParams_Call {
 	return &ServerlessPrivateEndpointsApi_CreateServerlessPrivateEndpointWithParams_Call{Call: _e.mock.On("CreateServerlessPrivateEndpointWithParams", ctx, args)}
 }
 
@@ -216,7 +216,7 @@ type ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpoint_Call struct {
 //   - groupId string
 //   - instanceName string
 //   - endpointId string
-func (_e *ServerlessPrivateEndpointsApi_Expecter) DeleteServerlessPrivateEndpoint(ctx interface{}, groupId interface{}, instanceName interface{}, endpointId interface{}) *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpoint_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) DeleteServerlessPrivateEndpoint(ctx any, groupId any, instanceName any, endpointId any) *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpoint_Call {
 	return &ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpoint_Call{Call: _e.mock.On("DeleteServerlessPrivateEndpoint", ctx, groupId, instanceName, endpointId)}
 }
 
@@ -238,24 +238,24 @@ func (_c *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpoint_Call) Ru
 }
 
 // DeleteServerlessPrivateEndpointExecute provides a mock function with given fields: r
-func (_m *ServerlessPrivateEndpointsApi) DeleteServerlessPrivateEndpointExecute(r admin.DeleteServerlessPrivateEndpointApiRequest) (interface{}, *http.Response, error) {
+func (_m *ServerlessPrivateEndpointsApi) DeleteServerlessPrivateEndpointExecute(r admin.DeleteServerlessPrivateEndpointApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteServerlessPrivateEndpointExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteServerlessPrivateEndpointApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteServerlessPrivateEndpointApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteServerlessPrivateEndpointApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteServerlessPrivateEndpointApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -283,7 +283,7 @@ type ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_Call s
 
 // DeleteServerlessPrivateEndpointExecute is a helper method to define mock.On call
 //   - r admin.DeleteServerlessPrivateEndpointApiRequest
-func (_e *ServerlessPrivateEndpointsApi_Expecter) DeleteServerlessPrivateEndpointExecute(r interface{}) *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) DeleteServerlessPrivateEndpointExecute(r any) *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_Call {
 	return &ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_Call{Call: _e.mock.On("DeleteServerlessPrivateEndpointExecute", r)}
 }
 
@@ -294,12 +294,12 @@ func (_c *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_C
 	return _c
 }
 
-func (_c *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_Call {
+func (_c *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_Call) RunAndReturn(run func(admin.DeleteServerlessPrivateEndpointApiRequest) (interface{}, *http.Response, error)) *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_Call {
+func (_c *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_Call) RunAndReturn(run func(admin.DeleteServerlessPrivateEndpointApiRequest) (any, *http.Response, error)) *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -330,7 +330,7 @@ type ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointWithParams_Cal
 // DeleteServerlessPrivateEndpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteServerlessPrivateEndpointApiParams
-func (_e *ServerlessPrivateEndpointsApi_Expecter) DeleteServerlessPrivateEndpointWithParams(ctx interface{}, args interface{}) *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointWithParams_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) DeleteServerlessPrivateEndpointWithParams(ctx any, args any) *ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointWithParams_Call {
 	return &ServerlessPrivateEndpointsApi_DeleteServerlessPrivateEndpointWithParams_Call{Call: _e.mock.On("DeleteServerlessPrivateEndpointWithParams", ctx, args)}
 }
 
@@ -379,7 +379,7 @@ type ServerlessPrivateEndpointsApi_GetServerlessPrivateEndpoint_Call struct {
 //   - groupId string
 //   - instanceName string
 //   - endpointId string
-func (_e *ServerlessPrivateEndpointsApi_Expecter) GetServerlessPrivateEndpoint(ctx interface{}, groupId interface{}, instanceName interface{}, endpointId interface{}) *ServerlessPrivateEndpointsApi_GetServerlessPrivateEndpoint_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) GetServerlessPrivateEndpoint(ctx any, groupId any, instanceName any, endpointId any) *ServerlessPrivateEndpointsApi_GetServerlessPrivateEndpoint_Call {
 	return &ServerlessPrivateEndpointsApi_GetServerlessPrivateEndpoint_Call{Call: _e.mock.On("GetServerlessPrivateEndpoint", ctx, groupId, instanceName, endpointId)}
 }
 
@@ -446,7 +446,7 @@ type ServerlessPrivateEndpointsApi_GetServerlessPrivateEndpointExecute_Call stru
 
 // GetServerlessPrivateEndpointExecute is a helper method to define mock.On call
 //   - r admin.GetServerlessPrivateEndpointApiRequest
-func (_e *ServerlessPrivateEndpointsApi_Expecter) GetServerlessPrivateEndpointExecute(r interface{}) *ServerlessPrivateEndpointsApi_GetServerlessPrivateEndpointExecute_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) GetServerlessPrivateEndpointExecute(r any) *ServerlessPrivateEndpointsApi_GetServerlessPrivateEndpointExecute_Call {
 	return &ServerlessPrivateEndpointsApi_GetServerlessPrivateEndpointExecute_Call{Call: _e.mock.On("GetServerlessPrivateEndpointExecute", r)}
 }
 
@@ -493,7 +493,7 @@ type ServerlessPrivateEndpointsApi_GetServerlessPrivateEndpointWithParams_Call s
 // GetServerlessPrivateEndpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetServerlessPrivateEndpointApiParams
-func (_e *ServerlessPrivateEndpointsApi_Expecter) GetServerlessPrivateEndpointWithParams(ctx interface{}, args interface{}) *ServerlessPrivateEndpointsApi_GetServerlessPrivateEndpointWithParams_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) GetServerlessPrivateEndpointWithParams(ctx any, args any) *ServerlessPrivateEndpointsApi_GetServerlessPrivateEndpointWithParams_Call {
 	return &ServerlessPrivateEndpointsApi_GetServerlessPrivateEndpointWithParams_Call{Call: _e.mock.On("GetServerlessPrivateEndpointWithParams", ctx, args)}
 }
 
@@ -541,7 +541,7 @@ type ServerlessPrivateEndpointsApi_ListServerlessPrivateEndpoints_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - instanceName string
-func (_e *ServerlessPrivateEndpointsApi_Expecter) ListServerlessPrivateEndpoints(ctx interface{}, groupId interface{}, instanceName interface{}) *ServerlessPrivateEndpointsApi_ListServerlessPrivateEndpoints_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) ListServerlessPrivateEndpoints(ctx any, groupId any, instanceName any) *ServerlessPrivateEndpointsApi_ListServerlessPrivateEndpoints_Call {
 	return &ServerlessPrivateEndpointsApi_ListServerlessPrivateEndpoints_Call{Call: _e.mock.On("ListServerlessPrivateEndpoints", ctx, groupId, instanceName)}
 }
 
@@ -608,7 +608,7 @@ type ServerlessPrivateEndpointsApi_ListServerlessPrivateEndpointsExecute_Call st
 
 // ListServerlessPrivateEndpointsExecute is a helper method to define mock.On call
 //   - r admin.ListServerlessPrivateEndpointsApiRequest
-func (_e *ServerlessPrivateEndpointsApi_Expecter) ListServerlessPrivateEndpointsExecute(r interface{}) *ServerlessPrivateEndpointsApi_ListServerlessPrivateEndpointsExecute_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) ListServerlessPrivateEndpointsExecute(r any) *ServerlessPrivateEndpointsApi_ListServerlessPrivateEndpointsExecute_Call {
 	return &ServerlessPrivateEndpointsApi_ListServerlessPrivateEndpointsExecute_Call{Call: _e.mock.On("ListServerlessPrivateEndpointsExecute", r)}
 }
 
@@ -655,7 +655,7 @@ type ServerlessPrivateEndpointsApi_ListServerlessPrivateEndpointsWithParams_Call
 // ListServerlessPrivateEndpointsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListServerlessPrivateEndpointsApiParams
-func (_e *ServerlessPrivateEndpointsApi_Expecter) ListServerlessPrivateEndpointsWithParams(ctx interface{}, args interface{}) *ServerlessPrivateEndpointsApi_ListServerlessPrivateEndpointsWithParams_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) ListServerlessPrivateEndpointsWithParams(ctx any, args any) *ServerlessPrivateEndpointsApi_ListServerlessPrivateEndpointsWithParams_Call {
 	return &ServerlessPrivateEndpointsApi_ListServerlessPrivateEndpointsWithParams_Call{Call: _e.mock.On("ListServerlessPrivateEndpointsWithParams", ctx, args)}
 }
 
@@ -705,7 +705,7 @@ type ServerlessPrivateEndpointsApi_UpdateServerlessPrivateEndpoint_Call struct {
 //   - instanceName string
 //   - endpointId string
 //   - serverlessTenantEndpointUpdate *admin.ServerlessTenantEndpointUpdate
-func (_e *ServerlessPrivateEndpointsApi_Expecter) UpdateServerlessPrivateEndpoint(ctx interface{}, groupId interface{}, instanceName interface{}, endpointId interface{}, serverlessTenantEndpointUpdate interface{}) *ServerlessPrivateEndpointsApi_UpdateServerlessPrivateEndpoint_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) UpdateServerlessPrivateEndpoint(ctx any, groupId any, instanceName any, endpointId any, serverlessTenantEndpointUpdate any) *ServerlessPrivateEndpointsApi_UpdateServerlessPrivateEndpoint_Call {
 	return &ServerlessPrivateEndpointsApi_UpdateServerlessPrivateEndpoint_Call{Call: _e.mock.On("UpdateServerlessPrivateEndpoint", ctx, groupId, instanceName, endpointId, serverlessTenantEndpointUpdate)}
 }
 
@@ -772,7 +772,7 @@ type ServerlessPrivateEndpointsApi_UpdateServerlessPrivateEndpointExecute_Call s
 
 // UpdateServerlessPrivateEndpointExecute is a helper method to define mock.On call
 //   - r admin.UpdateServerlessPrivateEndpointApiRequest
-func (_e *ServerlessPrivateEndpointsApi_Expecter) UpdateServerlessPrivateEndpointExecute(r interface{}) *ServerlessPrivateEndpointsApi_UpdateServerlessPrivateEndpointExecute_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) UpdateServerlessPrivateEndpointExecute(r any) *ServerlessPrivateEndpointsApi_UpdateServerlessPrivateEndpointExecute_Call {
 	return &ServerlessPrivateEndpointsApi_UpdateServerlessPrivateEndpointExecute_Call{Call: _e.mock.On("UpdateServerlessPrivateEndpointExecute", r)}
 }
 
@@ -819,7 +819,7 @@ type ServerlessPrivateEndpointsApi_UpdateServerlessPrivateEndpointWithParams_Cal
 // UpdateServerlessPrivateEndpointWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateServerlessPrivateEndpointApiParams
-func (_e *ServerlessPrivateEndpointsApi_Expecter) UpdateServerlessPrivateEndpointWithParams(ctx interface{}, args interface{}) *ServerlessPrivateEndpointsApi_UpdateServerlessPrivateEndpointWithParams_Call {
+func (_e *ServerlessPrivateEndpointsApi_Expecter) UpdateServerlessPrivateEndpointWithParams(ctx any, args any) *ServerlessPrivateEndpointsApi_UpdateServerlessPrivateEndpointWithParams_Call {
 	return &ServerlessPrivateEndpointsApi_UpdateServerlessPrivateEndpointWithParams_Call{Call: _e.mock.On("UpdateServerlessPrivateEndpointWithParams", ctx, args)}
 }
 

--- a/mockadmin/shared_tier_restore_jobs_api.go
+++ b/mockadmin/shared_tier_restore_jobs_api.go
@@ -53,7 +53,7 @@ type SharedTierRestoreJobsApi_CreateSharedClusterBackupRestoreJob_Call struct {
 //   - clusterName string
 //   - groupId string
 //   - tenantRestore *admin.TenantRestore
-func (_e *SharedTierRestoreJobsApi_Expecter) CreateSharedClusterBackupRestoreJob(ctx interface{}, clusterName interface{}, groupId interface{}, tenantRestore interface{}) *SharedTierRestoreJobsApi_CreateSharedClusterBackupRestoreJob_Call {
+func (_e *SharedTierRestoreJobsApi_Expecter) CreateSharedClusterBackupRestoreJob(ctx any, clusterName any, groupId any, tenantRestore any) *SharedTierRestoreJobsApi_CreateSharedClusterBackupRestoreJob_Call {
 	return &SharedTierRestoreJobsApi_CreateSharedClusterBackupRestoreJob_Call{Call: _e.mock.On("CreateSharedClusterBackupRestoreJob", ctx, clusterName, groupId, tenantRestore)}
 }
 
@@ -120,7 +120,7 @@ type SharedTierRestoreJobsApi_CreateSharedClusterBackupRestoreJobExecute_Call st
 
 // CreateSharedClusterBackupRestoreJobExecute is a helper method to define mock.On call
 //   - r admin.CreateSharedClusterBackupRestoreJobApiRequest
-func (_e *SharedTierRestoreJobsApi_Expecter) CreateSharedClusterBackupRestoreJobExecute(r interface{}) *SharedTierRestoreJobsApi_CreateSharedClusterBackupRestoreJobExecute_Call {
+func (_e *SharedTierRestoreJobsApi_Expecter) CreateSharedClusterBackupRestoreJobExecute(r any) *SharedTierRestoreJobsApi_CreateSharedClusterBackupRestoreJobExecute_Call {
 	return &SharedTierRestoreJobsApi_CreateSharedClusterBackupRestoreJobExecute_Call{Call: _e.mock.On("CreateSharedClusterBackupRestoreJobExecute", r)}
 }
 
@@ -167,7 +167,7 @@ type SharedTierRestoreJobsApi_CreateSharedClusterBackupRestoreJobWithParams_Call
 // CreateSharedClusterBackupRestoreJobWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateSharedClusterBackupRestoreJobApiParams
-func (_e *SharedTierRestoreJobsApi_Expecter) CreateSharedClusterBackupRestoreJobWithParams(ctx interface{}, args interface{}) *SharedTierRestoreJobsApi_CreateSharedClusterBackupRestoreJobWithParams_Call {
+func (_e *SharedTierRestoreJobsApi_Expecter) CreateSharedClusterBackupRestoreJobWithParams(ctx any, args any) *SharedTierRestoreJobsApi_CreateSharedClusterBackupRestoreJobWithParams_Call {
 	return &SharedTierRestoreJobsApi_CreateSharedClusterBackupRestoreJobWithParams_Call{Call: _e.mock.On("CreateSharedClusterBackupRestoreJobWithParams", ctx, args)}
 }
 
@@ -216,7 +216,7 @@ type SharedTierRestoreJobsApi_GetSharedClusterBackupRestoreJob_Call struct {
 //   - clusterName string
 //   - groupId string
 //   - restoreId string
-func (_e *SharedTierRestoreJobsApi_Expecter) GetSharedClusterBackupRestoreJob(ctx interface{}, clusterName interface{}, groupId interface{}, restoreId interface{}) *SharedTierRestoreJobsApi_GetSharedClusterBackupRestoreJob_Call {
+func (_e *SharedTierRestoreJobsApi_Expecter) GetSharedClusterBackupRestoreJob(ctx any, clusterName any, groupId any, restoreId any) *SharedTierRestoreJobsApi_GetSharedClusterBackupRestoreJob_Call {
 	return &SharedTierRestoreJobsApi_GetSharedClusterBackupRestoreJob_Call{Call: _e.mock.On("GetSharedClusterBackupRestoreJob", ctx, clusterName, groupId, restoreId)}
 }
 
@@ -283,7 +283,7 @@ type SharedTierRestoreJobsApi_GetSharedClusterBackupRestoreJobExecute_Call struc
 
 // GetSharedClusterBackupRestoreJobExecute is a helper method to define mock.On call
 //   - r admin.GetSharedClusterBackupRestoreJobApiRequest
-func (_e *SharedTierRestoreJobsApi_Expecter) GetSharedClusterBackupRestoreJobExecute(r interface{}) *SharedTierRestoreJobsApi_GetSharedClusterBackupRestoreJobExecute_Call {
+func (_e *SharedTierRestoreJobsApi_Expecter) GetSharedClusterBackupRestoreJobExecute(r any) *SharedTierRestoreJobsApi_GetSharedClusterBackupRestoreJobExecute_Call {
 	return &SharedTierRestoreJobsApi_GetSharedClusterBackupRestoreJobExecute_Call{Call: _e.mock.On("GetSharedClusterBackupRestoreJobExecute", r)}
 }
 
@@ -330,7 +330,7 @@ type SharedTierRestoreJobsApi_GetSharedClusterBackupRestoreJobWithParams_Call st
 // GetSharedClusterBackupRestoreJobWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetSharedClusterBackupRestoreJobApiParams
-func (_e *SharedTierRestoreJobsApi_Expecter) GetSharedClusterBackupRestoreJobWithParams(ctx interface{}, args interface{}) *SharedTierRestoreJobsApi_GetSharedClusterBackupRestoreJobWithParams_Call {
+func (_e *SharedTierRestoreJobsApi_Expecter) GetSharedClusterBackupRestoreJobWithParams(ctx any, args any) *SharedTierRestoreJobsApi_GetSharedClusterBackupRestoreJobWithParams_Call {
 	return &SharedTierRestoreJobsApi_GetSharedClusterBackupRestoreJobWithParams_Call{Call: _e.mock.On("GetSharedClusterBackupRestoreJobWithParams", ctx, args)}
 }
 
@@ -378,7 +378,7 @@ type SharedTierRestoreJobsApi_ListSharedClusterBackupRestoreJobs_Call struct {
 //   - ctx context.Context
 //   - clusterName string
 //   - groupId string
-func (_e *SharedTierRestoreJobsApi_Expecter) ListSharedClusterBackupRestoreJobs(ctx interface{}, clusterName interface{}, groupId interface{}) *SharedTierRestoreJobsApi_ListSharedClusterBackupRestoreJobs_Call {
+func (_e *SharedTierRestoreJobsApi_Expecter) ListSharedClusterBackupRestoreJobs(ctx any, clusterName any, groupId any) *SharedTierRestoreJobsApi_ListSharedClusterBackupRestoreJobs_Call {
 	return &SharedTierRestoreJobsApi_ListSharedClusterBackupRestoreJobs_Call{Call: _e.mock.On("ListSharedClusterBackupRestoreJobs", ctx, clusterName, groupId)}
 }
 
@@ -445,7 +445,7 @@ type SharedTierRestoreJobsApi_ListSharedClusterBackupRestoreJobsExecute_Call str
 
 // ListSharedClusterBackupRestoreJobsExecute is a helper method to define mock.On call
 //   - r admin.ListSharedClusterBackupRestoreJobsApiRequest
-func (_e *SharedTierRestoreJobsApi_Expecter) ListSharedClusterBackupRestoreJobsExecute(r interface{}) *SharedTierRestoreJobsApi_ListSharedClusterBackupRestoreJobsExecute_Call {
+func (_e *SharedTierRestoreJobsApi_Expecter) ListSharedClusterBackupRestoreJobsExecute(r any) *SharedTierRestoreJobsApi_ListSharedClusterBackupRestoreJobsExecute_Call {
 	return &SharedTierRestoreJobsApi_ListSharedClusterBackupRestoreJobsExecute_Call{Call: _e.mock.On("ListSharedClusterBackupRestoreJobsExecute", r)}
 }
 
@@ -492,7 +492,7 @@ type SharedTierRestoreJobsApi_ListSharedClusterBackupRestoreJobsWithParams_Call 
 // ListSharedClusterBackupRestoreJobsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListSharedClusterBackupRestoreJobsApiParams
-func (_e *SharedTierRestoreJobsApi_Expecter) ListSharedClusterBackupRestoreJobsWithParams(ctx interface{}, args interface{}) *SharedTierRestoreJobsApi_ListSharedClusterBackupRestoreJobsWithParams_Call {
+func (_e *SharedTierRestoreJobsApi_Expecter) ListSharedClusterBackupRestoreJobsWithParams(ctx any, args any) *SharedTierRestoreJobsApi_ListSharedClusterBackupRestoreJobsWithParams_Call {
 	return &SharedTierRestoreJobsApi_ListSharedClusterBackupRestoreJobsWithParams_Call{Call: _e.mock.On("ListSharedClusterBackupRestoreJobsWithParams", ctx, args)}
 }
 

--- a/mockadmin/shared_tier_snapshots_api.go
+++ b/mockadmin/shared_tier_snapshots_api.go
@@ -53,7 +53,7 @@ type SharedTierSnapshotsApi_DownloadSharedClusterBackup_Call struct {
 //   - clusterName string
 //   - groupId string
 //   - tenantRestore *admin.TenantRestore
-func (_e *SharedTierSnapshotsApi_Expecter) DownloadSharedClusterBackup(ctx interface{}, clusterName interface{}, groupId interface{}, tenantRestore interface{}) *SharedTierSnapshotsApi_DownloadSharedClusterBackup_Call {
+func (_e *SharedTierSnapshotsApi_Expecter) DownloadSharedClusterBackup(ctx any, clusterName any, groupId any, tenantRestore any) *SharedTierSnapshotsApi_DownloadSharedClusterBackup_Call {
 	return &SharedTierSnapshotsApi_DownloadSharedClusterBackup_Call{Call: _e.mock.On("DownloadSharedClusterBackup", ctx, clusterName, groupId, tenantRestore)}
 }
 
@@ -120,7 +120,7 @@ type SharedTierSnapshotsApi_DownloadSharedClusterBackupExecute_Call struct {
 
 // DownloadSharedClusterBackupExecute is a helper method to define mock.On call
 //   - r admin.DownloadSharedClusterBackupApiRequest
-func (_e *SharedTierSnapshotsApi_Expecter) DownloadSharedClusterBackupExecute(r interface{}) *SharedTierSnapshotsApi_DownloadSharedClusterBackupExecute_Call {
+func (_e *SharedTierSnapshotsApi_Expecter) DownloadSharedClusterBackupExecute(r any) *SharedTierSnapshotsApi_DownloadSharedClusterBackupExecute_Call {
 	return &SharedTierSnapshotsApi_DownloadSharedClusterBackupExecute_Call{Call: _e.mock.On("DownloadSharedClusterBackupExecute", r)}
 }
 
@@ -167,7 +167,7 @@ type SharedTierSnapshotsApi_DownloadSharedClusterBackupWithParams_Call struct {
 // DownloadSharedClusterBackupWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DownloadSharedClusterBackupApiParams
-func (_e *SharedTierSnapshotsApi_Expecter) DownloadSharedClusterBackupWithParams(ctx interface{}, args interface{}) *SharedTierSnapshotsApi_DownloadSharedClusterBackupWithParams_Call {
+func (_e *SharedTierSnapshotsApi_Expecter) DownloadSharedClusterBackupWithParams(ctx any, args any) *SharedTierSnapshotsApi_DownloadSharedClusterBackupWithParams_Call {
 	return &SharedTierSnapshotsApi_DownloadSharedClusterBackupWithParams_Call{Call: _e.mock.On("DownloadSharedClusterBackupWithParams", ctx, args)}
 }
 
@@ -216,7 +216,7 @@ type SharedTierSnapshotsApi_GetSharedClusterBackup_Call struct {
 //   - groupId string
 //   - clusterName string
 //   - snapshotId string
-func (_e *SharedTierSnapshotsApi_Expecter) GetSharedClusterBackup(ctx interface{}, groupId interface{}, clusterName interface{}, snapshotId interface{}) *SharedTierSnapshotsApi_GetSharedClusterBackup_Call {
+func (_e *SharedTierSnapshotsApi_Expecter) GetSharedClusterBackup(ctx any, groupId any, clusterName any, snapshotId any) *SharedTierSnapshotsApi_GetSharedClusterBackup_Call {
 	return &SharedTierSnapshotsApi_GetSharedClusterBackup_Call{Call: _e.mock.On("GetSharedClusterBackup", ctx, groupId, clusterName, snapshotId)}
 }
 
@@ -283,7 +283,7 @@ type SharedTierSnapshotsApi_GetSharedClusterBackupExecute_Call struct {
 
 // GetSharedClusterBackupExecute is a helper method to define mock.On call
 //   - r admin.GetSharedClusterBackupApiRequest
-func (_e *SharedTierSnapshotsApi_Expecter) GetSharedClusterBackupExecute(r interface{}) *SharedTierSnapshotsApi_GetSharedClusterBackupExecute_Call {
+func (_e *SharedTierSnapshotsApi_Expecter) GetSharedClusterBackupExecute(r any) *SharedTierSnapshotsApi_GetSharedClusterBackupExecute_Call {
 	return &SharedTierSnapshotsApi_GetSharedClusterBackupExecute_Call{Call: _e.mock.On("GetSharedClusterBackupExecute", r)}
 }
 
@@ -330,7 +330,7 @@ type SharedTierSnapshotsApi_GetSharedClusterBackupWithParams_Call struct {
 // GetSharedClusterBackupWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetSharedClusterBackupApiParams
-func (_e *SharedTierSnapshotsApi_Expecter) GetSharedClusterBackupWithParams(ctx interface{}, args interface{}) *SharedTierSnapshotsApi_GetSharedClusterBackupWithParams_Call {
+func (_e *SharedTierSnapshotsApi_Expecter) GetSharedClusterBackupWithParams(ctx any, args any) *SharedTierSnapshotsApi_GetSharedClusterBackupWithParams_Call {
 	return &SharedTierSnapshotsApi_GetSharedClusterBackupWithParams_Call{Call: _e.mock.On("GetSharedClusterBackupWithParams", ctx, args)}
 }
 
@@ -378,7 +378,7 @@ type SharedTierSnapshotsApi_ListSharedClusterBackups_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - clusterName string
-func (_e *SharedTierSnapshotsApi_Expecter) ListSharedClusterBackups(ctx interface{}, groupId interface{}, clusterName interface{}) *SharedTierSnapshotsApi_ListSharedClusterBackups_Call {
+func (_e *SharedTierSnapshotsApi_Expecter) ListSharedClusterBackups(ctx any, groupId any, clusterName any) *SharedTierSnapshotsApi_ListSharedClusterBackups_Call {
 	return &SharedTierSnapshotsApi_ListSharedClusterBackups_Call{Call: _e.mock.On("ListSharedClusterBackups", ctx, groupId, clusterName)}
 }
 
@@ -445,7 +445,7 @@ type SharedTierSnapshotsApi_ListSharedClusterBackupsExecute_Call struct {
 
 // ListSharedClusterBackupsExecute is a helper method to define mock.On call
 //   - r admin.ListSharedClusterBackupsApiRequest
-func (_e *SharedTierSnapshotsApi_Expecter) ListSharedClusterBackupsExecute(r interface{}) *SharedTierSnapshotsApi_ListSharedClusterBackupsExecute_Call {
+func (_e *SharedTierSnapshotsApi_Expecter) ListSharedClusterBackupsExecute(r any) *SharedTierSnapshotsApi_ListSharedClusterBackupsExecute_Call {
 	return &SharedTierSnapshotsApi_ListSharedClusterBackupsExecute_Call{Call: _e.mock.On("ListSharedClusterBackupsExecute", r)}
 }
 
@@ -492,7 +492,7 @@ type SharedTierSnapshotsApi_ListSharedClusterBackupsWithParams_Call struct {
 // ListSharedClusterBackupsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListSharedClusterBackupsApiParams
-func (_e *SharedTierSnapshotsApi_Expecter) ListSharedClusterBackupsWithParams(ctx interface{}, args interface{}) *SharedTierSnapshotsApi_ListSharedClusterBackupsWithParams_Call {
+func (_e *SharedTierSnapshotsApi_Expecter) ListSharedClusterBackupsWithParams(ctx any, args any) *SharedTierSnapshotsApi_ListSharedClusterBackupsWithParams_Call {
 	return &SharedTierSnapshotsApi_ListSharedClusterBackupsWithParams_Call{Call: _e.mock.On("ListSharedClusterBackupsWithParams", ctx, args)}
 }
 

--- a/mockadmin/streams_api.go
+++ b/mockadmin/streams_api.go
@@ -55,7 +55,7 @@ type StreamsApi_AcceptVPCPeeringConnection_Call struct {
 //   - groupId string
 //   - id string
 //   - vPCPeeringActionChallenge *admin.VPCPeeringActionChallenge
-func (_e *StreamsApi_Expecter) AcceptVPCPeeringConnection(ctx interface{}, groupId interface{}, id interface{}, vPCPeeringActionChallenge interface{}) *StreamsApi_AcceptVPCPeeringConnection_Call {
+func (_e *StreamsApi_Expecter) AcceptVPCPeeringConnection(ctx any, groupId any, id any, vPCPeeringActionChallenge any) *StreamsApi_AcceptVPCPeeringConnection_Call {
 	return &StreamsApi_AcceptVPCPeeringConnection_Call{Call: _e.mock.On("AcceptVPCPeeringConnection", ctx, groupId, id, vPCPeeringActionChallenge)}
 }
 
@@ -77,24 +77,24 @@ func (_c *StreamsApi_AcceptVPCPeeringConnection_Call) RunAndReturn(run func(cont
 }
 
 // AcceptVPCPeeringConnectionExecute provides a mock function with given fields: r
-func (_m *StreamsApi) AcceptVPCPeeringConnectionExecute(r admin.AcceptVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error) {
+func (_m *StreamsApi) AcceptVPCPeeringConnectionExecute(r admin.AcceptVPCPeeringConnectionApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AcceptVPCPeeringConnectionExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.AcceptVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.AcceptVPCPeeringConnectionApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.AcceptVPCPeeringConnectionApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.AcceptVPCPeeringConnectionApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -122,7 +122,7 @@ type StreamsApi_AcceptVPCPeeringConnectionExecute_Call struct {
 
 // AcceptVPCPeeringConnectionExecute is a helper method to define mock.On call
 //   - r admin.AcceptVPCPeeringConnectionApiRequest
-func (_e *StreamsApi_Expecter) AcceptVPCPeeringConnectionExecute(r interface{}) *StreamsApi_AcceptVPCPeeringConnectionExecute_Call {
+func (_e *StreamsApi_Expecter) AcceptVPCPeeringConnectionExecute(r any) *StreamsApi_AcceptVPCPeeringConnectionExecute_Call {
 	return &StreamsApi_AcceptVPCPeeringConnectionExecute_Call{Call: _e.mock.On("AcceptVPCPeeringConnectionExecute", r)}
 }
 
@@ -133,12 +133,12 @@ func (_c *StreamsApi_AcceptVPCPeeringConnectionExecute_Call) Run(run func(r admi
 	return _c
 }
 
-func (_c *StreamsApi_AcceptVPCPeeringConnectionExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *StreamsApi_AcceptVPCPeeringConnectionExecute_Call {
+func (_c *StreamsApi_AcceptVPCPeeringConnectionExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *StreamsApi_AcceptVPCPeeringConnectionExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *StreamsApi_AcceptVPCPeeringConnectionExecute_Call) RunAndReturn(run func(admin.AcceptVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error)) *StreamsApi_AcceptVPCPeeringConnectionExecute_Call {
+func (_c *StreamsApi_AcceptVPCPeeringConnectionExecute_Call) RunAndReturn(run func(admin.AcceptVPCPeeringConnectionApiRequest) (any, *http.Response, error)) *StreamsApi_AcceptVPCPeeringConnectionExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -169,7 +169,7 @@ type StreamsApi_AcceptVPCPeeringConnectionWithParams_Call struct {
 // AcceptVPCPeeringConnectionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.AcceptVPCPeeringConnectionApiParams
-func (_e *StreamsApi_Expecter) AcceptVPCPeeringConnectionWithParams(ctx interface{}, args interface{}) *StreamsApi_AcceptVPCPeeringConnectionWithParams_Call {
+func (_e *StreamsApi_Expecter) AcceptVPCPeeringConnectionWithParams(ctx any, args any) *StreamsApi_AcceptVPCPeeringConnectionWithParams_Call {
 	return &StreamsApi_AcceptVPCPeeringConnectionWithParams_Call{Call: _e.mock.On("AcceptVPCPeeringConnectionWithParams", ctx, args)}
 }
 
@@ -218,7 +218,7 @@ type StreamsApi_CreateStreamConnection_Call struct {
 //   - groupId string
 //   - tenantName string
 //   - streamsConnection *admin.StreamsConnection
-func (_e *StreamsApi_Expecter) CreateStreamConnection(ctx interface{}, groupId interface{}, tenantName interface{}, streamsConnection interface{}) *StreamsApi_CreateStreamConnection_Call {
+func (_e *StreamsApi_Expecter) CreateStreamConnection(ctx any, groupId any, tenantName any, streamsConnection any) *StreamsApi_CreateStreamConnection_Call {
 	return &StreamsApi_CreateStreamConnection_Call{Call: _e.mock.On("CreateStreamConnection", ctx, groupId, tenantName, streamsConnection)}
 }
 
@@ -285,7 +285,7 @@ type StreamsApi_CreateStreamConnectionExecute_Call struct {
 
 // CreateStreamConnectionExecute is a helper method to define mock.On call
 //   - r admin.CreateStreamConnectionApiRequest
-func (_e *StreamsApi_Expecter) CreateStreamConnectionExecute(r interface{}) *StreamsApi_CreateStreamConnectionExecute_Call {
+func (_e *StreamsApi_Expecter) CreateStreamConnectionExecute(r any) *StreamsApi_CreateStreamConnectionExecute_Call {
 	return &StreamsApi_CreateStreamConnectionExecute_Call{Call: _e.mock.On("CreateStreamConnectionExecute", r)}
 }
 
@@ -332,7 +332,7 @@ type StreamsApi_CreateStreamConnectionWithParams_Call struct {
 // CreateStreamConnectionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateStreamConnectionApiParams
-func (_e *StreamsApi_Expecter) CreateStreamConnectionWithParams(ctx interface{}, args interface{}) *StreamsApi_CreateStreamConnectionWithParams_Call {
+func (_e *StreamsApi_Expecter) CreateStreamConnectionWithParams(ctx any, args any) *StreamsApi_CreateStreamConnectionWithParams_Call {
 	return &StreamsApi_CreateStreamConnectionWithParams_Call{Call: _e.mock.On("CreateStreamConnectionWithParams", ctx, args)}
 }
 
@@ -380,7 +380,7 @@ type StreamsApi_CreateStreamInstance_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - streamsTenant *admin.StreamsTenant
-func (_e *StreamsApi_Expecter) CreateStreamInstance(ctx interface{}, groupId interface{}, streamsTenant interface{}) *StreamsApi_CreateStreamInstance_Call {
+func (_e *StreamsApi_Expecter) CreateStreamInstance(ctx any, groupId any, streamsTenant any) *StreamsApi_CreateStreamInstance_Call {
 	return &StreamsApi_CreateStreamInstance_Call{Call: _e.mock.On("CreateStreamInstance", ctx, groupId, streamsTenant)}
 }
 
@@ -447,7 +447,7 @@ type StreamsApi_CreateStreamInstanceExecute_Call struct {
 
 // CreateStreamInstanceExecute is a helper method to define mock.On call
 //   - r admin.CreateStreamInstanceApiRequest
-func (_e *StreamsApi_Expecter) CreateStreamInstanceExecute(r interface{}) *StreamsApi_CreateStreamInstanceExecute_Call {
+func (_e *StreamsApi_Expecter) CreateStreamInstanceExecute(r any) *StreamsApi_CreateStreamInstanceExecute_Call {
 	return &StreamsApi_CreateStreamInstanceExecute_Call{Call: _e.mock.On("CreateStreamInstanceExecute", r)}
 }
 
@@ -494,7 +494,7 @@ type StreamsApi_CreateStreamInstanceWithParams_Call struct {
 // CreateStreamInstanceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateStreamInstanceApiParams
-func (_e *StreamsApi_Expecter) CreateStreamInstanceWithParams(ctx interface{}, args interface{}) *StreamsApi_CreateStreamInstanceWithParams_Call {
+func (_e *StreamsApi_Expecter) CreateStreamInstanceWithParams(ctx any, args any) *StreamsApi_CreateStreamInstanceWithParams_Call {
 	return &StreamsApi_CreateStreamInstanceWithParams_Call{Call: _e.mock.On("CreateStreamInstanceWithParams", ctx, args)}
 }
 
@@ -516,7 +516,7 @@ func (_c *StreamsApi_CreateStreamInstanceWithParams_Call) RunAndReturn(run func(
 }
 
 // CreateStreamInstanceWithSampleConnections provides a mock function with given fields: ctx, groupId, body
-func (_m *StreamsApi) CreateStreamInstanceWithSampleConnections(ctx context.Context, groupId string, body *interface{}) admin.CreateStreamInstanceWithSampleConnectionsApiRequest {
+func (_m *StreamsApi) CreateStreamInstanceWithSampleConnections(ctx context.Context, groupId string, body *any) admin.CreateStreamInstanceWithSampleConnectionsApiRequest {
 	ret := _m.Called(ctx, groupId, body)
 
 	if len(ret) == 0 {
@@ -524,7 +524,7 @@ func (_m *StreamsApi) CreateStreamInstanceWithSampleConnections(ctx context.Cont
 	}
 
 	var r0 admin.CreateStreamInstanceWithSampleConnectionsApiRequest
-	if rf, ok := ret.Get(0).(func(context.Context, string, *interface{}) admin.CreateStreamInstanceWithSampleConnectionsApiRequest); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, *any) admin.CreateStreamInstanceWithSampleConnectionsApiRequest); ok {
 		r0 = rf(ctx, groupId, body)
 	} else {
 		r0 = ret.Get(0).(admin.CreateStreamInstanceWithSampleConnectionsApiRequest)
@@ -541,14 +541,14 @@ type StreamsApi_CreateStreamInstanceWithSampleConnections_Call struct {
 // CreateStreamInstanceWithSampleConnections is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-//   - body *interface{}
-func (_e *StreamsApi_Expecter) CreateStreamInstanceWithSampleConnections(ctx interface{}, groupId interface{}, body interface{}) *StreamsApi_CreateStreamInstanceWithSampleConnections_Call {
+//   - body *any
+func (_e *StreamsApi_Expecter) CreateStreamInstanceWithSampleConnections(ctx any, groupId any, body any) *StreamsApi_CreateStreamInstanceWithSampleConnections_Call {
 	return &StreamsApi_CreateStreamInstanceWithSampleConnections_Call{Call: _e.mock.On("CreateStreamInstanceWithSampleConnections", ctx, groupId, body)}
 }
 
-func (_c *StreamsApi_CreateStreamInstanceWithSampleConnections_Call) Run(run func(ctx context.Context, groupId string, body *interface{})) *StreamsApi_CreateStreamInstanceWithSampleConnections_Call {
+func (_c *StreamsApi_CreateStreamInstanceWithSampleConnections_Call) Run(run func(ctx context.Context, groupId string, body *any)) *StreamsApi_CreateStreamInstanceWithSampleConnections_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(*interface{}))
+		run(args[0].(context.Context), args[1].(string), args[2].(*any))
 	})
 	return _c
 }
@@ -558,7 +558,7 @@ func (_c *StreamsApi_CreateStreamInstanceWithSampleConnections_Call) Return(_a0 
 	return _c
 }
 
-func (_c *StreamsApi_CreateStreamInstanceWithSampleConnections_Call) RunAndReturn(run func(context.Context, string, *interface{}) admin.CreateStreamInstanceWithSampleConnectionsApiRequest) *StreamsApi_CreateStreamInstanceWithSampleConnections_Call {
+func (_c *StreamsApi_CreateStreamInstanceWithSampleConnections_Call) RunAndReturn(run func(context.Context, string, *any) admin.CreateStreamInstanceWithSampleConnectionsApiRequest) *StreamsApi_CreateStreamInstanceWithSampleConnections_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -609,7 +609,7 @@ type StreamsApi_CreateStreamInstanceWithSampleConnectionsExecute_Call struct {
 
 // CreateStreamInstanceWithSampleConnectionsExecute is a helper method to define mock.On call
 //   - r admin.CreateStreamInstanceWithSampleConnectionsApiRequest
-func (_e *StreamsApi_Expecter) CreateStreamInstanceWithSampleConnectionsExecute(r interface{}) *StreamsApi_CreateStreamInstanceWithSampleConnectionsExecute_Call {
+func (_e *StreamsApi_Expecter) CreateStreamInstanceWithSampleConnectionsExecute(r any) *StreamsApi_CreateStreamInstanceWithSampleConnectionsExecute_Call {
 	return &StreamsApi_CreateStreamInstanceWithSampleConnectionsExecute_Call{Call: _e.mock.On("CreateStreamInstanceWithSampleConnectionsExecute", r)}
 }
 
@@ -656,7 +656,7 @@ type StreamsApi_CreateStreamInstanceWithSampleConnectionsWithParams_Call struct 
 // CreateStreamInstanceWithSampleConnectionsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateStreamInstanceWithSampleConnectionsApiParams
-func (_e *StreamsApi_Expecter) CreateStreamInstanceWithSampleConnectionsWithParams(ctx interface{}, args interface{}) *StreamsApi_CreateStreamInstanceWithSampleConnectionsWithParams_Call {
+func (_e *StreamsApi_Expecter) CreateStreamInstanceWithSampleConnectionsWithParams(ctx any, args any) *StreamsApi_CreateStreamInstanceWithSampleConnectionsWithParams_Call {
 	return &StreamsApi_CreateStreamInstanceWithSampleConnectionsWithParams_Call{Call: _e.mock.On("CreateStreamInstanceWithSampleConnectionsWithParams", ctx, args)}
 }
 
@@ -705,7 +705,7 @@ type StreamsApi_CreateStreamProcessor_Call struct {
 //   - groupId string
 //   - tenantName string
 //   - streamsProcessor *admin.StreamsProcessor
-func (_e *StreamsApi_Expecter) CreateStreamProcessor(ctx interface{}, groupId interface{}, tenantName interface{}, streamsProcessor interface{}) *StreamsApi_CreateStreamProcessor_Call {
+func (_e *StreamsApi_Expecter) CreateStreamProcessor(ctx any, groupId any, tenantName any, streamsProcessor any) *StreamsApi_CreateStreamProcessor_Call {
 	return &StreamsApi_CreateStreamProcessor_Call{Call: _e.mock.On("CreateStreamProcessor", ctx, groupId, tenantName, streamsProcessor)}
 }
 
@@ -772,7 +772,7 @@ type StreamsApi_CreateStreamProcessorExecute_Call struct {
 
 // CreateStreamProcessorExecute is a helper method to define mock.On call
 //   - r admin.CreateStreamProcessorApiRequest
-func (_e *StreamsApi_Expecter) CreateStreamProcessorExecute(r interface{}) *StreamsApi_CreateStreamProcessorExecute_Call {
+func (_e *StreamsApi_Expecter) CreateStreamProcessorExecute(r any) *StreamsApi_CreateStreamProcessorExecute_Call {
 	return &StreamsApi_CreateStreamProcessorExecute_Call{Call: _e.mock.On("CreateStreamProcessorExecute", r)}
 }
 
@@ -819,7 +819,7 @@ type StreamsApi_CreateStreamProcessorWithParams_Call struct {
 // CreateStreamProcessorWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateStreamProcessorApiParams
-func (_e *StreamsApi_Expecter) CreateStreamProcessorWithParams(ctx interface{}, args interface{}) *StreamsApi_CreateStreamProcessorWithParams_Call {
+func (_e *StreamsApi_Expecter) CreateStreamProcessorWithParams(ctx any, args any) *StreamsApi_CreateStreamProcessorWithParams_Call {
 	return &StreamsApi_CreateStreamProcessorWithParams_Call{Call: _e.mock.On("CreateStreamProcessorWithParams", ctx, args)}
 }
 
@@ -868,7 +868,7 @@ type StreamsApi_DeleteStreamConnection_Call struct {
 //   - groupId string
 //   - tenantName string
 //   - connectionName string
-func (_e *StreamsApi_Expecter) DeleteStreamConnection(ctx interface{}, groupId interface{}, tenantName interface{}, connectionName interface{}) *StreamsApi_DeleteStreamConnection_Call {
+func (_e *StreamsApi_Expecter) DeleteStreamConnection(ctx any, groupId any, tenantName any, connectionName any) *StreamsApi_DeleteStreamConnection_Call {
 	return &StreamsApi_DeleteStreamConnection_Call{Call: _e.mock.On("DeleteStreamConnection", ctx, groupId, tenantName, connectionName)}
 }
 
@@ -890,24 +890,24 @@ func (_c *StreamsApi_DeleteStreamConnection_Call) RunAndReturn(run func(context.
 }
 
 // DeleteStreamConnectionExecute provides a mock function with given fields: r
-func (_m *StreamsApi) DeleteStreamConnectionExecute(r admin.DeleteStreamConnectionApiRequest) (interface{}, *http.Response, error) {
+func (_m *StreamsApi) DeleteStreamConnectionExecute(r admin.DeleteStreamConnectionApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteStreamConnectionExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteStreamConnectionApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteStreamConnectionApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteStreamConnectionApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteStreamConnectionApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -935,7 +935,7 @@ type StreamsApi_DeleteStreamConnectionExecute_Call struct {
 
 // DeleteStreamConnectionExecute is a helper method to define mock.On call
 //   - r admin.DeleteStreamConnectionApiRequest
-func (_e *StreamsApi_Expecter) DeleteStreamConnectionExecute(r interface{}) *StreamsApi_DeleteStreamConnectionExecute_Call {
+func (_e *StreamsApi_Expecter) DeleteStreamConnectionExecute(r any) *StreamsApi_DeleteStreamConnectionExecute_Call {
 	return &StreamsApi_DeleteStreamConnectionExecute_Call{Call: _e.mock.On("DeleteStreamConnectionExecute", r)}
 }
 
@@ -946,12 +946,12 @@ func (_c *StreamsApi_DeleteStreamConnectionExecute_Call) Run(run func(r admin.De
 	return _c
 }
 
-func (_c *StreamsApi_DeleteStreamConnectionExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *StreamsApi_DeleteStreamConnectionExecute_Call {
+func (_c *StreamsApi_DeleteStreamConnectionExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *StreamsApi_DeleteStreamConnectionExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *StreamsApi_DeleteStreamConnectionExecute_Call) RunAndReturn(run func(admin.DeleteStreamConnectionApiRequest) (interface{}, *http.Response, error)) *StreamsApi_DeleteStreamConnectionExecute_Call {
+func (_c *StreamsApi_DeleteStreamConnectionExecute_Call) RunAndReturn(run func(admin.DeleteStreamConnectionApiRequest) (any, *http.Response, error)) *StreamsApi_DeleteStreamConnectionExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -982,7 +982,7 @@ type StreamsApi_DeleteStreamConnectionWithParams_Call struct {
 // DeleteStreamConnectionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteStreamConnectionApiParams
-func (_e *StreamsApi_Expecter) DeleteStreamConnectionWithParams(ctx interface{}, args interface{}) *StreamsApi_DeleteStreamConnectionWithParams_Call {
+func (_e *StreamsApi_Expecter) DeleteStreamConnectionWithParams(ctx any, args any) *StreamsApi_DeleteStreamConnectionWithParams_Call {
 	return &StreamsApi_DeleteStreamConnectionWithParams_Call{Call: _e.mock.On("DeleteStreamConnectionWithParams", ctx, args)}
 }
 
@@ -1030,7 +1030,7 @@ type StreamsApi_DeleteStreamInstance_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - tenantName string
-func (_e *StreamsApi_Expecter) DeleteStreamInstance(ctx interface{}, groupId interface{}, tenantName interface{}) *StreamsApi_DeleteStreamInstance_Call {
+func (_e *StreamsApi_Expecter) DeleteStreamInstance(ctx any, groupId any, tenantName any) *StreamsApi_DeleteStreamInstance_Call {
 	return &StreamsApi_DeleteStreamInstance_Call{Call: _e.mock.On("DeleteStreamInstance", ctx, groupId, tenantName)}
 }
 
@@ -1052,24 +1052,24 @@ func (_c *StreamsApi_DeleteStreamInstance_Call) RunAndReturn(run func(context.Co
 }
 
 // DeleteStreamInstanceExecute provides a mock function with given fields: r
-func (_m *StreamsApi) DeleteStreamInstanceExecute(r admin.DeleteStreamInstanceApiRequest) (interface{}, *http.Response, error) {
+func (_m *StreamsApi) DeleteStreamInstanceExecute(r admin.DeleteStreamInstanceApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteStreamInstanceExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteStreamInstanceApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteStreamInstanceApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteStreamInstanceApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteStreamInstanceApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -1097,7 +1097,7 @@ type StreamsApi_DeleteStreamInstanceExecute_Call struct {
 
 // DeleteStreamInstanceExecute is a helper method to define mock.On call
 //   - r admin.DeleteStreamInstanceApiRequest
-func (_e *StreamsApi_Expecter) DeleteStreamInstanceExecute(r interface{}) *StreamsApi_DeleteStreamInstanceExecute_Call {
+func (_e *StreamsApi_Expecter) DeleteStreamInstanceExecute(r any) *StreamsApi_DeleteStreamInstanceExecute_Call {
 	return &StreamsApi_DeleteStreamInstanceExecute_Call{Call: _e.mock.On("DeleteStreamInstanceExecute", r)}
 }
 
@@ -1108,12 +1108,12 @@ func (_c *StreamsApi_DeleteStreamInstanceExecute_Call) Run(run func(r admin.Dele
 	return _c
 }
 
-func (_c *StreamsApi_DeleteStreamInstanceExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *StreamsApi_DeleteStreamInstanceExecute_Call {
+func (_c *StreamsApi_DeleteStreamInstanceExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *StreamsApi_DeleteStreamInstanceExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *StreamsApi_DeleteStreamInstanceExecute_Call) RunAndReturn(run func(admin.DeleteStreamInstanceApiRequest) (interface{}, *http.Response, error)) *StreamsApi_DeleteStreamInstanceExecute_Call {
+func (_c *StreamsApi_DeleteStreamInstanceExecute_Call) RunAndReturn(run func(admin.DeleteStreamInstanceApiRequest) (any, *http.Response, error)) *StreamsApi_DeleteStreamInstanceExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1144,7 +1144,7 @@ type StreamsApi_DeleteStreamInstanceWithParams_Call struct {
 // DeleteStreamInstanceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteStreamInstanceApiParams
-func (_e *StreamsApi_Expecter) DeleteStreamInstanceWithParams(ctx interface{}, args interface{}) *StreamsApi_DeleteStreamInstanceWithParams_Call {
+func (_e *StreamsApi_Expecter) DeleteStreamInstanceWithParams(ctx any, args any) *StreamsApi_DeleteStreamInstanceWithParams_Call {
 	return &StreamsApi_DeleteStreamInstanceWithParams_Call{Call: _e.mock.On("DeleteStreamInstanceWithParams", ctx, args)}
 }
 
@@ -1193,7 +1193,7 @@ type StreamsApi_DeleteStreamProcessor_Call struct {
 //   - groupId string
 //   - tenantName string
 //   - processorName string
-func (_e *StreamsApi_Expecter) DeleteStreamProcessor(ctx interface{}, groupId interface{}, tenantName interface{}, processorName interface{}) *StreamsApi_DeleteStreamProcessor_Call {
+func (_e *StreamsApi_Expecter) DeleteStreamProcessor(ctx any, groupId any, tenantName any, processorName any) *StreamsApi_DeleteStreamProcessor_Call {
 	return &StreamsApi_DeleteStreamProcessor_Call{Call: _e.mock.On("DeleteStreamProcessor", ctx, groupId, tenantName, processorName)}
 }
 
@@ -1251,7 +1251,7 @@ type StreamsApi_DeleteStreamProcessorExecute_Call struct {
 
 // DeleteStreamProcessorExecute is a helper method to define mock.On call
 //   - r admin.DeleteStreamProcessorApiRequest
-func (_e *StreamsApi_Expecter) DeleteStreamProcessorExecute(r interface{}) *StreamsApi_DeleteStreamProcessorExecute_Call {
+func (_e *StreamsApi_Expecter) DeleteStreamProcessorExecute(r any) *StreamsApi_DeleteStreamProcessorExecute_Call {
 	return &StreamsApi_DeleteStreamProcessorExecute_Call{Call: _e.mock.On("DeleteStreamProcessorExecute", r)}
 }
 
@@ -1298,7 +1298,7 @@ type StreamsApi_DeleteStreamProcessorWithParams_Call struct {
 // DeleteStreamProcessorWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteStreamProcessorApiParams
-func (_e *StreamsApi_Expecter) DeleteStreamProcessorWithParams(ctx interface{}, args interface{}) *StreamsApi_DeleteStreamProcessorWithParams_Call {
+func (_e *StreamsApi_Expecter) DeleteStreamProcessorWithParams(ctx any, args any) *StreamsApi_DeleteStreamProcessorWithParams_Call {
 	return &StreamsApi_DeleteStreamProcessorWithParams_Call{Call: _e.mock.On("DeleteStreamProcessorWithParams", ctx, args)}
 }
 
@@ -1346,7 +1346,7 @@ type StreamsApi_DeleteVPCPeeringConnection_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - id string
-func (_e *StreamsApi_Expecter) DeleteVPCPeeringConnection(ctx interface{}, groupId interface{}, id interface{}) *StreamsApi_DeleteVPCPeeringConnection_Call {
+func (_e *StreamsApi_Expecter) DeleteVPCPeeringConnection(ctx any, groupId any, id any) *StreamsApi_DeleteVPCPeeringConnection_Call {
 	return &StreamsApi_DeleteVPCPeeringConnection_Call{Call: _e.mock.On("DeleteVPCPeeringConnection", ctx, groupId, id)}
 }
 
@@ -1368,24 +1368,24 @@ func (_c *StreamsApi_DeleteVPCPeeringConnection_Call) RunAndReturn(run func(cont
 }
 
 // DeleteVPCPeeringConnectionExecute provides a mock function with given fields: r
-func (_m *StreamsApi) DeleteVPCPeeringConnectionExecute(r admin.DeleteVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error) {
+func (_m *StreamsApi) DeleteVPCPeeringConnectionExecute(r admin.DeleteVPCPeeringConnectionApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteVPCPeeringConnectionExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteVPCPeeringConnectionApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteVPCPeeringConnectionApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteVPCPeeringConnectionApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -1413,7 +1413,7 @@ type StreamsApi_DeleteVPCPeeringConnectionExecute_Call struct {
 
 // DeleteVPCPeeringConnectionExecute is a helper method to define mock.On call
 //   - r admin.DeleteVPCPeeringConnectionApiRequest
-func (_e *StreamsApi_Expecter) DeleteVPCPeeringConnectionExecute(r interface{}) *StreamsApi_DeleteVPCPeeringConnectionExecute_Call {
+func (_e *StreamsApi_Expecter) DeleteVPCPeeringConnectionExecute(r any) *StreamsApi_DeleteVPCPeeringConnectionExecute_Call {
 	return &StreamsApi_DeleteVPCPeeringConnectionExecute_Call{Call: _e.mock.On("DeleteVPCPeeringConnectionExecute", r)}
 }
 
@@ -1424,12 +1424,12 @@ func (_c *StreamsApi_DeleteVPCPeeringConnectionExecute_Call) Run(run func(r admi
 	return _c
 }
 
-func (_c *StreamsApi_DeleteVPCPeeringConnectionExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *StreamsApi_DeleteVPCPeeringConnectionExecute_Call {
+func (_c *StreamsApi_DeleteVPCPeeringConnectionExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *StreamsApi_DeleteVPCPeeringConnectionExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *StreamsApi_DeleteVPCPeeringConnectionExecute_Call) RunAndReturn(run func(admin.DeleteVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error)) *StreamsApi_DeleteVPCPeeringConnectionExecute_Call {
+func (_c *StreamsApi_DeleteVPCPeeringConnectionExecute_Call) RunAndReturn(run func(admin.DeleteVPCPeeringConnectionApiRequest) (any, *http.Response, error)) *StreamsApi_DeleteVPCPeeringConnectionExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1460,7 +1460,7 @@ type StreamsApi_DeleteVPCPeeringConnectionWithParams_Call struct {
 // DeleteVPCPeeringConnectionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteVPCPeeringConnectionApiParams
-func (_e *StreamsApi_Expecter) DeleteVPCPeeringConnectionWithParams(ctx interface{}, args interface{}) *StreamsApi_DeleteVPCPeeringConnectionWithParams_Call {
+func (_e *StreamsApi_Expecter) DeleteVPCPeeringConnectionWithParams(ctx any, args any) *StreamsApi_DeleteVPCPeeringConnectionWithParams_Call {
 	return &StreamsApi_DeleteVPCPeeringConnectionWithParams_Call{Call: _e.mock.On("DeleteVPCPeeringConnectionWithParams", ctx, args)}
 }
 
@@ -1508,7 +1508,7 @@ type StreamsApi_DownloadStreamTenantAuditLogs_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - tenantName string
-func (_e *StreamsApi_Expecter) DownloadStreamTenantAuditLogs(ctx interface{}, groupId interface{}, tenantName interface{}) *StreamsApi_DownloadStreamTenantAuditLogs_Call {
+func (_e *StreamsApi_Expecter) DownloadStreamTenantAuditLogs(ctx any, groupId any, tenantName any) *StreamsApi_DownloadStreamTenantAuditLogs_Call {
 	return &StreamsApi_DownloadStreamTenantAuditLogs_Call{Call: _e.mock.On("DownloadStreamTenantAuditLogs", ctx, groupId, tenantName)}
 }
 
@@ -1575,7 +1575,7 @@ type StreamsApi_DownloadStreamTenantAuditLogsExecute_Call struct {
 
 // DownloadStreamTenantAuditLogsExecute is a helper method to define mock.On call
 //   - r admin.DownloadStreamTenantAuditLogsApiRequest
-func (_e *StreamsApi_Expecter) DownloadStreamTenantAuditLogsExecute(r interface{}) *StreamsApi_DownloadStreamTenantAuditLogsExecute_Call {
+func (_e *StreamsApi_Expecter) DownloadStreamTenantAuditLogsExecute(r any) *StreamsApi_DownloadStreamTenantAuditLogsExecute_Call {
 	return &StreamsApi_DownloadStreamTenantAuditLogsExecute_Call{Call: _e.mock.On("DownloadStreamTenantAuditLogsExecute", r)}
 }
 
@@ -1622,7 +1622,7 @@ type StreamsApi_DownloadStreamTenantAuditLogsWithParams_Call struct {
 // DownloadStreamTenantAuditLogsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DownloadStreamTenantAuditLogsApiParams
-func (_e *StreamsApi_Expecter) DownloadStreamTenantAuditLogsWithParams(ctx interface{}, args interface{}) *StreamsApi_DownloadStreamTenantAuditLogsWithParams_Call {
+func (_e *StreamsApi_Expecter) DownloadStreamTenantAuditLogsWithParams(ctx any, args any) *StreamsApi_DownloadStreamTenantAuditLogsWithParams_Call {
 	return &StreamsApi_DownloadStreamTenantAuditLogsWithParams_Call{Call: _e.mock.On("DownloadStreamTenantAuditLogsWithParams", ctx, args)}
 }
 
@@ -1671,7 +1671,7 @@ type StreamsApi_GetStreamConnection_Call struct {
 //   - groupId string
 //   - tenantName string
 //   - connectionName string
-func (_e *StreamsApi_Expecter) GetStreamConnection(ctx interface{}, groupId interface{}, tenantName interface{}, connectionName interface{}) *StreamsApi_GetStreamConnection_Call {
+func (_e *StreamsApi_Expecter) GetStreamConnection(ctx any, groupId any, tenantName any, connectionName any) *StreamsApi_GetStreamConnection_Call {
 	return &StreamsApi_GetStreamConnection_Call{Call: _e.mock.On("GetStreamConnection", ctx, groupId, tenantName, connectionName)}
 }
 
@@ -1738,7 +1738,7 @@ type StreamsApi_GetStreamConnectionExecute_Call struct {
 
 // GetStreamConnectionExecute is a helper method to define mock.On call
 //   - r admin.GetStreamConnectionApiRequest
-func (_e *StreamsApi_Expecter) GetStreamConnectionExecute(r interface{}) *StreamsApi_GetStreamConnectionExecute_Call {
+func (_e *StreamsApi_Expecter) GetStreamConnectionExecute(r any) *StreamsApi_GetStreamConnectionExecute_Call {
 	return &StreamsApi_GetStreamConnectionExecute_Call{Call: _e.mock.On("GetStreamConnectionExecute", r)}
 }
 
@@ -1785,7 +1785,7 @@ type StreamsApi_GetStreamConnectionWithParams_Call struct {
 // GetStreamConnectionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetStreamConnectionApiParams
-func (_e *StreamsApi_Expecter) GetStreamConnectionWithParams(ctx interface{}, args interface{}) *StreamsApi_GetStreamConnectionWithParams_Call {
+func (_e *StreamsApi_Expecter) GetStreamConnectionWithParams(ctx any, args any) *StreamsApi_GetStreamConnectionWithParams_Call {
 	return &StreamsApi_GetStreamConnectionWithParams_Call{Call: _e.mock.On("GetStreamConnectionWithParams", ctx, args)}
 }
 
@@ -1833,7 +1833,7 @@ type StreamsApi_GetStreamInstance_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - tenantName string
-func (_e *StreamsApi_Expecter) GetStreamInstance(ctx interface{}, groupId interface{}, tenantName interface{}) *StreamsApi_GetStreamInstance_Call {
+func (_e *StreamsApi_Expecter) GetStreamInstance(ctx any, groupId any, tenantName any) *StreamsApi_GetStreamInstance_Call {
 	return &StreamsApi_GetStreamInstance_Call{Call: _e.mock.On("GetStreamInstance", ctx, groupId, tenantName)}
 }
 
@@ -1900,7 +1900,7 @@ type StreamsApi_GetStreamInstanceExecute_Call struct {
 
 // GetStreamInstanceExecute is a helper method to define mock.On call
 //   - r admin.GetStreamInstanceApiRequest
-func (_e *StreamsApi_Expecter) GetStreamInstanceExecute(r interface{}) *StreamsApi_GetStreamInstanceExecute_Call {
+func (_e *StreamsApi_Expecter) GetStreamInstanceExecute(r any) *StreamsApi_GetStreamInstanceExecute_Call {
 	return &StreamsApi_GetStreamInstanceExecute_Call{Call: _e.mock.On("GetStreamInstanceExecute", r)}
 }
 
@@ -1947,7 +1947,7 @@ type StreamsApi_GetStreamInstanceWithParams_Call struct {
 // GetStreamInstanceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetStreamInstanceApiParams
-func (_e *StreamsApi_Expecter) GetStreamInstanceWithParams(ctx interface{}, args interface{}) *StreamsApi_GetStreamInstanceWithParams_Call {
+func (_e *StreamsApi_Expecter) GetStreamInstanceWithParams(ctx any, args any) *StreamsApi_GetStreamInstanceWithParams_Call {
 	return &StreamsApi_GetStreamInstanceWithParams_Call{Call: _e.mock.On("GetStreamInstanceWithParams", ctx, args)}
 }
 
@@ -1996,7 +1996,7 @@ type StreamsApi_GetStreamProcessor_Call struct {
 //   - groupId string
 //   - tenantName string
 //   - processorName string
-func (_e *StreamsApi_Expecter) GetStreamProcessor(ctx interface{}, groupId interface{}, tenantName interface{}, processorName interface{}) *StreamsApi_GetStreamProcessor_Call {
+func (_e *StreamsApi_Expecter) GetStreamProcessor(ctx any, groupId any, tenantName any, processorName any) *StreamsApi_GetStreamProcessor_Call {
 	return &StreamsApi_GetStreamProcessor_Call{Call: _e.mock.On("GetStreamProcessor", ctx, groupId, tenantName, processorName)}
 }
 
@@ -2063,7 +2063,7 @@ type StreamsApi_GetStreamProcessorExecute_Call struct {
 
 // GetStreamProcessorExecute is a helper method to define mock.On call
 //   - r admin.GetStreamProcessorApiRequest
-func (_e *StreamsApi_Expecter) GetStreamProcessorExecute(r interface{}) *StreamsApi_GetStreamProcessorExecute_Call {
+func (_e *StreamsApi_Expecter) GetStreamProcessorExecute(r any) *StreamsApi_GetStreamProcessorExecute_Call {
 	return &StreamsApi_GetStreamProcessorExecute_Call{Call: _e.mock.On("GetStreamProcessorExecute", r)}
 }
 
@@ -2110,7 +2110,7 @@ type StreamsApi_GetStreamProcessorWithParams_Call struct {
 // GetStreamProcessorWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetStreamProcessorApiParams
-func (_e *StreamsApi_Expecter) GetStreamProcessorWithParams(ctx interface{}, args interface{}) *StreamsApi_GetStreamProcessorWithParams_Call {
+func (_e *StreamsApi_Expecter) GetStreamProcessorWithParams(ctx any, args any) *StreamsApi_GetStreamProcessorWithParams_Call {
 	return &StreamsApi_GetStreamProcessorWithParams_Call{Call: _e.mock.On("GetStreamProcessorWithParams", ctx, args)}
 }
 
@@ -2157,7 +2157,7 @@ type StreamsApi_GetVPCPeeringConnections_Call struct {
 // GetVPCPeeringConnections is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *StreamsApi_Expecter) GetVPCPeeringConnections(ctx interface{}, groupId interface{}) *StreamsApi_GetVPCPeeringConnections_Call {
+func (_e *StreamsApi_Expecter) GetVPCPeeringConnections(ctx any, groupId any) *StreamsApi_GetVPCPeeringConnections_Call {
 	return &StreamsApi_GetVPCPeeringConnections_Call{Call: _e.mock.On("GetVPCPeeringConnections", ctx, groupId)}
 }
 
@@ -2215,7 +2215,7 @@ type StreamsApi_GetVPCPeeringConnectionsExecute_Call struct {
 
 // GetVPCPeeringConnectionsExecute is a helper method to define mock.On call
 //   - r admin.GetVPCPeeringConnectionsApiRequest
-func (_e *StreamsApi_Expecter) GetVPCPeeringConnectionsExecute(r interface{}) *StreamsApi_GetVPCPeeringConnectionsExecute_Call {
+func (_e *StreamsApi_Expecter) GetVPCPeeringConnectionsExecute(r any) *StreamsApi_GetVPCPeeringConnectionsExecute_Call {
 	return &StreamsApi_GetVPCPeeringConnectionsExecute_Call{Call: _e.mock.On("GetVPCPeeringConnectionsExecute", r)}
 }
 
@@ -2262,7 +2262,7 @@ type StreamsApi_GetVPCPeeringConnectionsWithParams_Call struct {
 // GetVPCPeeringConnectionsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetVPCPeeringConnectionsApiParams
-func (_e *StreamsApi_Expecter) GetVPCPeeringConnectionsWithParams(ctx interface{}, args interface{}) *StreamsApi_GetVPCPeeringConnectionsWithParams_Call {
+func (_e *StreamsApi_Expecter) GetVPCPeeringConnectionsWithParams(ctx any, args any) *StreamsApi_GetVPCPeeringConnectionsWithParams_Call {
 	return &StreamsApi_GetVPCPeeringConnectionsWithParams_Call{Call: _e.mock.On("GetVPCPeeringConnectionsWithParams", ctx, args)}
 }
 
@@ -2310,7 +2310,7 @@ type StreamsApi_ListStreamConnections_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - tenantName string
-func (_e *StreamsApi_Expecter) ListStreamConnections(ctx interface{}, groupId interface{}, tenantName interface{}) *StreamsApi_ListStreamConnections_Call {
+func (_e *StreamsApi_Expecter) ListStreamConnections(ctx any, groupId any, tenantName any) *StreamsApi_ListStreamConnections_Call {
 	return &StreamsApi_ListStreamConnections_Call{Call: _e.mock.On("ListStreamConnections", ctx, groupId, tenantName)}
 }
 
@@ -2377,7 +2377,7 @@ type StreamsApi_ListStreamConnectionsExecute_Call struct {
 
 // ListStreamConnectionsExecute is a helper method to define mock.On call
 //   - r admin.ListStreamConnectionsApiRequest
-func (_e *StreamsApi_Expecter) ListStreamConnectionsExecute(r interface{}) *StreamsApi_ListStreamConnectionsExecute_Call {
+func (_e *StreamsApi_Expecter) ListStreamConnectionsExecute(r any) *StreamsApi_ListStreamConnectionsExecute_Call {
 	return &StreamsApi_ListStreamConnectionsExecute_Call{Call: _e.mock.On("ListStreamConnectionsExecute", r)}
 }
 
@@ -2424,7 +2424,7 @@ type StreamsApi_ListStreamConnectionsWithParams_Call struct {
 // ListStreamConnectionsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListStreamConnectionsApiParams
-func (_e *StreamsApi_Expecter) ListStreamConnectionsWithParams(ctx interface{}, args interface{}) *StreamsApi_ListStreamConnectionsWithParams_Call {
+func (_e *StreamsApi_Expecter) ListStreamConnectionsWithParams(ctx any, args any) *StreamsApi_ListStreamConnectionsWithParams_Call {
 	return &StreamsApi_ListStreamConnectionsWithParams_Call{Call: _e.mock.On("ListStreamConnectionsWithParams", ctx, args)}
 }
 
@@ -2471,7 +2471,7 @@ type StreamsApi_ListStreamInstances_Call struct {
 // ListStreamInstances is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *StreamsApi_Expecter) ListStreamInstances(ctx interface{}, groupId interface{}) *StreamsApi_ListStreamInstances_Call {
+func (_e *StreamsApi_Expecter) ListStreamInstances(ctx any, groupId any) *StreamsApi_ListStreamInstances_Call {
 	return &StreamsApi_ListStreamInstances_Call{Call: _e.mock.On("ListStreamInstances", ctx, groupId)}
 }
 
@@ -2538,7 +2538,7 @@ type StreamsApi_ListStreamInstancesExecute_Call struct {
 
 // ListStreamInstancesExecute is a helper method to define mock.On call
 //   - r admin.ListStreamInstancesApiRequest
-func (_e *StreamsApi_Expecter) ListStreamInstancesExecute(r interface{}) *StreamsApi_ListStreamInstancesExecute_Call {
+func (_e *StreamsApi_Expecter) ListStreamInstancesExecute(r any) *StreamsApi_ListStreamInstancesExecute_Call {
 	return &StreamsApi_ListStreamInstancesExecute_Call{Call: _e.mock.On("ListStreamInstancesExecute", r)}
 }
 
@@ -2585,7 +2585,7 @@ type StreamsApi_ListStreamInstancesWithParams_Call struct {
 // ListStreamInstancesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListStreamInstancesApiParams
-func (_e *StreamsApi_Expecter) ListStreamInstancesWithParams(ctx interface{}, args interface{}) *StreamsApi_ListStreamInstancesWithParams_Call {
+func (_e *StreamsApi_Expecter) ListStreamInstancesWithParams(ctx any, args any) *StreamsApi_ListStreamInstancesWithParams_Call {
 	return &StreamsApi_ListStreamInstancesWithParams_Call{Call: _e.mock.On("ListStreamInstancesWithParams", ctx, args)}
 }
 
@@ -2633,7 +2633,7 @@ type StreamsApi_ListStreamProcessors_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - tenantName string
-func (_e *StreamsApi_Expecter) ListStreamProcessors(ctx interface{}, groupId interface{}, tenantName interface{}) *StreamsApi_ListStreamProcessors_Call {
+func (_e *StreamsApi_Expecter) ListStreamProcessors(ctx any, groupId any, tenantName any) *StreamsApi_ListStreamProcessors_Call {
 	return &StreamsApi_ListStreamProcessors_Call{Call: _e.mock.On("ListStreamProcessors", ctx, groupId, tenantName)}
 }
 
@@ -2700,7 +2700,7 @@ type StreamsApi_ListStreamProcessorsExecute_Call struct {
 
 // ListStreamProcessorsExecute is a helper method to define mock.On call
 //   - r admin.ListStreamProcessorsApiRequest
-func (_e *StreamsApi_Expecter) ListStreamProcessorsExecute(r interface{}) *StreamsApi_ListStreamProcessorsExecute_Call {
+func (_e *StreamsApi_Expecter) ListStreamProcessorsExecute(r any) *StreamsApi_ListStreamProcessorsExecute_Call {
 	return &StreamsApi_ListStreamProcessorsExecute_Call{Call: _e.mock.On("ListStreamProcessorsExecute", r)}
 }
 
@@ -2747,7 +2747,7 @@ type StreamsApi_ListStreamProcessorsWithParams_Call struct {
 // ListStreamProcessorsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListStreamProcessorsApiParams
-func (_e *StreamsApi_Expecter) ListStreamProcessorsWithParams(ctx interface{}, args interface{}) *StreamsApi_ListStreamProcessorsWithParams_Call {
+func (_e *StreamsApi_Expecter) ListStreamProcessorsWithParams(ctx any, args any) *StreamsApi_ListStreamProcessorsWithParams_Call {
 	return &StreamsApi_ListStreamProcessorsWithParams_Call{Call: _e.mock.On("ListStreamProcessorsWithParams", ctx, args)}
 }
 
@@ -2795,7 +2795,7 @@ type StreamsApi_RejectVPCPeeringConnection_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - id string
-func (_e *StreamsApi_Expecter) RejectVPCPeeringConnection(ctx interface{}, groupId interface{}, id interface{}) *StreamsApi_RejectVPCPeeringConnection_Call {
+func (_e *StreamsApi_Expecter) RejectVPCPeeringConnection(ctx any, groupId any, id any) *StreamsApi_RejectVPCPeeringConnection_Call {
 	return &StreamsApi_RejectVPCPeeringConnection_Call{Call: _e.mock.On("RejectVPCPeeringConnection", ctx, groupId, id)}
 }
 
@@ -2817,24 +2817,24 @@ func (_c *StreamsApi_RejectVPCPeeringConnection_Call) RunAndReturn(run func(cont
 }
 
 // RejectVPCPeeringConnectionExecute provides a mock function with given fields: r
-func (_m *StreamsApi) RejectVPCPeeringConnectionExecute(r admin.RejectVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error) {
+func (_m *StreamsApi) RejectVPCPeeringConnectionExecute(r admin.RejectVPCPeeringConnectionApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RejectVPCPeeringConnectionExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.RejectVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.RejectVPCPeeringConnectionApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.RejectVPCPeeringConnectionApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.RejectVPCPeeringConnectionApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -2862,7 +2862,7 @@ type StreamsApi_RejectVPCPeeringConnectionExecute_Call struct {
 
 // RejectVPCPeeringConnectionExecute is a helper method to define mock.On call
 //   - r admin.RejectVPCPeeringConnectionApiRequest
-func (_e *StreamsApi_Expecter) RejectVPCPeeringConnectionExecute(r interface{}) *StreamsApi_RejectVPCPeeringConnectionExecute_Call {
+func (_e *StreamsApi_Expecter) RejectVPCPeeringConnectionExecute(r any) *StreamsApi_RejectVPCPeeringConnectionExecute_Call {
 	return &StreamsApi_RejectVPCPeeringConnectionExecute_Call{Call: _e.mock.On("RejectVPCPeeringConnectionExecute", r)}
 }
 
@@ -2873,12 +2873,12 @@ func (_c *StreamsApi_RejectVPCPeeringConnectionExecute_Call) Run(run func(r admi
 	return _c
 }
 
-func (_c *StreamsApi_RejectVPCPeeringConnectionExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *StreamsApi_RejectVPCPeeringConnectionExecute_Call {
+func (_c *StreamsApi_RejectVPCPeeringConnectionExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *StreamsApi_RejectVPCPeeringConnectionExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *StreamsApi_RejectVPCPeeringConnectionExecute_Call) RunAndReturn(run func(admin.RejectVPCPeeringConnectionApiRequest) (interface{}, *http.Response, error)) *StreamsApi_RejectVPCPeeringConnectionExecute_Call {
+func (_c *StreamsApi_RejectVPCPeeringConnectionExecute_Call) RunAndReturn(run func(admin.RejectVPCPeeringConnectionApiRequest) (any, *http.Response, error)) *StreamsApi_RejectVPCPeeringConnectionExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2909,7 +2909,7 @@ type StreamsApi_RejectVPCPeeringConnectionWithParams_Call struct {
 // RejectVPCPeeringConnectionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.RejectVPCPeeringConnectionApiParams
-func (_e *StreamsApi_Expecter) RejectVPCPeeringConnectionWithParams(ctx interface{}, args interface{}) *StreamsApi_RejectVPCPeeringConnectionWithParams_Call {
+func (_e *StreamsApi_Expecter) RejectVPCPeeringConnectionWithParams(ctx any, args any) *StreamsApi_RejectVPCPeeringConnectionWithParams_Call {
 	return &StreamsApi_RejectVPCPeeringConnectionWithParams_Call{Call: _e.mock.On("RejectVPCPeeringConnectionWithParams", ctx, args)}
 }
 
@@ -2958,7 +2958,7 @@ type StreamsApi_StartStreamProcessor_Call struct {
 //   - groupId string
 //   - tenantName string
 //   - processorName string
-func (_e *StreamsApi_Expecter) StartStreamProcessor(ctx interface{}, groupId interface{}, tenantName interface{}, processorName interface{}) *StreamsApi_StartStreamProcessor_Call {
+func (_e *StreamsApi_Expecter) StartStreamProcessor(ctx any, groupId any, tenantName any, processorName any) *StreamsApi_StartStreamProcessor_Call {
 	return &StreamsApi_StartStreamProcessor_Call{Call: _e.mock.On("StartStreamProcessor", ctx, groupId, tenantName, processorName)}
 }
 
@@ -2980,24 +2980,24 @@ func (_c *StreamsApi_StartStreamProcessor_Call) RunAndReturn(run func(context.Co
 }
 
 // StartStreamProcessorExecute provides a mock function with given fields: r
-func (_m *StreamsApi) StartStreamProcessorExecute(r admin.StartStreamProcessorApiRequest) (interface{}, *http.Response, error) {
+func (_m *StreamsApi) StartStreamProcessorExecute(r admin.StartStreamProcessorApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StartStreamProcessorExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.StartStreamProcessorApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.StartStreamProcessorApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.StartStreamProcessorApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.StartStreamProcessorApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -3025,7 +3025,7 @@ type StreamsApi_StartStreamProcessorExecute_Call struct {
 
 // StartStreamProcessorExecute is a helper method to define mock.On call
 //   - r admin.StartStreamProcessorApiRequest
-func (_e *StreamsApi_Expecter) StartStreamProcessorExecute(r interface{}) *StreamsApi_StartStreamProcessorExecute_Call {
+func (_e *StreamsApi_Expecter) StartStreamProcessorExecute(r any) *StreamsApi_StartStreamProcessorExecute_Call {
 	return &StreamsApi_StartStreamProcessorExecute_Call{Call: _e.mock.On("StartStreamProcessorExecute", r)}
 }
 
@@ -3036,12 +3036,12 @@ func (_c *StreamsApi_StartStreamProcessorExecute_Call) Run(run func(r admin.Star
 	return _c
 }
 
-func (_c *StreamsApi_StartStreamProcessorExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *StreamsApi_StartStreamProcessorExecute_Call {
+func (_c *StreamsApi_StartStreamProcessorExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *StreamsApi_StartStreamProcessorExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *StreamsApi_StartStreamProcessorExecute_Call) RunAndReturn(run func(admin.StartStreamProcessorApiRequest) (interface{}, *http.Response, error)) *StreamsApi_StartStreamProcessorExecute_Call {
+func (_c *StreamsApi_StartStreamProcessorExecute_Call) RunAndReturn(run func(admin.StartStreamProcessorApiRequest) (any, *http.Response, error)) *StreamsApi_StartStreamProcessorExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3072,7 +3072,7 @@ type StreamsApi_StartStreamProcessorWithParams_Call struct {
 // StartStreamProcessorWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.StartStreamProcessorApiParams
-func (_e *StreamsApi_Expecter) StartStreamProcessorWithParams(ctx interface{}, args interface{}) *StreamsApi_StartStreamProcessorWithParams_Call {
+func (_e *StreamsApi_Expecter) StartStreamProcessorWithParams(ctx any, args any) *StreamsApi_StartStreamProcessorWithParams_Call {
 	return &StreamsApi_StartStreamProcessorWithParams_Call{Call: _e.mock.On("StartStreamProcessorWithParams", ctx, args)}
 }
 
@@ -3121,7 +3121,7 @@ type StreamsApi_StopStreamProcessor_Call struct {
 //   - groupId string
 //   - tenantName string
 //   - processorName string
-func (_e *StreamsApi_Expecter) StopStreamProcessor(ctx interface{}, groupId interface{}, tenantName interface{}, processorName interface{}) *StreamsApi_StopStreamProcessor_Call {
+func (_e *StreamsApi_Expecter) StopStreamProcessor(ctx any, groupId any, tenantName any, processorName any) *StreamsApi_StopStreamProcessor_Call {
 	return &StreamsApi_StopStreamProcessor_Call{Call: _e.mock.On("StopStreamProcessor", ctx, groupId, tenantName, processorName)}
 }
 
@@ -3143,24 +3143,24 @@ func (_c *StreamsApi_StopStreamProcessor_Call) RunAndReturn(run func(context.Con
 }
 
 // StopStreamProcessorExecute provides a mock function with given fields: r
-func (_m *StreamsApi) StopStreamProcessorExecute(r admin.StopStreamProcessorApiRequest) (interface{}, *http.Response, error) {
+func (_m *StreamsApi) StopStreamProcessorExecute(r admin.StopStreamProcessorApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StopStreamProcessorExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.StopStreamProcessorApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.StopStreamProcessorApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.StopStreamProcessorApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.StopStreamProcessorApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -3188,7 +3188,7 @@ type StreamsApi_StopStreamProcessorExecute_Call struct {
 
 // StopStreamProcessorExecute is a helper method to define mock.On call
 //   - r admin.StopStreamProcessorApiRequest
-func (_e *StreamsApi_Expecter) StopStreamProcessorExecute(r interface{}) *StreamsApi_StopStreamProcessorExecute_Call {
+func (_e *StreamsApi_Expecter) StopStreamProcessorExecute(r any) *StreamsApi_StopStreamProcessorExecute_Call {
 	return &StreamsApi_StopStreamProcessorExecute_Call{Call: _e.mock.On("StopStreamProcessorExecute", r)}
 }
 
@@ -3199,12 +3199,12 @@ func (_c *StreamsApi_StopStreamProcessorExecute_Call) Run(run func(r admin.StopS
 	return _c
 }
 
-func (_c *StreamsApi_StopStreamProcessorExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *StreamsApi_StopStreamProcessorExecute_Call {
+func (_c *StreamsApi_StopStreamProcessorExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *StreamsApi_StopStreamProcessorExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *StreamsApi_StopStreamProcessorExecute_Call) RunAndReturn(run func(admin.StopStreamProcessorApiRequest) (interface{}, *http.Response, error)) *StreamsApi_StopStreamProcessorExecute_Call {
+func (_c *StreamsApi_StopStreamProcessorExecute_Call) RunAndReturn(run func(admin.StopStreamProcessorApiRequest) (any, *http.Response, error)) *StreamsApi_StopStreamProcessorExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3235,7 +3235,7 @@ type StreamsApi_StopStreamProcessorWithParams_Call struct {
 // StopStreamProcessorWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.StopStreamProcessorApiParams
-func (_e *StreamsApi_Expecter) StopStreamProcessorWithParams(ctx interface{}, args interface{}) *StreamsApi_StopStreamProcessorWithParams_Call {
+func (_e *StreamsApi_Expecter) StopStreamProcessorWithParams(ctx any, args any) *StreamsApi_StopStreamProcessorWithParams_Call {
 	return &StreamsApi_StopStreamProcessorWithParams_Call{Call: _e.mock.On("StopStreamProcessorWithParams", ctx, args)}
 }
 
@@ -3285,7 +3285,7 @@ type StreamsApi_UpdateStreamConnection_Call struct {
 //   - tenantName string
 //   - connectionName string
 //   - streamsConnection *admin.StreamsConnection
-func (_e *StreamsApi_Expecter) UpdateStreamConnection(ctx interface{}, groupId interface{}, tenantName interface{}, connectionName interface{}, streamsConnection interface{}) *StreamsApi_UpdateStreamConnection_Call {
+func (_e *StreamsApi_Expecter) UpdateStreamConnection(ctx any, groupId any, tenantName any, connectionName any, streamsConnection any) *StreamsApi_UpdateStreamConnection_Call {
 	return &StreamsApi_UpdateStreamConnection_Call{Call: _e.mock.On("UpdateStreamConnection", ctx, groupId, tenantName, connectionName, streamsConnection)}
 }
 
@@ -3352,7 +3352,7 @@ type StreamsApi_UpdateStreamConnectionExecute_Call struct {
 
 // UpdateStreamConnectionExecute is a helper method to define mock.On call
 //   - r admin.UpdateStreamConnectionApiRequest
-func (_e *StreamsApi_Expecter) UpdateStreamConnectionExecute(r interface{}) *StreamsApi_UpdateStreamConnectionExecute_Call {
+func (_e *StreamsApi_Expecter) UpdateStreamConnectionExecute(r any) *StreamsApi_UpdateStreamConnectionExecute_Call {
 	return &StreamsApi_UpdateStreamConnectionExecute_Call{Call: _e.mock.On("UpdateStreamConnectionExecute", r)}
 }
 
@@ -3399,7 +3399,7 @@ type StreamsApi_UpdateStreamConnectionWithParams_Call struct {
 // UpdateStreamConnectionWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateStreamConnectionApiParams
-func (_e *StreamsApi_Expecter) UpdateStreamConnectionWithParams(ctx interface{}, args interface{}) *StreamsApi_UpdateStreamConnectionWithParams_Call {
+func (_e *StreamsApi_Expecter) UpdateStreamConnectionWithParams(ctx any, args any) *StreamsApi_UpdateStreamConnectionWithParams_Call {
 	return &StreamsApi_UpdateStreamConnectionWithParams_Call{Call: _e.mock.On("UpdateStreamConnectionWithParams", ctx, args)}
 }
 
@@ -3448,7 +3448,7 @@ type StreamsApi_UpdateStreamInstance_Call struct {
 //   - groupId string
 //   - tenantName string
 //   - streamsDataProcessRegion *admin.StreamsDataProcessRegion
-func (_e *StreamsApi_Expecter) UpdateStreamInstance(ctx interface{}, groupId interface{}, tenantName interface{}, streamsDataProcessRegion interface{}) *StreamsApi_UpdateStreamInstance_Call {
+func (_e *StreamsApi_Expecter) UpdateStreamInstance(ctx any, groupId any, tenantName any, streamsDataProcessRegion any) *StreamsApi_UpdateStreamInstance_Call {
 	return &StreamsApi_UpdateStreamInstance_Call{Call: _e.mock.On("UpdateStreamInstance", ctx, groupId, tenantName, streamsDataProcessRegion)}
 }
 
@@ -3515,7 +3515,7 @@ type StreamsApi_UpdateStreamInstanceExecute_Call struct {
 
 // UpdateStreamInstanceExecute is a helper method to define mock.On call
 //   - r admin.UpdateStreamInstanceApiRequest
-func (_e *StreamsApi_Expecter) UpdateStreamInstanceExecute(r interface{}) *StreamsApi_UpdateStreamInstanceExecute_Call {
+func (_e *StreamsApi_Expecter) UpdateStreamInstanceExecute(r any) *StreamsApi_UpdateStreamInstanceExecute_Call {
 	return &StreamsApi_UpdateStreamInstanceExecute_Call{Call: _e.mock.On("UpdateStreamInstanceExecute", r)}
 }
 
@@ -3562,7 +3562,7 @@ type StreamsApi_UpdateStreamInstanceWithParams_Call struct {
 // UpdateStreamInstanceWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateStreamInstanceApiParams
-func (_e *StreamsApi_Expecter) UpdateStreamInstanceWithParams(ctx interface{}, args interface{}) *StreamsApi_UpdateStreamInstanceWithParams_Call {
+func (_e *StreamsApi_Expecter) UpdateStreamInstanceWithParams(ctx any, args any) *StreamsApi_UpdateStreamInstanceWithParams_Call {
 	return &StreamsApi_UpdateStreamInstanceWithParams_Call{Call: _e.mock.On("UpdateStreamInstanceWithParams", ctx, args)}
 }
 

--- a/mockadmin/teams_api.go
+++ b/mockadmin/teams_api.go
@@ -52,7 +52,7 @@ type TeamsApi_AddAllTeamsToProject_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - teamRole *[]admin.TeamRole
-func (_e *TeamsApi_Expecter) AddAllTeamsToProject(ctx interface{}, groupId interface{}, teamRole interface{}) *TeamsApi_AddAllTeamsToProject_Call {
+func (_e *TeamsApi_Expecter) AddAllTeamsToProject(ctx any, groupId any, teamRole any) *TeamsApi_AddAllTeamsToProject_Call {
 	return &TeamsApi_AddAllTeamsToProject_Call{Call: _e.mock.On("AddAllTeamsToProject", ctx, groupId, teamRole)}
 }
 
@@ -119,7 +119,7 @@ type TeamsApi_AddAllTeamsToProjectExecute_Call struct {
 
 // AddAllTeamsToProjectExecute is a helper method to define mock.On call
 //   - r admin.AddAllTeamsToProjectApiRequest
-func (_e *TeamsApi_Expecter) AddAllTeamsToProjectExecute(r interface{}) *TeamsApi_AddAllTeamsToProjectExecute_Call {
+func (_e *TeamsApi_Expecter) AddAllTeamsToProjectExecute(r any) *TeamsApi_AddAllTeamsToProjectExecute_Call {
 	return &TeamsApi_AddAllTeamsToProjectExecute_Call{Call: _e.mock.On("AddAllTeamsToProjectExecute", r)}
 }
 
@@ -166,7 +166,7 @@ type TeamsApi_AddAllTeamsToProjectWithParams_Call struct {
 // AddAllTeamsToProjectWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.AddAllTeamsToProjectApiParams
-func (_e *TeamsApi_Expecter) AddAllTeamsToProjectWithParams(ctx interface{}, args interface{}) *TeamsApi_AddAllTeamsToProjectWithParams_Call {
+func (_e *TeamsApi_Expecter) AddAllTeamsToProjectWithParams(ctx any, args any) *TeamsApi_AddAllTeamsToProjectWithParams_Call {
 	return &TeamsApi_AddAllTeamsToProjectWithParams_Call{Call: _e.mock.On("AddAllTeamsToProjectWithParams", ctx, args)}
 }
 
@@ -215,7 +215,7 @@ type TeamsApi_AddTeamUser_Call struct {
 //   - orgId string
 //   - teamId string
 //   - addUserToTeam *[]admin.AddUserToTeam
-func (_e *TeamsApi_Expecter) AddTeamUser(ctx interface{}, orgId interface{}, teamId interface{}, addUserToTeam interface{}) *TeamsApi_AddTeamUser_Call {
+func (_e *TeamsApi_Expecter) AddTeamUser(ctx any, orgId any, teamId any, addUserToTeam any) *TeamsApi_AddTeamUser_Call {
 	return &TeamsApi_AddTeamUser_Call{Call: _e.mock.On("AddTeamUser", ctx, orgId, teamId, addUserToTeam)}
 }
 
@@ -282,7 +282,7 @@ type TeamsApi_AddTeamUserExecute_Call struct {
 
 // AddTeamUserExecute is a helper method to define mock.On call
 //   - r admin.AddTeamUserApiRequest
-func (_e *TeamsApi_Expecter) AddTeamUserExecute(r interface{}) *TeamsApi_AddTeamUserExecute_Call {
+func (_e *TeamsApi_Expecter) AddTeamUserExecute(r any) *TeamsApi_AddTeamUserExecute_Call {
 	return &TeamsApi_AddTeamUserExecute_Call{Call: _e.mock.On("AddTeamUserExecute", r)}
 }
 
@@ -329,7 +329,7 @@ type TeamsApi_AddTeamUserWithParams_Call struct {
 // AddTeamUserWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.AddTeamUserApiParams
-func (_e *TeamsApi_Expecter) AddTeamUserWithParams(ctx interface{}, args interface{}) *TeamsApi_AddTeamUserWithParams_Call {
+func (_e *TeamsApi_Expecter) AddTeamUserWithParams(ctx any, args any) *TeamsApi_AddTeamUserWithParams_Call {
 	return &TeamsApi_AddTeamUserWithParams_Call{Call: _e.mock.On("AddTeamUserWithParams", ctx, args)}
 }
 
@@ -377,7 +377,7 @@ type TeamsApi_CreateTeam_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - team *admin.Team
-func (_e *TeamsApi_Expecter) CreateTeam(ctx interface{}, orgId interface{}, team interface{}) *TeamsApi_CreateTeam_Call {
+func (_e *TeamsApi_Expecter) CreateTeam(ctx any, orgId any, team any) *TeamsApi_CreateTeam_Call {
 	return &TeamsApi_CreateTeam_Call{Call: _e.mock.On("CreateTeam", ctx, orgId, team)}
 }
 
@@ -444,7 +444,7 @@ type TeamsApi_CreateTeamExecute_Call struct {
 
 // CreateTeamExecute is a helper method to define mock.On call
 //   - r admin.CreateTeamApiRequest
-func (_e *TeamsApi_Expecter) CreateTeamExecute(r interface{}) *TeamsApi_CreateTeamExecute_Call {
+func (_e *TeamsApi_Expecter) CreateTeamExecute(r any) *TeamsApi_CreateTeamExecute_Call {
 	return &TeamsApi_CreateTeamExecute_Call{Call: _e.mock.On("CreateTeamExecute", r)}
 }
 
@@ -491,7 +491,7 @@ type TeamsApi_CreateTeamWithParams_Call struct {
 // CreateTeamWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateTeamApiParams
-func (_e *TeamsApi_Expecter) CreateTeamWithParams(ctx interface{}, args interface{}) *TeamsApi_CreateTeamWithParams_Call {
+func (_e *TeamsApi_Expecter) CreateTeamWithParams(ctx any, args any) *TeamsApi_CreateTeamWithParams_Call {
 	return &TeamsApi_CreateTeamWithParams_Call{Call: _e.mock.On("CreateTeamWithParams", ctx, args)}
 }
 
@@ -539,7 +539,7 @@ type TeamsApi_DeleteTeam_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - teamId string
-func (_e *TeamsApi_Expecter) DeleteTeam(ctx interface{}, orgId interface{}, teamId interface{}) *TeamsApi_DeleteTeam_Call {
+func (_e *TeamsApi_Expecter) DeleteTeam(ctx any, orgId any, teamId any) *TeamsApi_DeleteTeam_Call {
 	return &TeamsApi_DeleteTeam_Call{Call: _e.mock.On("DeleteTeam", ctx, orgId, teamId)}
 }
 
@@ -561,24 +561,24 @@ func (_c *TeamsApi_DeleteTeam_Call) RunAndReturn(run func(context.Context, strin
 }
 
 // DeleteTeamExecute provides a mock function with given fields: r
-func (_m *TeamsApi) DeleteTeamExecute(r admin.DeleteTeamApiRequest) (interface{}, *http.Response, error) {
+func (_m *TeamsApi) DeleteTeamExecute(r admin.DeleteTeamApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteTeamExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteTeamApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteTeamApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteTeamApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteTeamApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -606,7 +606,7 @@ type TeamsApi_DeleteTeamExecute_Call struct {
 
 // DeleteTeamExecute is a helper method to define mock.On call
 //   - r admin.DeleteTeamApiRequest
-func (_e *TeamsApi_Expecter) DeleteTeamExecute(r interface{}) *TeamsApi_DeleteTeamExecute_Call {
+func (_e *TeamsApi_Expecter) DeleteTeamExecute(r any) *TeamsApi_DeleteTeamExecute_Call {
 	return &TeamsApi_DeleteTeamExecute_Call{Call: _e.mock.On("DeleteTeamExecute", r)}
 }
 
@@ -617,12 +617,12 @@ func (_c *TeamsApi_DeleteTeamExecute_Call) Run(run func(r admin.DeleteTeamApiReq
 	return _c
 }
 
-func (_c *TeamsApi_DeleteTeamExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *TeamsApi_DeleteTeamExecute_Call {
+func (_c *TeamsApi_DeleteTeamExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *TeamsApi_DeleteTeamExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *TeamsApi_DeleteTeamExecute_Call) RunAndReturn(run func(admin.DeleteTeamApiRequest) (interface{}, *http.Response, error)) *TeamsApi_DeleteTeamExecute_Call {
+func (_c *TeamsApi_DeleteTeamExecute_Call) RunAndReturn(run func(admin.DeleteTeamApiRequest) (any, *http.Response, error)) *TeamsApi_DeleteTeamExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -653,7 +653,7 @@ type TeamsApi_DeleteTeamWithParams_Call struct {
 // DeleteTeamWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteTeamApiParams
-func (_e *TeamsApi_Expecter) DeleteTeamWithParams(ctx interface{}, args interface{}) *TeamsApi_DeleteTeamWithParams_Call {
+func (_e *TeamsApi_Expecter) DeleteTeamWithParams(ctx any, args any) *TeamsApi_DeleteTeamWithParams_Call {
 	return &TeamsApi_DeleteTeamWithParams_Call{Call: _e.mock.On("DeleteTeamWithParams", ctx, args)}
 }
 
@@ -701,7 +701,7 @@ type TeamsApi_GetTeamById_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - teamId string
-func (_e *TeamsApi_Expecter) GetTeamById(ctx interface{}, orgId interface{}, teamId interface{}) *TeamsApi_GetTeamById_Call {
+func (_e *TeamsApi_Expecter) GetTeamById(ctx any, orgId any, teamId any) *TeamsApi_GetTeamById_Call {
 	return &TeamsApi_GetTeamById_Call{Call: _e.mock.On("GetTeamById", ctx, orgId, teamId)}
 }
 
@@ -768,7 +768,7 @@ type TeamsApi_GetTeamByIdExecute_Call struct {
 
 // GetTeamByIdExecute is a helper method to define mock.On call
 //   - r admin.GetTeamByIdApiRequest
-func (_e *TeamsApi_Expecter) GetTeamByIdExecute(r interface{}) *TeamsApi_GetTeamByIdExecute_Call {
+func (_e *TeamsApi_Expecter) GetTeamByIdExecute(r any) *TeamsApi_GetTeamByIdExecute_Call {
 	return &TeamsApi_GetTeamByIdExecute_Call{Call: _e.mock.On("GetTeamByIdExecute", r)}
 }
 
@@ -815,7 +815,7 @@ type TeamsApi_GetTeamByIdWithParams_Call struct {
 // GetTeamByIdWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetTeamByIdApiParams
-func (_e *TeamsApi_Expecter) GetTeamByIdWithParams(ctx interface{}, args interface{}) *TeamsApi_GetTeamByIdWithParams_Call {
+func (_e *TeamsApi_Expecter) GetTeamByIdWithParams(ctx any, args any) *TeamsApi_GetTeamByIdWithParams_Call {
 	return &TeamsApi_GetTeamByIdWithParams_Call{Call: _e.mock.On("GetTeamByIdWithParams", ctx, args)}
 }
 
@@ -863,7 +863,7 @@ type TeamsApi_GetTeamByName_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - teamName string
-func (_e *TeamsApi_Expecter) GetTeamByName(ctx interface{}, orgId interface{}, teamName interface{}) *TeamsApi_GetTeamByName_Call {
+func (_e *TeamsApi_Expecter) GetTeamByName(ctx any, orgId any, teamName any) *TeamsApi_GetTeamByName_Call {
 	return &TeamsApi_GetTeamByName_Call{Call: _e.mock.On("GetTeamByName", ctx, orgId, teamName)}
 }
 
@@ -930,7 +930,7 @@ type TeamsApi_GetTeamByNameExecute_Call struct {
 
 // GetTeamByNameExecute is a helper method to define mock.On call
 //   - r admin.GetTeamByNameApiRequest
-func (_e *TeamsApi_Expecter) GetTeamByNameExecute(r interface{}) *TeamsApi_GetTeamByNameExecute_Call {
+func (_e *TeamsApi_Expecter) GetTeamByNameExecute(r any) *TeamsApi_GetTeamByNameExecute_Call {
 	return &TeamsApi_GetTeamByNameExecute_Call{Call: _e.mock.On("GetTeamByNameExecute", r)}
 }
 
@@ -977,7 +977,7 @@ type TeamsApi_GetTeamByNameWithParams_Call struct {
 // GetTeamByNameWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetTeamByNameApiParams
-func (_e *TeamsApi_Expecter) GetTeamByNameWithParams(ctx interface{}, args interface{}) *TeamsApi_GetTeamByNameWithParams_Call {
+func (_e *TeamsApi_Expecter) GetTeamByNameWithParams(ctx any, args any) *TeamsApi_GetTeamByNameWithParams_Call {
 	return &TeamsApi_GetTeamByNameWithParams_Call{Call: _e.mock.On("GetTeamByNameWithParams", ctx, args)}
 }
 
@@ -1024,7 +1024,7 @@ type TeamsApi_ListOrganizationTeams_Call struct {
 // ListOrganizationTeams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - orgId string
-func (_e *TeamsApi_Expecter) ListOrganizationTeams(ctx interface{}, orgId interface{}) *TeamsApi_ListOrganizationTeams_Call {
+func (_e *TeamsApi_Expecter) ListOrganizationTeams(ctx any, orgId any) *TeamsApi_ListOrganizationTeams_Call {
 	return &TeamsApi_ListOrganizationTeams_Call{Call: _e.mock.On("ListOrganizationTeams", ctx, orgId)}
 }
 
@@ -1091,7 +1091,7 @@ type TeamsApi_ListOrganizationTeamsExecute_Call struct {
 
 // ListOrganizationTeamsExecute is a helper method to define mock.On call
 //   - r admin.ListOrganizationTeamsApiRequest
-func (_e *TeamsApi_Expecter) ListOrganizationTeamsExecute(r interface{}) *TeamsApi_ListOrganizationTeamsExecute_Call {
+func (_e *TeamsApi_Expecter) ListOrganizationTeamsExecute(r any) *TeamsApi_ListOrganizationTeamsExecute_Call {
 	return &TeamsApi_ListOrganizationTeamsExecute_Call{Call: _e.mock.On("ListOrganizationTeamsExecute", r)}
 }
 
@@ -1138,7 +1138,7 @@ type TeamsApi_ListOrganizationTeamsWithParams_Call struct {
 // ListOrganizationTeamsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListOrganizationTeamsApiParams
-func (_e *TeamsApi_Expecter) ListOrganizationTeamsWithParams(ctx interface{}, args interface{}) *TeamsApi_ListOrganizationTeamsWithParams_Call {
+func (_e *TeamsApi_Expecter) ListOrganizationTeamsWithParams(ctx any, args any) *TeamsApi_ListOrganizationTeamsWithParams_Call {
 	return &TeamsApi_ListOrganizationTeamsWithParams_Call{Call: _e.mock.On("ListOrganizationTeamsWithParams", ctx, args)}
 }
 
@@ -1185,7 +1185,7 @@ type TeamsApi_ListProjectTeams_Call struct {
 // ListProjectTeams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *TeamsApi_Expecter) ListProjectTeams(ctx interface{}, groupId interface{}) *TeamsApi_ListProjectTeams_Call {
+func (_e *TeamsApi_Expecter) ListProjectTeams(ctx any, groupId any) *TeamsApi_ListProjectTeams_Call {
 	return &TeamsApi_ListProjectTeams_Call{Call: _e.mock.On("ListProjectTeams", ctx, groupId)}
 }
 
@@ -1252,7 +1252,7 @@ type TeamsApi_ListProjectTeamsExecute_Call struct {
 
 // ListProjectTeamsExecute is a helper method to define mock.On call
 //   - r admin.ListProjectTeamsApiRequest
-func (_e *TeamsApi_Expecter) ListProjectTeamsExecute(r interface{}) *TeamsApi_ListProjectTeamsExecute_Call {
+func (_e *TeamsApi_Expecter) ListProjectTeamsExecute(r any) *TeamsApi_ListProjectTeamsExecute_Call {
 	return &TeamsApi_ListProjectTeamsExecute_Call{Call: _e.mock.On("ListProjectTeamsExecute", r)}
 }
 
@@ -1299,7 +1299,7 @@ type TeamsApi_ListProjectTeamsWithParams_Call struct {
 // ListProjectTeamsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListProjectTeamsApiParams
-func (_e *TeamsApi_Expecter) ListProjectTeamsWithParams(ctx interface{}, args interface{}) *TeamsApi_ListProjectTeamsWithParams_Call {
+func (_e *TeamsApi_Expecter) ListProjectTeamsWithParams(ctx any, args any) *TeamsApi_ListProjectTeamsWithParams_Call {
 	return &TeamsApi_ListProjectTeamsWithParams_Call{Call: _e.mock.On("ListProjectTeamsWithParams", ctx, args)}
 }
 
@@ -1347,7 +1347,7 @@ type TeamsApi_ListTeamUsers_Call struct {
 //   - ctx context.Context
 //   - orgId string
 //   - teamId string
-func (_e *TeamsApi_Expecter) ListTeamUsers(ctx interface{}, orgId interface{}, teamId interface{}) *TeamsApi_ListTeamUsers_Call {
+func (_e *TeamsApi_Expecter) ListTeamUsers(ctx any, orgId any, teamId any) *TeamsApi_ListTeamUsers_Call {
 	return &TeamsApi_ListTeamUsers_Call{Call: _e.mock.On("ListTeamUsers", ctx, orgId, teamId)}
 }
 
@@ -1414,7 +1414,7 @@ type TeamsApi_ListTeamUsersExecute_Call struct {
 
 // ListTeamUsersExecute is a helper method to define mock.On call
 //   - r admin.ListTeamUsersApiRequest
-func (_e *TeamsApi_Expecter) ListTeamUsersExecute(r interface{}) *TeamsApi_ListTeamUsersExecute_Call {
+func (_e *TeamsApi_Expecter) ListTeamUsersExecute(r any) *TeamsApi_ListTeamUsersExecute_Call {
 	return &TeamsApi_ListTeamUsersExecute_Call{Call: _e.mock.On("ListTeamUsersExecute", r)}
 }
 
@@ -1461,7 +1461,7 @@ type TeamsApi_ListTeamUsersWithParams_Call struct {
 // ListTeamUsersWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListTeamUsersApiParams
-func (_e *TeamsApi_Expecter) ListTeamUsersWithParams(ctx interface{}, args interface{}) *TeamsApi_ListTeamUsersWithParams_Call {
+func (_e *TeamsApi_Expecter) ListTeamUsersWithParams(ctx any, args any) *TeamsApi_ListTeamUsersWithParams_Call {
 	return &TeamsApi_ListTeamUsersWithParams_Call{Call: _e.mock.On("ListTeamUsersWithParams", ctx, args)}
 }
 
@@ -1509,7 +1509,7 @@ type TeamsApi_RemoveProjectTeam_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - teamId string
-func (_e *TeamsApi_Expecter) RemoveProjectTeam(ctx interface{}, groupId interface{}, teamId interface{}) *TeamsApi_RemoveProjectTeam_Call {
+func (_e *TeamsApi_Expecter) RemoveProjectTeam(ctx any, groupId any, teamId any) *TeamsApi_RemoveProjectTeam_Call {
 	return &TeamsApi_RemoveProjectTeam_Call{Call: _e.mock.On("RemoveProjectTeam", ctx, groupId, teamId)}
 }
 
@@ -1567,7 +1567,7 @@ type TeamsApi_RemoveProjectTeamExecute_Call struct {
 
 // RemoveProjectTeamExecute is a helper method to define mock.On call
 //   - r admin.RemoveProjectTeamApiRequest
-func (_e *TeamsApi_Expecter) RemoveProjectTeamExecute(r interface{}) *TeamsApi_RemoveProjectTeamExecute_Call {
+func (_e *TeamsApi_Expecter) RemoveProjectTeamExecute(r any) *TeamsApi_RemoveProjectTeamExecute_Call {
 	return &TeamsApi_RemoveProjectTeamExecute_Call{Call: _e.mock.On("RemoveProjectTeamExecute", r)}
 }
 
@@ -1614,7 +1614,7 @@ type TeamsApi_RemoveProjectTeamWithParams_Call struct {
 // RemoveProjectTeamWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.RemoveProjectTeamApiParams
-func (_e *TeamsApi_Expecter) RemoveProjectTeamWithParams(ctx interface{}, args interface{}) *TeamsApi_RemoveProjectTeamWithParams_Call {
+func (_e *TeamsApi_Expecter) RemoveProjectTeamWithParams(ctx any, args any) *TeamsApi_RemoveProjectTeamWithParams_Call {
 	return &TeamsApi_RemoveProjectTeamWithParams_Call{Call: _e.mock.On("RemoveProjectTeamWithParams", ctx, args)}
 }
 
@@ -1663,7 +1663,7 @@ type TeamsApi_RemoveTeamUser_Call struct {
 //   - orgId string
 //   - teamId string
 //   - userId string
-func (_e *TeamsApi_Expecter) RemoveTeamUser(ctx interface{}, orgId interface{}, teamId interface{}, userId interface{}) *TeamsApi_RemoveTeamUser_Call {
+func (_e *TeamsApi_Expecter) RemoveTeamUser(ctx any, orgId any, teamId any, userId any) *TeamsApi_RemoveTeamUser_Call {
 	return &TeamsApi_RemoveTeamUser_Call{Call: _e.mock.On("RemoveTeamUser", ctx, orgId, teamId, userId)}
 }
 
@@ -1721,7 +1721,7 @@ type TeamsApi_RemoveTeamUserExecute_Call struct {
 
 // RemoveTeamUserExecute is a helper method to define mock.On call
 //   - r admin.RemoveTeamUserApiRequest
-func (_e *TeamsApi_Expecter) RemoveTeamUserExecute(r interface{}) *TeamsApi_RemoveTeamUserExecute_Call {
+func (_e *TeamsApi_Expecter) RemoveTeamUserExecute(r any) *TeamsApi_RemoveTeamUserExecute_Call {
 	return &TeamsApi_RemoveTeamUserExecute_Call{Call: _e.mock.On("RemoveTeamUserExecute", r)}
 }
 
@@ -1768,7 +1768,7 @@ type TeamsApi_RemoveTeamUserWithParams_Call struct {
 // RemoveTeamUserWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.RemoveTeamUserApiParams
-func (_e *TeamsApi_Expecter) RemoveTeamUserWithParams(ctx interface{}, args interface{}) *TeamsApi_RemoveTeamUserWithParams_Call {
+func (_e *TeamsApi_Expecter) RemoveTeamUserWithParams(ctx any, args any) *TeamsApi_RemoveTeamUserWithParams_Call {
 	return &TeamsApi_RemoveTeamUserWithParams_Call{Call: _e.mock.On("RemoveTeamUserWithParams", ctx, args)}
 }
 
@@ -1817,7 +1817,7 @@ type TeamsApi_RenameTeam_Call struct {
 //   - orgId string
 //   - teamId string
 //   - teamUpdate *admin.TeamUpdate
-func (_e *TeamsApi_Expecter) RenameTeam(ctx interface{}, orgId interface{}, teamId interface{}, teamUpdate interface{}) *TeamsApi_RenameTeam_Call {
+func (_e *TeamsApi_Expecter) RenameTeam(ctx any, orgId any, teamId any, teamUpdate any) *TeamsApi_RenameTeam_Call {
 	return &TeamsApi_RenameTeam_Call{Call: _e.mock.On("RenameTeam", ctx, orgId, teamId, teamUpdate)}
 }
 
@@ -1884,7 +1884,7 @@ type TeamsApi_RenameTeamExecute_Call struct {
 
 // RenameTeamExecute is a helper method to define mock.On call
 //   - r admin.RenameTeamApiRequest
-func (_e *TeamsApi_Expecter) RenameTeamExecute(r interface{}) *TeamsApi_RenameTeamExecute_Call {
+func (_e *TeamsApi_Expecter) RenameTeamExecute(r any) *TeamsApi_RenameTeamExecute_Call {
 	return &TeamsApi_RenameTeamExecute_Call{Call: _e.mock.On("RenameTeamExecute", r)}
 }
 
@@ -1931,7 +1931,7 @@ type TeamsApi_RenameTeamWithParams_Call struct {
 // RenameTeamWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.RenameTeamApiParams
-func (_e *TeamsApi_Expecter) RenameTeamWithParams(ctx interface{}, args interface{}) *TeamsApi_RenameTeamWithParams_Call {
+func (_e *TeamsApi_Expecter) RenameTeamWithParams(ctx any, args any) *TeamsApi_RenameTeamWithParams_Call {
 	return &TeamsApi_RenameTeamWithParams_Call{Call: _e.mock.On("RenameTeamWithParams", ctx, args)}
 }
 
@@ -1980,7 +1980,7 @@ type TeamsApi_UpdateTeamRoles_Call struct {
 //   - groupId string
 //   - teamId string
 //   - teamRole *admin.TeamRole
-func (_e *TeamsApi_Expecter) UpdateTeamRoles(ctx interface{}, groupId interface{}, teamId interface{}, teamRole interface{}) *TeamsApi_UpdateTeamRoles_Call {
+func (_e *TeamsApi_Expecter) UpdateTeamRoles(ctx any, groupId any, teamId any, teamRole any) *TeamsApi_UpdateTeamRoles_Call {
 	return &TeamsApi_UpdateTeamRoles_Call{Call: _e.mock.On("UpdateTeamRoles", ctx, groupId, teamId, teamRole)}
 }
 
@@ -2047,7 +2047,7 @@ type TeamsApi_UpdateTeamRolesExecute_Call struct {
 
 // UpdateTeamRolesExecute is a helper method to define mock.On call
 //   - r admin.UpdateTeamRolesApiRequest
-func (_e *TeamsApi_Expecter) UpdateTeamRolesExecute(r interface{}) *TeamsApi_UpdateTeamRolesExecute_Call {
+func (_e *TeamsApi_Expecter) UpdateTeamRolesExecute(r any) *TeamsApi_UpdateTeamRolesExecute_Call {
 	return &TeamsApi_UpdateTeamRolesExecute_Call{Call: _e.mock.On("UpdateTeamRolesExecute", r)}
 }
 
@@ -2094,7 +2094,7 @@ type TeamsApi_UpdateTeamRolesWithParams_Call struct {
 // UpdateTeamRolesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateTeamRolesApiParams
-func (_e *TeamsApi_Expecter) UpdateTeamRolesWithParams(ctx interface{}, args interface{}) *TeamsApi_UpdateTeamRolesWithParams_Call {
+func (_e *TeamsApi_Expecter) UpdateTeamRolesWithParams(ctx any, args any) *TeamsApi_UpdateTeamRolesWithParams_Call {
 	return &TeamsApi_UpdateTeamRolesWithParams_Call{Call: _e.mock.On("UpdateTeamRolesWithParams", ctx, args)}
 }
 

--- a/mockadmin/third_party_integrations_api.go
+++ b/mockadmin/third_party_integrations_api.go
@@ -53,7 +53,7 @@ type ThirdPartyIntegrationsApi_CreateThirdPartyIntegration_Call struct {
 //   - integrationType string
 //   - groupId string
 //   - thirdPartyIntegration *admin.ThirdPartyIntegration
-func (_e *ThirdPartyIntegrationsApi_Expecter) CreateThirdPartyIntegration(ctx interface{}, integrationType interface{}, groupId interface{}, thirdPartyIntegration interface{}) *ThirdPartyIntegrationsApi_CreateThirdPartyIntegration_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) CreateThirdPartyIntegration(ctx any, integrationType any, groupId any, thirdPartyIntegration any) *ThirdPartyIntegrationsApi_CreateThirdPartyIntegration_Call {
 	return &ThirdPartyIntegrationsApi_CreateThirdPartyIntegration_Call{Call: _e.mock.On("CreateThirdPartyIntegration", ctx, integrationType, groupId, thirdPartyIntegration)}
 }
 
@@ -120,7 +120,7 @@ type ThirdPartyIntegrationsApi_CreateThirdPartyIntegrationExecute_Call struct {
 
 // CreateThirdPartyIntegrationExecute is a helper method to define mock.On call
 //   - r admin.CreateThirdPartyIntegrationApiRequest
-func (_e *ThirdPartyIntegrationsApi_Expecter) CreateThirdPartyIntegrationExecute(r interface{}) *ThirdPartyIntegrationsApi_CreateThirdPartyIntegrationExecute_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) CreateThirdPartyIntegrationExecute(r any) *ThirdPartyIntegrationsApi_CreateThirdPartyIntegrationExecute_Call {
 	return &ThirdPartyIntegrationsApi_CreateThirdPartyIntegrationExecute_Call{Call: _e.mock.On("CreateThirdPartyIntegrationExecute", r)}
 }
 
@@ -167,7 +167,7 @@ type ThirdPartyIntegrationsApi_CreateThirdPartyIntegrationWithParams_Call struct
 // CreateThirdPartyIntegrationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateThirdPartyIntegrationApiParams
-func (_e *ThirdPartyIntegrationsApi_Expecter) CreateThirdPartyIntegrationWithParams(ctx interface{}, args interface{}) *ThirdPartyIntegrationsApi_CreateThirdPartyIntegrationWithParams_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) CreateThirdPartyIntegrationWithParams(ctx any, args any) *ThirdPartyIntegrationsApi_CreateThirdPartyIntegrationWithParams_Call {
 	return &ThirdPartyIntegrationsApi_CreateThirdPartyIntegrationWithParams_Call{Call: _e.mock.On("CreateThirdPartyIntegrationWithParams", ctx, args)}
 }
 
@@ -215,7 +215,7 @@ type ThirdPartyIntegrationsApi_DeleteThirdPartyIntegration_Call struct {
 //   - ctx context.Context
 //   - integrationType string
 //   - groupId string
-func (_e *ThirdPartyIntegrationsApi_Expecter) DeleteThirdPartyIntegration(ctx interface{}, integrationType interface{}, groupId interface{}) *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegration_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) DeleteThirdPartyIntegration(ctx any, integrationType any, groupId any) *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegration_Call {
 	return &ThirdPartyIntegrationsApi_DeleteThirdPartyIntegration_Call{Call: _e.mock.On("DeleteThirdPartyIntegration", ctx, integrationType, groupId)}
 }
 
@@ -237,24 +237,24 @@ func (_c *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegration_Call) RunAndRetu
 }
 
 // DeleteThirdPartyIntegrationExecute provides a mock function with given fields: r
-func (_m *ThirdPartyIntegrationsApi) DeleteThirdPartyIntegrationExecute(r admin.DeleteThirdPartyIntegrationApiRequest) (interface{}, *http.Response, error) {
+func (_m *ThirdPartyIntegrationsApi) DeleteThirdPartyIntegrationExecute(r admin.DeleteThirdPartyIntegrationApiRequest) (any, *http.Response, error) {
 	ret := _m.Called(r)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteThirdPartyIntegrationExecute")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 *http.Response
 	var r2 error
-	if rf, ok := ret.Get(0).(func(admin.DeleteThirdPartyIntegrationApiRequest) (interface{}, *http.Response, error)); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteThirdPartyIntegrationApiRequest) (any, *http.Response, error)); ok {
 		return rf(r)
 	}
-	if rf, ok := ret.Get(0).(func(admin.DeleteThirdPartyIntegrationApiRequest) interface{}); ok {
+	if rf, ok := ret.Get(0).(func(admin.DeleteThirdPartyIntegrationApiRequest) any); ok {
 		r0 = rf(r)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 
@@ -282,7 +282,7 @@ type ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call struct {
 
 // DeleteThirdPartyIntegrationExecute is a helper method to define mock.On call
 //   - r admin.DeleteThirdPartyIntegrationApiRequest
-func (_e *ThirdPartyIntegrationsApi_Expecter) DeleteThirdPartyIntegrationExecute(r interface{}) *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) DeleteThirdPartyIntegrationExecute(r any) *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call {
 	return &ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call{Call: _e.mock.On("DeleteThirdPartyIntegrationExecute", r)}
 }
 
@@ -293,12 +293,12 @@ func (_c *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call) Run
 	return _c
 }
 
-func (_c *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call) Return(_a0 interface{}, _a1 *http.Response, _a2 error) *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call {
+func (_c *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call) Return(_a0 any, _a1 *http.Response, _a2 error) *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call) RunAndReturn(run func(admin.DeleteThirdPartyIntegrationApiRequest) (interface{}, *http.Response, error)) *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call {
+func (_c *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call) RunAndReturn(run func(admin.DeleteThirdPartyIntegrationApiRequest) (any, *http.Response, error)) *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationExecute_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -329,7 +329,7 @@ type ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationWithParams_Call struct
 // DeleteThirdPartyIntegrationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DeleteThirdPartyIntegrationApiParams
-func (_e *ThirdPartyIntegrationsApi_Expecter) DeleteThirdPartyIntegrationWithParams(ctx interface{}, args interface{}) *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationWithParams_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) DeleteThirdPartyIntegrationWithParams(ctx any, args any) *ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationWithParams_Call {
 	return &ThirdPartyIntegrationsApi_DeleteThirdPartyIntegrationWithParams_Call{Call: _e.mock.On("DeleteThirdPartyIntegrationWithParams", ctx, args)}
 }
 
@@ -377,7 +377,7 @@ type ThirdPartyIntegrationsApi_GetThirdPartyIntegration_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - integrationType string
-func (_e *ThirdPartyIntegrationsApi_Expecter) GetThirdPartyIntegration(ctx interface{}, groupId interface{}, integrationType interface{}) *ThirdPartyIntegrationsApi_GetThirdPartyIntegration_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) GetThirdPartyIntegration(ctx any, groupId any, integrationType any) *ThirdPartyIntegrationsApi_GetThirdPartyIntegration_Call {
 	return &ThirdPartyIntegrationsApi_GetThirdPartyIntegration_Call{Call: _e.mock.On("GetThirdPartyIntegration", ctx, groupId, integrationType)}
 }
 
@@ -444,7 +444,7 @@ type ThirdPartyIntegrationsApi_GetThirdPartyIntegrationExecute_Call struct {
 
 // GetThirdPartyIntegrationExecute is a helper method to define mock.On call
 //   - r admin.GetThirdPartyIntegrationApiRequest
-func (_e *ThirdPartyIntegrationsApi_Expecter) GetThirdPartyIntegrationExecute(r interface{}) *ThirdPartyIntegrationsApi_GetThirdPartyIntegrationExecute_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) GetThirdPartyIntegrationExecute(r any) *ThirdPartyIntegrationsApi_GetThirdPartyIntegrationExecute_Call {
 	return &ThirdPartyIntegrationsApi_GetThirdPartyIntegrationExecute_Call{Call: _e.mock.On("GetThirdPartyIntegrationExecute", r)}
 }
 
@@ -491,7 +491,7 @@ type ThirdPartyIntegrationsApi_GetThirdPartyIntegrationWithParams_Call struct {
 // GetThirdPartyIntegrationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.GetThirdPartyIntegrationApiParams
-func (_e *ThirdPartyIntegrationsApi_Expecter) GetThirdPartyIntegrationWithParams(ctx interface{}, args interface{}) *ThirdPartyIntegrationsApi_GetThirdPartyIntegrationWithParams_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) GetThirdPartyIntegrationWithParams(ctx any, args any) *ThirdPartyIntegrationsApi_GetThirdPartyIntegrationWithParams_Call {
 	return &ThirdPartyIntegrationsApi_GetThirdPartyIntegrationWithParams_Call{Call: _e.mock.On("GetThirdPartyIntegrationWithParams", ctx, args)}
 }
 
@@ -538,7 +538,7 @@ type ThirdPartyIntegrationsApi_ListThirdPartyIntegrations_Call struct {
 // ListThirdPartyIntegrations is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *ThirdPartyIntegrationsApi_Expecter) ListThirdPartyIntegrations(ctx interface{}, groupId interface{}) *ThirdPartyIntegrationsApi_ListThirdPartyIntegrations_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) ListThirdPartyIntegrations(ctx any, groupId any) *ThirdPartyIntegrationsApi_ListThirdPartyIntegrations_Call {
 	return &ThirdPartyIntegrationsApi_ListThirdPartyIntegrations_Call{Call: _e.mock.On("ListThirdPartyIntegrations", ctx, groupId)}
 }
 
@@ -605,7 +605,7 @@ type ThirdPartyIntegrationsApi_ListThirdPartyIntegrationsExecute_Call struct {
 
 // ListThirdPartyIntegrationsExecute is a helper method to define mock.On call
 //   - r admin.ListThirdPartyIntegrationsApiRequest
-func (_e *ThirdPartyIntegrationsApi_Expecter) ListThirdPartyIntegrationsExecute(r interface{}) *ThirdPartyIntegrationsApi_ListThirdPartyIntegrationsExecute_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) ListThirdPartyIntegrationsExecute(r any) *ThirdPartyIntegrationsApi_ListThirdPartyIntegrationsExecute_Call {
 	return &ThirdPartyIntegrationsApi_ListThirdPartyIntegrationsExecute_Call{Call: _e.mock.On("ListThirdPartyIntegrationsExecute", r)}
 }
 
@@ -652,7 +652,7 @@ type ThirdPartyIntegrationsApi_ListThirdPartyIntegrationsWithParams_Call struct 
 // ListThirdPartyIntegrationsWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListThirdPartyIntegrationsApiParams
-func (_e *ThirdPartyIntegrationsApi_Expecter) ListThirdPartyIntegrationsWithParams(ctx interface{}, args interface{}) *ThirdPartyIntegrationsApi_ListThirdPartyIntegrationsWithParams_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) ListThirdPartyIntegrationsWithParams(ctx any, args any) *ThirdPartyIntegrationsApi_ListThirdPartyIntegrationsWithParams_Call {
 	return &ThirdPartyIntegrationsApi_ListThirdPartyIntegrationsWithParams_Call{Call: _e.mock.On("ListThirdPartyIntegrationsWithParams", ctx, args)}
 }
 
@@ -701,7 +701,7 @@ type ThirdPartyIntegrationsApi_UpdateThirdPartyIntegration_Call struct {
 //   - integrationType string
 //   - groupId string
 //   - thirdPartyIntegration *admin.ThirdPartyIntegration
-func (_e *ThirdPartyIntegrationsApi_Expecter) UpdateThirdPartyIntegration(ctx interface{}, integrationType interface{}, groupId interface{}, thirdPartyIntegration interface{}) *ThirdPartyIntegrationsApi_UpdateThirdPartyIntegration_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) UpdateThirdPartyIntegration(ctx any, integrationType any, groupId any, thirdPartyIntegration any) *ThirdPartyIntegrationsApi_UpdateThirdPartyIntegration_Call {
 	return &ThirdPartyIntegrationsApi_UpdateThirdPartyIntegration_Call{Call: _e.mock.On("UpdateThirdPartyIntegration", ctx, integrationType, groupId, thirdPartyIntegration)}
 }
 
@@ -768,7 +768,7 @@ type ThirdPartyIntegrationsApi_UpdateThirdPartyIntegrationExecute_Call struct {
 
 // UpdateThirdPartyIntegrationExecute is a helper method to define mock.On call
 //   - r admin.UpdateThirdPartyIntegrationApiRequest
-func (_e *ThirdPartyIntegrationsApi_Expecter) UpdateThirdPartyIntegrationExecute(r interface{}) *ThirdPartyIntegrationsApi_UpdateThirdPartyIntegrationExecute_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) UpdateThirdPartyIntegrationExecute(r any) *ThirdPartyIntegrationsApi_UpdateThirdPartyIntegrationExecute_Call {
 	return &ThirdPartyIntegrationsApi_UpdateThirdPartyIntegrationExecute_Call{Call: _e.mock.On("UpdateThirdPartyIntegrationExecute", r)}
 }
 
@@ -815,7 +815,7 @@ type ThirdPartyIntegrationsApi_UpdateThirdPartyIntegrationWithParams_Call struct
 // UpdateThirdPartyIntegrationWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.UpdateThirdPartyIntegrationApiParams
-func (_e *ThirdPartyIntegrationsApi_Expecter) UpdateThirdPartyIntegrationWithParams(ctx interface{}, args interface{}) *ThirdPartyIntegrationsApi_UpdateThirdPartyIntegrationWithParams_Call {
+func (_e *ThirdPartyIntegrationsApi_Expecter) UpdateThirdPartyIntegrationWithParams(ctx any, args any) *ThirdPartyIntegrationsApi_UpdateThirdPartyIntegrationWithParams_Call {
 	return &ThirdPartyIntegrationsApi_UpdateThirdPartyIntegrationWithParams_Call{Call: _e.mock.On("UpdateThirdPartyIntegrationWithParams", ctx, args)}
 }
 

--- a/mockadmin/x509_authentication_api.go
+++ b/mockadmin/x509_authentication_api.go
@@ -53,7 +53,7 @@ type X509AuthenticationApi_CreateDatabaseUserCertificate_Call struct {
 //   - groupId string
 //   - username string
 //   - userCert *admin.UserCert
-func (_e *X509AuthenticationApi_Expecter) CreateDatabaseUserCertificate(ctx interface{}, groupId interface{}, username interface{}, userCert interface{}) *X509AuthenticationApi_CreateDatabaseUserCertificate_Call {
+func (_e *X509AuthenticationApi_Expecter) CreateDatabaseUserCertificate(ctx any, groupId any, username any, userCert any) *X509AuthenticationApi_CreateDatabaseUserCertificate_Call {
 	return &X509AuthenticationApi_CreateDatabaseUserCertificate_Call{Call: _e.mock.On("CreateDatabaseUserCertificate", ctx, groupId, username, userCert)}
 }
 
@@ -118,7 +118,7 @@ type X509AuthenticationApi_CreateDatabaseUserCertificateExecute_Call struct {
 
 // CreateDatabaseUserCertificateExecute is a helper method to define mock.On call
 //   - r admin.CreateDatabaseUserCertificateApiRequest
-func (_e *X509AuthenticationApi_Expecter) CreateDatabaseUserCertificateExecute(r interface{}) *X509AuthenticationApi_CreateDatabaseUserCertificateExecute_Call {
+func (_e *X509AuthenticationApi_Expecter) CreateDatabaseUserCertificateExecute(r any) *X509AuthenticationApi_CreateDatabaseUserCertificateExecute_Call {
 	return &X509AuthenticationApi_CreateDatabaseUserCertificateExecute_Call{Call: _e.mock.On("CreateDatabaseUserCertificateExecute", r)}
 }
 
@@ -165,7 +165,7 @@ type X509AuthenticationApi_CreateDatabaseUserCertificateWithParams_Call struct {
 // CreateDatabaseUserCertificateWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.CreateDatabaseUserCertificateApiParams
-func (_e *X509AuthenticationApi_Expecter) CreateDatabaseUserCertificateWithParams(ctx interface{}, args interface{}) *X509AuthenticationApi_CreateDatabaseUserCertificateWithParams_Call {
+func (_e *X509AuthenticationApi_Expecter) CreateDatabaseUserCertificateWithParams(ctx any, args any) *X509AuthenticationApi_CreateDatabaseUserCertificateWithParams_Call {
 	return &X509AuthenticationApi_CreateDatabaseUserCertificateWithParams_Call{Call: _e.mock.On("CreateDatabaseUserCertificateWithParams", ctx, args)}
 }
 
@@ -212,7 +212,7 @@ type X509AuthenticationApi_DisableCustomerManagedX509_Call struct {
 // DisableCustomerManagedX509 is a helper method to define mock.On call
 //   - ctx context.Context
 //   - groupId string
-func (_e *X509AuthenticationApi_Expecter) DisableCustomerManagedX509(ctx interface{}, groupId interface{}) *X509AuthenticationApi_DisableCustomerManagedX509_Call {
+func (_e *X509AuthenticationApi_Expecter) DisableCustomerManagedX509(ctx any, groupId any) *X509AuthenticationApi_DisableCustomerManagedX509_Call {
 	return &X509AuthenticationApi_DisableCustomerManagedX509_Call{Call: _e.mock.On("DisableCustomerManagedX509", ctx, groupId)}
 }
 
@@ -279,7 +279,7 @@ type X509AuthenticationApi_DisableCustomerManagedX509Execute_Call struct {
 
 // DisableCustomerManagedX509Execute is a helper method to define mock.On call
 //   - r admin.DisableCustomerManagedX509ApiRequest
-func (_e *X509AuthenticationApi_Expecter) DisableCustomerManagedX509Execute(r interface{}) *X509AuthenticationApi_DisableCustomerManagedX509Execute_Call {
+func (_e *X509AuthenticationApi_Expecter) DisableCustomerManagedX509Execute(r any) *X509AuthenticationApi_DisableCustomerManagedX509Execute_Call {
 	return &X509AuthenticationApi_DisableCustomerManagedX509Execute_Call{Call: _e.mock.On("DisableCustomerManagedX509Execute", r)}
 }
 
@@ -326,7 +326,7 @@ type X509AuthenticationApi_DisableCustomerManagedX509WithParams_Call struct {
 // DisableCustomerManagedX509WithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.DisableCustomerManagedX509ApiParams
-func (_e *X509AuthenticationApi_Expecter) DisableCustomerManagedX509WithParams(ctx interface{}, args interface{}) *X509AuthenticationApi_DisableCustomerManagedX509WithParams_Call {
+func (_e *X509AuthenticationApi_Expecter) DisableCustomerManagedX509WithParams(ctx any, args any) *X509AuthenticationApi_DisableCustomerManagedX509WithParams_Call {
 	return &X509AuthenticationApi_DisableCustomerManagedX509WithParams_Call{Call: _e.mock.On("DisableCustomerManagedX509WithParams", ctx, args)}
 }
 
@@ -374,7 +374,7 @@ type X509AuthenticationApi_ListDatabaseUserCertificates_Call struct {
 //   - ctx context.Context
 //   - groupId string
 //   - username string
-func (_e *X509AuthenticationApi_Expecter) ListDatabaseUserCertificates(ctx interface{}, groupId interface{}, username interface{}) *X509AuthenticationApi_ListDatabaseUserCertificates_Call {
+func (_e *X509AuthenticationApi_Expecter) ListDatabaseUserCertificates(ctx any, groupId any, username any) *X509AuthenticationApi_ListDatabaseUserCertificates_Call {
 	return &X509AuthenticationApi_ListDatabaseUserCertificates_Call{Call: _e.mock.On("ListDatabaseUserCertificates", ctx, groupId, username)}
 }
 
@@ -441,7 +441,7 @@ type X509AuthenticationApi_ListDatabaseUserCertificatesExecute_Call struct {
 
 // ListDatabaseUserCertificatesExecute is a helper method to define mock.On call
 //   - r admin.ListDatabaseUserCertificatesApiRequest
-func (_e *X509AuthenticationApi_Expecter) ListDatabaseUserCertificatesExecute(r interface{}) *X509AuthenticationApi_ListDatabaseUserCertificatesExecute_Call {
+func (_e *X509AuthenticationApi_Expecter) ListDatabaseUserCertificatesExecute(r any) *X509AuthenticationApi_ListDatabaseUserCertificatesExecute_Call {
 	return &X509AuthenticationApi_ListDatabaseUserCertificatesExecute_Call{Call: _e.mock.On("ListDatabaseUserCertificatesExecute", r)}
 }
 
@@ -488,7 +488,7 @@ type X509AuthenticationApi_ListDatabaseUserCertificatesWithParams_Call struct {
 // ListDatabaseUserCertificatesWithParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - args *admin.ListDatabaseUserCertificatesApiParams
-func (_e *X509AuthenticationApi_Expecter) ListDatabaseUserCertificatesWithParams(ctx interface{}, args interface{}) *X509AuthenticationApi_ListDatabaseUserCertificatesWithParams_Call {
+func (_e *X509AuthenticationApi_Expecter) ListDatabaseUserCertificatesWithParams(ctx any, args any) *X509AuthenticationApi_ListDatabaseUserCertificatesWithParams_Call {
 	return &X509AuthenticationApi_ListDatabaseUserCertificatesWithParams_Call{Call: _e.mock.On("ListDatabaseUserCertificatesWithParams", ctx, args)}
 }
 

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -141,7 +141,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#pathParams
 func (a *{{{classname}}}Service) {{{nickname}}}Execute(r {{operationId}}ApiRequest) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.Method{{httpMethod}}
-		localVarPostBody     interface{}
+		localVarPostBody     any
 		formFiles            []formFile
 		{{#returnType}}
 		localVarReturnValue  {{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}

--- a/tools/config/go-templates/client.mustache
+++ b/tools/config/go-templates/client.mustache
@@ -113,7 +113,7 @@ func contains(haystack []string, needle string) bool {
 	return false
 }
 
-func parameterValueToString( obj interface{}, key string ) string {
+func parameterValueToString( obj any, key string ) string {
 	if reflect.TypeOf(obj).Kind() != reflect.Ptr {
 		return fmt.Sprintf("%v", obj)
 	}
@@ -130,7 +130,7 @@ func parameterValueToString( obj interface{}, key string ) string {
 
 // parameterAddToHeaderOrQuery adds the provided object to the request header or url query
 // supporting deep object syntax
-func parameterAddToHeaderOrQuery(headerOrQueryParams interface{}, keyPrefix string, obj interface{}, collectionType string) {
+func parameterAddToHeaderOrQuery(headerOrQueryParams any, keyPrefix string, obj any, collectionType string) {
 	var v = reflect.ValueOf(obj)
 	var value = ""
 	if v == reflect.ValueOf(nil) {
@@ -254,7 +254,7 @@ type formFile struct {
 func (c *APIClient) prepareRequest(
 	ctx context.Context,
 	path string, method string,
-	postBody interface{},
+	postBody any,
 	headerParams map[string]string,
 	queryParams url.Values,
 	formParams url.Values,
@@ -497,7 +497,7 @@ func (c *APIClient) makeApiError(res *http.Response, httpMethod, httpPath string
 	return newErr
 }
 
-func (c *APIClient) decode(v interface{}, b io.ReadCloser, contentType string) (err error) {
+func (c *APIClient) decode(v any, b io.ReadCloser, contentType string) (err error) {
 	switch r := v.(type) {
 	case *string:
 		buf, err := io.ReadAll(b)
@@ -526,7 +526,7 @@ func (c *APIClient) decode(v interface{}, b io.ReadCloser, contentType string) (
 			return xml.Unmarshal(buf, v);
 		}
 		if jsonCheck.MatchString(contentType) {
-			if actualObj, ok := v.(interface{ GetActualInstance() interface{} }); ok { // oneOf, anyOf schemas
+			if actualObj, ok := v.(interface{ GetActualInstance() any }); ok { // oneOf, anyOf schemas
 				if unmarshalObj, ok := actualObj.(interface{ UnmarshalJSON([]byte) error }); ok { // make sure it has UnmarshalJSON defined
 					if err = unmarshalObj.UnmarshalJSON(buf); err != nil {
 						return err
@@ -564,12 +564,12 @@ func addFile(w *multipart.Writer, fieldName, path string) error {
 }
 
 // Prevent trying to import "fmt"
-func reportError(format string, a ...interface{}) error {
+func reportError(format string, a ...any) error {
 	return fmt.Errorf(format, a...)
 }
 
-// Set request body from an interface{}
-func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err error) {
+// Set request body from an any
+func setBody(body any, contentType string) (bodyBuf *bytes.Buffer, err error) {
 	bodyBuf = &bytes.Buffer{}
 
 	if reader, ok := body.(io.Reader); ok {
@@ -600,7 +600,7 @@ func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err e
 }
 
 // detectContentType method is used to figure out `Request.Body` content type for request header
-func detectContentType(body interface{}) string {
+func detectContentType(body any) string {
 	contentType := "text/plain; charset=utf-8"
 	kind := reflect.TypeOf(body).Kind()
 

--- a/tools/config/go-templates/model_anyof.mustache
+++ b/tools/config/go-templates/model_anyof.mustache
@@ -19,7 +19,7 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	{{#mappedModels}}
 	{{#-first}}
 	// use discriminator value to speed up the lookup
-	var jsonDict map[string]interface{}
+	var jsonDict map[string]any
 	err = json.Unmarshal(data, &jsonDict)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal JSON into map for the discriminator lookup")

--- a/tools/config/go-templates/model_oneof.mustache
+++ b/tools/config/go-templates/model_oneof.mustache
@@ -30,7 +30,7 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	{{#mappedModels}}
 	{{#-first}}
 	// use discriminator value to speed up the lookup
-	var jsonDict map[string]interface{}
+	var jsonDict map[string]any
 	err = newStrictDecoder(data).Decode(&jsonDict)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal JSON into map for the discriminator lookup")
@@ -127,7 +127,7 @@ func (src {{classname}}) MarshalJSON() ([]byte, error) {
 }
 
 // Get the actual instance
-func (obj *{{classname}}) GetActualInstance() (interface{}) {
+func (obj *{{classname}}) GetActualInstance() (any) {
 	if obj == nil {
 		return nil
 	}

--- a/tools/config/go-templates/model_simple.mustache
+++ b/tools/config/go-templates/model_simple.mustache
@@ -29,7 +29,7 @@ type {{classname}} struct {
 	{{name}} {{^required}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
 {{#isAdditionalPropertiesTrue}}
-	AdditionalProperties map[string]interface{}
+	AdditionalProperties map[string]any
 {{/isAdditionalPropertiesTrue}}
 }
 

--- a/tools/config/go-templates/utils.mustache
+++ b/tools/config/go-templates/utils.mustache
@@ -31,11 +31,11 @@ func PtrString(v string) *string { return &v }
 func PtrTime(v time.Time) *time.Time { return &v }
 
 type modelWithMap interface {
-	ToMap() (map[string]interface{}, error)
+	ToMap() (map[string]any, error)
 }
 
 // IsNil checks if an input is nil
-func IsNil(i interface{}) bool {
+func IsNil(i any) bool {
 	if i == nil {
 		return true
 	}

--- a/tools/scripts/generate.sh
+++ b/tools/scripts/generate.sh
@@ -34,6 +34,7 @@ npm exec openapi-generator-cli -- generate \
     --package-name="$client_package" \
     --type-mappings=integer=int \
     --type-mappings=object=interface{} \
+    --type-mappings=interface{}=any \
     --type-mappings=file=io.ReadCloser \
     --ignore-file-override=config/.go-ignore
 

--- a/tools/scripts/generate_docs.sh
+++ b/tools/scripts/generate_docs.sh
@@ -24,7 +24,8 @@ npm exec openapi-generator-cli -- generate \
     -c "./config/config.yaml" -i "$openapiFileLocation" -o "$DOC_FOLDER" \
     --package-name="$client_package" \
     --type-mappings=integer=int \
-    --type-mappings=object=any \
+    --type-mappings=object=interface{} \
+    --type-mappings=interface{}=any \
     --type-mappings=file=io.ReadCloser \
     --ignore-file-override=config/.go-ignore-docs
 

--- a/tools/scripts/generate_docs.sh
+++ b/tools/scripts/generate_docs.sh
@@ -24,7 +24,7 @@ npm exec openapi-generator-cli -- generate \
     -c "./config/config.yaml" -i "$openapiFileLocation" -o "$DOC_FOLDER" \
     --package-name="$client_package" \
     --type-mappings=integer=int \
-    --type-mappings=object=interface{} \
+    --type-mappings=object=any \
     --type-mappings=file=io.ReadCloser \
     --ignore-file-override=config/.go-ignore-docs
 

--- a/tools/scripts/generate_mocks.sh
+++ b/tools/scripts/generate_mocks.sh
@@ -7,3 +7,7 @@ if ! which mockery ; then
 else
 	mockery --dir ../mockadmin
 fi
+
+# Use any instead of interface{} in genereated mocks
+npm install
+npm exec -c "replace-in-file /interface{}/g any  ../mockadmin/**/*.go --isRegex"

--- a/tools/scripts/generate_tests.sh
+++ b/tools/scripts/generate_tests.sh
@@ -16,7 +16,8 @@ npm exec openapi-generator-cli -- generate \
     -c "./config/config.yaml" -i "$openapiFileLocation" -o "$FOLDER" \
     --package-name="$client_package" \
     --type-mappings=integer=int \
-    --type-mappings=object=any \
+    --type-mappings=object=interface{} \
+    --type-mappings=interface{}=any \
     --type-mappings=file=io.ReadCloser \
     --ignore-file-override=config/.go-ignore-tests
 

--- a/tools/scripts/generate_tests.sh
+++ b/tools/scripts/generate_tests.sh
@@ -16,7 +16,7 @@ npm exec openapi-generator-cli -- generate \
     -c "./config/config.yaml" -i "$openapiFileLocation" -o "$FOLDER" \
     --package-name="$client_package" \
     --type-mappings=integer=int \
-    --type-mappings=object=interface{} \
+    --type-mappings=object=any \
     --type-mappings=file=io.ReadCloser \
     --ignore-file-override=config/.go-ignore-tests
 

--- a/tools/transformer/src/transformations/additionalPropertiesObject.js
+++ b/tools/transformer/src/transformations/additionalPropertiesObject.js
@@ -1,7 +1,7 @@
 /**
  * Remove all AdditonalProperties object section
  * That generates an map[string]map[string]string objects for SDK
- * but for our API much safer is to rely on the map[string]interface{}
+ * but for our API much safer is to rely on the map[string]any
  * This is due to the fact that dynamic field can be array which would
  * not be possible to represent in map[string]map[string]string structure.
  * @param {*} api OpenAPI JSON File


### PR DESCRIPTION
## Description

Rename interface{} to any.

No need to review .go or .md files as they're auto-generated, review changes in templates and scripts.

NOTE: there are a few leftovers of interface{} in docs but don't seem easy to change using openapi-generator, maybe replacing strings in files.

Change tested in Terraform: https://github.com/mongodb/terraform-provider-mongodbatlas/compare/test_any?expand=1
Test execution: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/11230665305


Link to any related issue(s): CLOUDP-276360

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

