### PR TITLE
task: update codeowners to list only APIx Integrations team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # Maintained by the API experience team
-* @mongodb/apix1 @mongodb/APIx-Integrations
+* @mongodb/APIx-Integrations
 
 # All docs
 /docs @mongodb/docs-cloud-team
 
 # Docs exemptions
-/docs/docs @mongodb/apix1 @mongodb/APIx-Integrations
-/docs/doc_last_reference.md @mongodb/apix1 @mongodb/APIx-Integrations
-/docs/README.md @mongodb/apix1 @mongodb/APIx-Integrations
+/docs/docs @mongodb/APIx-Integrations
+/docs/doc_last_reference.md @mongodb/APIx-Integrations
+/docs/README.md @mongodb/APIx-Integrations


### PR DESCRIPTION
## Description

TL;DR - APIx Integrations approval is required for all PRs on the SDK-go
APIx1 will still be notified, but cannot merge without APIx Integrations approval.

<img width="950" alt="Screenshot 2024-10-15 at 18 32 20" src="https://github.com/user-attachments/assets/5243c9ed-0c6e-4cfd-9c4f-7ed07d80364f">

