### PR TITLE
chore: Adds status code to errors when code >= 3xx

### DIFF
--- a/admin/client.go
+++ b/admin/client.go
@@ -520,7 +520,7 @@ func (c *APIClient) makeApiError(res *http.Response, httpMethod, httpPath string
 
 	localVarBody, err := io.ReadAll(res.Body)
 	if err != nil {
-		newErr.error = err.Error()
+		newErr.error = fmt.Sprintf("(%s) failed to read response body: %s", res.Status, err.Error())
 		return newErr
 	}
 	newErr.body = localVarBody
@@ -528,7 +528,7 @@ func (c *APIClient) makeApiError(res *http.Response, httpMethod, httpPath string
 	var v ApiError
 	err = c.decode(&v, io.NopCloser(bytes.NewBuffer(localVarBody)), res.Header.Get("Content-Type"))
 	if err != nil {
-		newErr.error = err.Error()
+		newErr.error = fmt.Sprintf("(%s) failed to decode response body: %s", res.Status, err.Error())
 		return newErr
 	}
 	newErr.error = FormatErrorMessageWithDetails(res.Status, httpMethod, httpPath, v)


### PR DESCRIPTION
## Description

Adds status code to errors when code >= 3xx

Link to any related issue(s): CLOUDP-270745

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

