### PR TITLE
CLOUDP-261727: Breaking changes engine improvements

### DIFF
--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -19,6 +19,8 @@ jobs:
         run: make fetch_openapi
       - name: Override OpenAPI spec # TEMPORARY, WILL BE REVERTED BEFORE MERGE, USE OPEN API SPEC IN https://github.com/mongodb/atlas-sdk-go/pull/390
         run: curl -sSfL -o openapi/atlas-api.yaml https://raw.githubusercontent.com/mongodb/atlas-sdk-go/46a77abc48d7f644c31e130fcbbd5c3f8b0ab497/openapi/atlas-api.yaml
+      - name: Override this GHA file # TEMPORARY, WILL BE REVERTED BEFORE MERGE
+        run: curl -sSfL -o .github/workflows/autoupdate-prod.yaml https://raw.githubusercontent.com/mongodb/atlas-sdk-go/refs/heads/main/.github/workflows/autoupdate-prod.yaml
       - name: Commit OpenAPI changes
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -17,6 +17,8 @@ jobs:
       - name: Fetch changes
         working-directory: ./tools
         run: make fetch_openapi
+      - name: Override OpenAPI spec # TEMPORARY, WILL BE REVERTED BEFORE MERGE, USE OPEN API SPEC IN https://github.com/mongodb/atlas-sdk-go/pull/390
+        run: curl -sSfL -o openapi/atlas-api.yaml https://raw.githubusercontent.com/mongodb/atlas-sdk-go/46a77abc48d7f644c31e130fcbbd5c3f8b0ab497/openapi/atlas-api.yaml
       - name: Commit OpenAPI changes
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main # make it easier to do changes and verify this GHA as it can be executed from the branch in the WIP PR but will take changes from main branch
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -17,8 +17,6 @@ jobs:
       - name: Fetch changes
         working-directory: ./tools
         run: make fetch_openapi
-      - name: Override OpenAPI spec # TEMPORARY, WILL BE REVERTED BEFORE MERGE, USE OPEN API SPEC IN https://github.com/mongodb/atlas-sdk-go/pull/390
-        run: curl -sSfL -o openapi/atlas-api.yaml https://raw.githubusercontent.com/mongodb/atlas-sdk-go/46a77abc48d7f644c31e130fcbbd5c3f8b0ab497/openapi/atlas-api.yaml
       - name: Commit OpenAPI changes
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: main # make it easier to do changes and verify this GHA as it can be executed from the branch in the WIP PR but will take changes from main branch
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -37,28 +37,29 @@ jobs:
         with:
           files: |
              ./admin/**/*
-      - name: Exit job if no files changed
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
-        run: |
-          echo "No files changed, exiting job"
-          exit 0
       - name: Run docs generation
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: make gen-docs
       - name: Commit Generator Changes
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: |
           git add . && git commit -m "fix: Generated SDK source code and docs"
       - run: echo "API_DIFF_NEW_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Release updates
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
         working-directory: ./tools
         run: make new-release  
       - name: Ensure all markdown code is formatted
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
         working-directory: ./tools
         run: |
           npm install && npm run format
       - name: Run mock generation
         working-directory: ./tools
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: make generate_mocks  
       - uses: peter-evans/create-pull-request@v7
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
         with:
           token: ${{ secrets.APIX_BOT_PAT }}
           title: "APIBot: SDK update based on recent changes in Atlas API"

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -36,28 +36,27 @@ jobs:
         with:
           files: |
              ./admin/**/*
-      - name: Run docs generation
+      - name: Exit job if no files changed
         if: steps.verify-changed-files.outputs.files_changed == 'true'
+        run: |
+          echo "No files changed, exiting job"
+          exit 0
+      - name: Run docs generation
         run: make gen-docs
       - name: Commit Generator Changes
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: |
           git add . && git commit -m "fix: Generated SDK source code and docs"
       - name: Release updates
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
         working-directory: ./tools
         run: make new-release  
       - name: Ensure all markdown code is formatted
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
         working-directory: ./tools
         run: |
           npm install && npm run format
       - name: Run mock generation
         working-directory: ./tools
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: make generate_mocks  
       - uses: peter-evans/create-pull-request@v7
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
         with:
           token: ${{ secrets.APIX_BOT_PAT }}
           title: "APIBot: SDK update based on recent changes in Atlas API"

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -25,7 +25,8 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git add .
           git commit --allow-empty -m "fix: update OpenAPI spec"
-      - run: echo "API_DIFF_OLD_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      - name: Set old commit for SDK API diff
+        run: echo "API_DIFF_OLD_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Run generation
         working-directory: ./tools
         run: |
@@ -44,7 +45,9 @@ jobs:
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: |
           git add . && git commit -m "fix: Generated SDK source code and docs"
-      - run: echo "API_DIFF_NEW_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      - name: Set new commit for SDK API diff
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        run: echo "API_DIFF_NEW_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Release updates
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         working-directory: ./tools

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -46,10 +46,7 @@ jobs:
       - name: Release updates
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         working-directory: ./tools
-        env:
-          GIT_BASE_REF: ${{ github.sha }}
-        run: |
-          make new-release  
+        run: make new-release  
       - name: Ensure all markdown code is formatted
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         working-directory: ./tools

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -25,6 +25,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git add .
           git commit --allow-empty -m "fix: update OpenAPI spec"
+      - run: echo "API_DIFF_OLD_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Run generation
         working-directory: ./tools
         run: |
@@ -46,6 +47,7 @@ jobs:
       - name: Commit Generator Changes
         run: |
           git add . && git commit -m "fix: Generated SDK source code and docs"
+      - run: echo "API_DIFF_NEW_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Release updates
         working-directory: ./tools
         run: make new-release  

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -19,8 +19,6 @@ jobs:
         run: make fetch_openapi
       - name: Override OpenAPI spec # TEMPORARY, WILL BE REVERTED BEFORE MERGE, USE OPEN API SPEC IN https://github.com/mongodb/atlas-sdk-go/pull/390
         run: curl -sSfL -o openapi/atlas-api.yaml https://raw.githubusercontent.com/mongodb/atlas-sdk-go/46a77abc48d7f644c31e130fcbbd5c3f8b0ab497/openapi/atlas-api.yaml
-      - name: Override this GHA file # TEMPORARY, WILL BE REVERTED BEFORE MERGE
-        run: curl -sSfL -o .github/workflows/autoupdate-prod.yaml https://raw.githubusercontent.com/mongodb/atlas-sdk-go/refs/heads/main/.github/workflows/autoupdate-prod.yaml
       - name: Commit OpenAPI changes
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/tools/CONTRIBUTING.md
+++ b/tools/CONTRIBUTING.md
@@ -49,5 +49,5 @@ https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-ge
 ## Go API Diff
 
 We use [go-apidiff](https://github.com/joelanford/go-apidiff) to detect if there are breaking changes and a new major version release is needed.
-In [Generate SDK Github action](../.github/workdlows/autoupdate-prod.yaml), `API_DIFF_OLD_COMMIT` and `API_DIFF_NEW_COMMIT` are used to do the comparison.
+In [Generate SDK Github action](../.github/workflows/autoupdate-prod.yaml), `API_DIFF_OLD_COMMIT` and `API_DIFF_NEW_COMMIT` are used to do the comparison.
 

--- a/tools/CONTRIBUTING.md
+++ b/tools/CONTRIBUTING.md
@@ -50,4 +50,3 @@ https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-ge
 
 We use [go-apidiff](https://github.com/joelanford/go-apidiff) to detect if there are breaking changes and a new major version release is needed.
 In [Generate SDK Github action](../.github/workflows/autoupdate-prod.yaml), `API_DIFF_OLD_COMMIT` and `API_DIFF_NEW_COMMIT` are used to do the comparison.
-

--- a/tools/CONTRIBUTING.md
+++ b/tools/CONTRIBUTING.md
@@ -45,3 +45,9 @@ This enables us to verify new templates changes.
 Templates are sourced from openapi generator:
 
 https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator/src/main/resources/go
+
+## Go API Diff
+
+We use [go-apidiff](https://github.com/joelanford/go-apidiff) to detect if there are breaking changes and a new major version release is needed.
+In [Generate SDK Github action](../.github/workdlows/autoupdate-prod.yaml), `API_DIFF_OLD_COMMIT` and `API_DIFF_NEW_COMMIT` are used to do the comparison.
+

--- a/tools/releaser/scripts/breaking-changes.sh
+++ b/tools/releaser/scripts/breaking-changes.sh
@@ -12,7 +12,7 @@ script_path=$(dirname "$0")
 echo "Installing go-apidiff"
 go install github.com/joelanford/go-apidiff@latest > /dev/null
 
-echo "Running breaking changes check for $GIT_BASE_REF"
+echo "Running breaking changes check comparing commits ${API_DIFF_OLD_COMMIT} and ${API_DIFF_NEW_COMMIT}"
 
 pushd "$script_path/../../../" || exit ## workaround for --repo-path="../" not working
 echo "Changed directory to $(pwd)"

--- a/tools/releaser/scripts/breaking-changes.sh
+++ b/tools/releaser/scripts/breaking-changes.sh
@@ -3,16 +3,13 @@ set -eu
 GOPATH=$(go env GOPATH)
 
 # Inputs:
-# GIT_BASE_REF - The base REF of the git repository (git rev-parse origin/main)
-# Usually "${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}" 
 # TARGET_BREAKING_CHANGES_FILE - file to save breaking changes
 script_path=$(dirname "$0")
 
 echo "Installing go-apidiff"
 go install github.com/joelanford/go-apidiff@latest > /dev/null
 
-current_ref=$(git rev-parse main || echo)
-GIT_BASE_REF=${GIT_BASE_REF:-$current_ref}
+GIT_BASE_REF=$(git rev-parse HEAD^)
 TARGET_BREAKING_CHANGES_FILE=${TARGET_BREAKING_CHANGES_FILE:-""}
 
 echo "Running breaking changes check for $GIT_BASE_REF"
@@ -20,7 +17,7 @@ echo "Running breaking changes check for $GIT_BASE_REF"
 pushd "$script_path/../../../" || exit ## workaround for --repo-path="../" not working
 echo "Changed directory to $(pwd)"
 set +e
-BREAKING_CHANGES=$("$GOPATH/bin/go-apidiff" "$GIT_BASE_REF" "$(git rev-parse head)" --compare-imports="false" --print-compatible="false" )
+BREAKING_CHANGES=$("$GOPATH/bin/go-apidiff" "$GIT_BASE_REF" --compare-imports="false" --print-compatible="false")
 set -e
 popd || exit
 

--- a/tools/releaser/scripts/breaking-changes.sh
+++ b/tools/releaser/scripts/breaking-changes.sh
@@ -9,12 +9,15 @@ script_path=$(dirname "$0")
 echo "Installing go-apidiff"
 go install github.com/joelanford/go-apidiff@latest > /dev/null
 
+GIT_BASE_REF=$(git rev-parse HEAD^)
 TARGET_BREAKING_CHANGES_FILE=${TARGET_BREAKING_CHANGES_FILE:-""}
+
+echo "Running breaking changes check for $GIT_BASE_REF"
 
 pushd "$script_path/../../../" || exit ## workaround for --repo-path="../" not working
 echo "Changed directory to $(pwd)"
 set +e
-BREAKING_CHANGES=$("$GOPATH/bin/go-apidiff" main --compare-imports="false" --print-compatible="false")
+BREAKING_CHANGES=$("$GOPATH/bin/go-apidiff" "$GIT_BASE_REF" --compare-imports="false" --print-compatible="false")
 set -e
 popd || exit
 

--- a/tools/releaser/scripts/breaking-changes.sh
+++ b/tools/releaser/scripts/breaking-changes.sh
@@ -3,21 +3,21 @@ set -eu
 GOPATH=$(go env GOPATH)
 
 # Inputs:
+# API_DIFF_OLD_COMMIT: commit before the API changes to compare with. If not provided, script will fail with "unbound variable" error
+# API_DIFF_NEW_COMMIT: commit with the new API changes. If not provided, script will fail with "unbound variable" error
 # TARGET_BREAKING_CHANGES_FILE - file to save breaking changes
+TARGET_BREAKING_CHANGES_FILE=${TARGET_BREAKING_CHANGES_FILE:-""}
 script_path=$(dirname "$0")
 
 echo "Installing go-apidiff"
 go install github.com/joelanford/go-apidiff@latest > /dev/null
-
-GIT_BASE_REF=$(git rev-parse HEAD^)
-TARGET_BREAKING_CHANGES_FILE=${TARGET_BREAKING_CHANGES_FILE:-""}
 
 echo "Running breaking changes check for $GIT_BASE_REF"
 
 pushd "$script_path/../../../" || exit ## workaround for --repo-path="../" not working
 echo "Changed directory to $(pwd)"
 set +e
-BREAKING_CHANGES=$("$GOPATH/bin/go-apidiff" "$GIT_BASE_REF" --compare-imports="false" --print-compatible="false")
+BREAKING_CHANGES=$("$GOPATH/bin/go-apidiff" "${API_DIFF_OLD_COMMIT}" "${API_DIFF_NEW_COMMIT}" --compare-imports="false" --print-compatible="false")
 set -e
 popd || exit
 

--- a/tools/releaser/scripts/breaking-changes.sh
+++ b/tools/releaser/scripts/breaking-changes.sh
@@ -9,15 +9,12 @@ script_path=$(dirname "$0")
 echo "Installing go-apidiff"
 go install github.com/joelanford/go-apidiff@latest > /dev/null
 
-GIT_BASE_REF=$(git rev-parse HEAD^)
 TARGET_BREAKING_CHANGES_FILE=${TARGET_BREAKING_CHANGES_FILE:-""}
-
-echo "Running breaking changes check for $GIT_BASE_REF"
 
 pushd "$script_path/../../../" || exit ## workaround for --repo-path="../" not working
 echo "Changed directory to $(pwd)"
 set +e
-BREAKING_CHANGES=$("$GOPATH/bin/go-apidiff" "$GIT_BASE_REF" --compare-imports="false" --print-compatible="false")
+BREAKING_CHANGES=$("$GOPATH/bin/go-apidiff" main --compare-imports="false" --print-compatible="false")
 set -e
 popd || exit
 


### PR DESCRIPTION
## Description

Breaking changes engine improvements. Fixes commit to compare with if there are SDK breaking changes.

Link to any related issue(s): CLOUDP-261727

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

Before this PR, changes for API spec in PR 290 showed this. There are breaking changes so there should be a major release but it isn't.
https://github.com/mongodb/atlas-sdk-go/actions/runs/11344491264/job/31549328777
https://github.com/mongodb/atlas-sdk-go/pull/433/files#diff-429330c1bd13608c65647ca92e155a5d314420aac3bc6438011f00754a44d652
![before](https://github.com/user-attachments/assets/aeb113f8-1304-45d1-b0d8-35aecde43158)


With this PR there is a new major release, and file `tools/releaser/breaking_changes/v20240805005.md` is generated correctly:
https://github.com/mongodb/atlas-sdk-go/actions/runs/11363986358/job/31609079124
https://github.com/mongodb/atlas-sdk-go/pull/440/files#diff-429330c1bd13608c65647ca92e155a5d314420aac3bc6438011f00754a44d652

![after1](https://github.com/user-attachments/assets/3f2d67e5-46a4-455a-8082-5948d0792a59)

![after2](https://github.com/user-attachments/assets/46cd74df-b065-4bdf-9fec-65d54edeb92e)
