### PR TITLE
CLOUDP-279931: Add ability to control user agent for token endpoints

### DIFF
--- a/admin/atlas_client.go
+++ b/admin/atlas_client.go
@@ -2,9 +2,7 @@ package admin // import "go.mongodb.org/atlas-sdk/v20240805005/admin"
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
-	"runtime"
 	"strings"
 
 	"github.com/mongodb-forks/digest"
@@ -12,24 +10,19 @@ import (
 )
 
 const (
-	// DefaultCloudURL is default base URL for the services.
-	DefaultCloudURL = "https://cloud.mongodb.com"
 	// Version the version of the current API client inherited from.
 	Version = core.Version
-	// ClientName of the v2 API client.
-	ClientName = "go-atlas-sdk-admin"
 )
 
 // NewClient returns a new API Client.
 func NewClient(modifiers ...ClientModifier) (*APIClient, error) {
-	userAgent := fmt.Sprintf("%s/%s (%s;%s)", ClientName, Version, runtime.GOOS, runtime.GOARCH)
 	defaultConfig := &Configuration{
 		HTTPClient: http.DefaultClient,
 		Servers: ServerConfigurations{ServerConfiguration{
-			URL: DefaultCloudURL,
+			URL: core.DefaultCloudURL,
 		},
 		},
-		UserAgent: userAgent,
+		UserAgent: core.DefaultUserAgent,
 	}
 	for _, modifierFunction := range modifiers {
 		err := modifierFunction(defaultConfig)
@@ -87,7 +80,7 @@ func UseDebug(debug bool) ClientModifier {
 func UseBaseURL(baseURL string) ClientModifier {
 	return func(c *Configuration) error {
 		if baseURL == "" {
-			baseURL = DefaultCloudURL
+			baseURL = core.DefaultCloudURL
 		}
 		urlWithoutSuffix := strings.TrimSuffix(baseURL, "/")
 		c.Servers = ServerConfigurations{ServerConfiguration{

--- a/auth/credentials/api.go
+++ b/auth/credentials/api.go
@@ -2,6 +2,7 @@ package credentials
 
 import (
 	"context"
+	"go.mongodb.org/atlas-sdk/v20240805005/internal/core"
 	"net/http"
 )
 
@@ -11,13 +12,15 @@ import (
 const tokenAPIPath = "/api/oauth/token"
 
 // serverURL for atlas API
-const serverURL = "https://cloud.mongodb.com" + tokenAPIPath
+const serverURL = core.DefaultCloudURL + tokenAPIPath
 
 // AtlasTokenSourceOptions provides set of input arguments
 // for creation of credentials.TokenSource interface
 type AtlasTokenSourceOptions struct {
 	ClientID     string
 	ClientSecret string
+	// Custom user agent. core.DefaultUserAgent being default
+	UserAgent string
 	// Custom Token source. InMemoryTokenCache being default
 	TokenCache LocalTokenCache
 
@@ -28,13 +31,19 @@ type AtlasTokenSourceOptions struct {
 }
 
 // NewTokenSourceWithOptions initializes an OAuthTokenSource with advanced credentials.AtlasTokenSourceOptions
-// Use this method to initialize custom OAuth Token Cache (filesystem).
+// Use this method to initialize custom OAuth Token Cache (filesystem) or custom User Agent header.
 func NewTokenSourceWithOptions(opts AtlasTokenSourceOptions) TokenSource {
 	var tokenURL string
 	if opts.BaseURL != nil {
 		tokenURL = *opts.BaseURL + tokenAPIPath
 	} else {
 		tokenURL = serverURL
+	}
+	var userAgent string
+	if opts.UserAgent != "" {
+		userAgent = opts.UserAgent
+	} else {
+		userAgent = core.DefaultUserAgent
 	}
 	var ctx context.Context
 	if opts.Context == nil {
@@ -46,6 +55,7 @@ func NewTokenSourceWithOptions(opts AtlasTokenSourceOptions) TokenSource {
 	return &OAuthTokenSource{
 		clientID:     opts.ClientID,
 		clientSecret: opts.ClientSecret,
+		userAgent:    userAgent,
 		tokenURL:     tokenURL,
 		tokenCache:   opts.TokenCache,
 		ctx:          ctx,
@@ -58,6 +68,7 @@ func NewTokenSource(clientID, clientSecret string) TokenSource {
 	return NewTokenSourceWithOptions(AtlasTokenSourceOptions{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
+		UserAgent:    core.DefaultUserAgent,
 		TokenCache:   &InMemoryTokenCache{},
 	})
 }

--- a/auth/credentials/api.go
+++ b/auth/credentials/api.go
@@ -31,7 +31,6 @@ type AtlasTokenSourceOptions struct {
 }
 
 // NewTokenSourceWithOptions initializes an OAuthTokenSource with advanced credentials.AtlasTokenSourceOptions
-// Use this method to initialize custom OAuth Token Cache (filesystem) or custom User Agent header.
 func NewTokenSourceWithOptions(opts AtlasTokenSourceOptions) TokenSource {
 	var tokenURL string
 	if opts.BaseURL != nil {

--- a/auth/credentials/oauth.go
+++ b/auth/credentials/oauth.go
@@ -29,6 +29,7 @@ type TokenSource interface {
 type OAuthTokenSource struct {
 	clientID     string
 	clientSecret string
+	userAgent    string
 	tokenURL     string
 	token        *Token
 	tokenCache   LocalTokenCache
@@ -81,6 +82,7 @@ func (c *OAuthTokenSource) fetchToken() (*Token, error) {
 	}
 	req.SetBasicAuth(c.clientID, c.clientSecret)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", c.userAgent)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/auth/credentials/oauth_test.go
+++ b/auth/credentials/oauth_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"go.mongodb.org/atlas-sdk/v20240805005/internal/core"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -146,7 +147,7 @@ func TestOAuthClient_FetchToken_Failure(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to obtain Token")
 }
 
-// // Test CustomTransport to ensure Token is injected into requests
+// Test CustomTransport to ensure Token is injected into requests
 func TestCustomTransport_RoundTrip(t *testing.T) {
 	// Mock the OAuth TokenCache
 	expiration := time.Now().Add(1 * time.Hour)
@@ -185,4 +186,49 @@ func TestCustomTransport_RoundTrip(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// Test default User Agent
+func TestOAuthClient_DefaultUserAgent(t *testing.T) {
+	// Assert custom User Agent
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NotNil(t, r.Header.Get("User-Agent"))
+		assert.Equal(t, core.DefaultUserAgent, r.Header.Get("User-Agent"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	mockCache := &MockTokenCache{}
+	tokenSource := NewTokenSourceWithOptions(AtlasTokenSourceOptions{
+		ClientID:     "clientID",
+		ClientSecret: "clientSecret",
+		TokenCache:   mockCache,
+		BaseURL:      &mockServer.URL,
+	})
+
+	_, _ = tokenSource.GetValidToken()
+}
+
+// Test custom User Agent
+func TestOAuthClient_CustomUserAgent(t *testing.T) {
+	const customUserAgent = "/testing"
+
+	// Assert custom User Agent
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NotNil(t, r.Header.Get("User-Agent"))
+		assert.Equal(t, customUserAgent, r.Header.Get("User-Agent"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	mockCache := &MockTokenCache{}
+	tokenSource := NewTokenSourceWithOptions(AtlasTokenSourceOptions{
+		ClientID:     "clientID",
+		ClientSecret: "clientSecret",
+		UserAgent:    customUserAgent,
+		TokenCache:   mockCache,
+		BaseURL:      &mockServer.URL,
+	})
+
+	_, _ = tokenSource.GetValidToken()
 }

--- a/auth/credentials/oauth_test.go
+++ b/auth/credentials/oauth_test.go
@@ -190,7 +190,7 @@ func TestCustomTransport_RoundTrip(t *testing.T) {
 
 // Test default User Agent
 func TestOAuthClient_DefaultUserAgent(t *testing.T) {
-	// Assert custom User Agent
+	// Assert default User Agent
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.NotNil(t, r.Header.Get("User-Agent"))
 		assert.Equal(t, core.DefaultUserAgent, r.Header.Get("User-Agent"))

--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -22,6 +22,16 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"runtime"
+)
+
+const (
+	// DefaultCloudURL is default base URL for the services.
+	DefaultCloudURL = "https://cloud.mongodb.com"
+	// ClientName of the v2 API client.
+	ClientName = "go-atlas-sdk-admin"
+	// DefaultUserAgent is default user agent header.
+	DefaultUserAgent = ClientName + "/" + Version + " (" + runtime.GOOS + ";" + runtime.GOARCH + ")"
 )
 
 // Response is a MongoDBAtlas response. This wraps the standard http.Response returned from MongoDBAtlas API.

--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -22,16 +22,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"runtime"
-)
-
-const (
-	// DefaultCloudURL is default base URL for the services.
-	DefaultCloudURL = "https://cloud.mongodb.com"
-	// ClientName of the v2 API client.
-	ClientName = "go-atlas-sdk-admin"
-	// DefaultUserAgent is default user agent header.
-	DefaultUserAgent = ClientName + "/" + Version + " (" + runtime.GOOS + ";" + runtime.GOARCH + ")"
 )
 
 // Response is a MongoDBAtlas response. This wraps the standard http.Response returned from MongoDBAtlas API.

--- a/internal/core/constants.go
+++ b/internal/core/constants.go
@@ -1,0 +1,1 @@
+package core

--- a/internal/core/constants.go
+++ b/internal/core/constants.go
@@ -1,1 +1,14 @@
 package core
+
+import (
+	"runtime"
+)
+
+const (
+	// DefaultCloudURL is default base URL for the services.
+	DefaultCloudURL = "https://cloud.mongodb.com"
+	// ClientName of the v2 API client.
+	ClientName = "go-atlas-sdk-admin"
+	// DefaultUserAgent is default user agent header.
+	DefaultUserAgent = ClientName + "/" + Version + " (" + runtime.GOOS + ";" + runtime.GOARCH + ")"
+)

--- a/tools/config/go-templates/atlas_client.mustache
+++ b/tools/config/go-templates/atlas_client.mustache
@@ -2,9 +2,7 @@
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
-	"runtime"
 	"strings"
 
 	"github.com/mongodb-forks/digest"
@@ -12,24 +10,19 @@ import (
 )
 
 const (
-	// DefaultCloudURL is default base URL for the services.
-	DefaultCloudURL = "https://cloud.mongodb.com"
 	// Version the version of the current API client inherited from.
 	Version = core.Version
-	// ClientName of the v2 API client.
-	ClientName = "go-atlas-sdk-admin"
 )
 
 // NewClient returns a new API Client.
 func NewClient(modifiers ...ClientModifier) (*APIClient, error) {
-	userAgent := fmt.Sprintf("%s/%s (%s;%s)", ClientName, Version, runtime.GOOS, runtime.GOARCH)
 	defaultConfig := &Configuration{
 		HTTPClient: http.DefaultClient,
 		Servers: ServerConfigurations{ServerConfiguration{
-			URL: DefaultCloudURL,
+			URL: core.DefaultCloudURL,
 		},
 		},
-		UserAgent: userAgent,
+		UserAgent: core.DefaultUserAgent,
 	}
 	for _, modifierFunction := range modifiers {
 		err := modifierFunction(defaultConfig)
@@ -89,7 +82,7 @@ func UseDebug(debug bool) ClientModifier {
 func UseBaseURL(baseURL string) ClientModifier {
 	return func(c *Configuration) error {
 		if baseURL == "" {
-			baseURL = DefaultCloudURL
+			baseURL = core.DefaultCloudURL
 		}
 		urlWithoutSuffix := strings.TrimSuffix(baseURL, "/")
 		c.Servers = ServerConfigurations{ServerConfiguration{


### PR DESCRIPTION
## Description

Added support for default and custom User Agent in newly introduced `OAuthTokenSource`. Also moved now shared default User Agent, DefaultCloudURL and ClientName to the `core` package for sharing between the Admin client and the token endpoints.

## Jira

[CLOUDP-279931](https://jira.mongodb.org/browse/CLOUDP-279931)

## Testing

Extended `credentials/oauth_test.go` for testing default and custom User Agent.

