### PR TITLE
CLOUDP-261809: update sdk to use mongodb/openapi

### DIFF
--- a/.github/workflows/autoupdate-preview.yaml
+++ b/.github/workflows/autoupdate-preview.yaml
@@ -19,7 +19,6 @@ jobs:
         run: make fetch_openapi
         env:
           API_BASE_URL:  https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/v2
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
       - name: Verify Changed files
         uses: tj-actions/verify-changed-files@6b59fb7cbb8d9a6ecc10ee556496d0078a9ed957
         id: verify-changed-files

--- a/.github/workflows/autoupdate-preview.yaml
+++ b/.github/workflows/autoupdate-preview.yaml
@@ -18,7 +18,7 @@ jobs:
         working-directory: ./tools
         run: make fetch_openapi
         env:
-          API_BASE_URL: ${{ secrets.MDB_CURRENT_API_PREVIEW_URL }}
+          API_BASE_URL:  https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/v2
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
       - name: Verify Changed files
         uses: tj-actions/verify-changed-files@6b59fb7cbb8d9a6ecc10ee556496d0078a9ed957

--- a/.github/workflows/autoupdate-preview.yaml
+++ b/.github/workflows/autoupdate-preview.yaml
@@ -19,7 +19,7 @@ jobs:
         run: make fetch_openapi
         env:
           API_BASE_URL: ${{ secrets.MDB_CURRENT_API_PREVIEW_URL }}
-          S3_BUCKET: ${{ secrets.MDB_CURRENT_API_PREVIEW_S3_BUCKET }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
       - name: Verify Changed files
         uses: tj-actions/verify-changed-files@6b59fb7cbb8d9a6ecc10ee556496d0078a9ed957
         id: verify-changed-files

--- a/tools/releaser/scripts/extract-version.sh
+++ b/tools/releaser/scripts/extract-version.sh
@@ -13,7 +13,7 @@ SDK_MINOR_VERSION=$(echo "$SDK_VERSION" | awk -F'.' '{print $2}')
 SDK_MAJOR_VERSION=$(echo "$SDK_VERSION" | awk -F'.' '{print $1}')
 
 # Extract the last version from the versions.json file
-HYPEN_RESOURCE_VERSION=$(cat $versions_file_path | jq -r '.versions."2.0" | .[-1]')
+HYPEN_RESOURCE_VERSION=$(cat $versions_file_path | jq -r ' .[-1]')
 NEW_RESOURCE_VERSION=$(echo "$HYPEN_RESOURCE_VERSION" | tr -d '-')
 
 echo "Extracted version from version.go file: '$SDK_VERSION'. Resource Version: '$SDK_RESOURCE_VERSION'"

--- a/tools/scripts/fetch.sh
+++ b/tools/scripts/fetch.sh
@@ -20,6 +20,8 @@ OPENAPI_FILE_NAME=${OPENAPI_FILE_NAME:-"atlas-api.yaml"}
 ## Folder used for fetching files
 OPENAPI_FOLDER=${OPENAPI_FOLDER:-"../openapi"}
 
+
+# Base URL for fetching the openapi file
 API_BASE_URL=${API_BASE_URL:https://raw.githubusercontent.com/mongodb/openapi/refs/heads/main/openapi/v2
 versions_file="versions.json"
 

--- a/tools/scripts/fetch.sh
+++ b/tools/scripts/fetch.sh
@@ -22,7 +22,7 @@ OPENAPI_FOLDER=${OPENAPI_FOLDER:-"../openapi"}
 
 
 # Base URL for fetching the openapi file
-API_BASE_URL=${API_BASE_URL:https://raw.githubusercontent.com/mongodb/openapi/refs/heads/main/openapi/v2
+API_BASE_URL=${API_BASE_URL:}https://raw.githubusercontent.com/mongodb/openapi/refs/heads/main/openapi/v2
 versions_file="versions.json"
 
 pushd "${OPENAPI_FOLDER}"

--- a/tools/scripts/fetch.sh
+++ b/tools/scripts/fetch.sh
@@ -22,7 +22,7 @@ OPENAPI_FOLDER=${OPENAPI_FOLDER:-"../openapi"}
 
 
 # Base URL for fetching the openapi file
-API_BASE_URL=${API_BASE_URL:}https://raw.githubusercontent.com/mongodb/openapi/refs/heads/main/openapi/v2
+API_BASE_URL=${API_BASE_URL:-}https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/v2
 versions_file="versions.json"
 
 pushd "${OPENAPI_FOLDER}"
@@ -31,6 +31,10 @@ echo "Fetching versions from $versions_url"
 
 curl --show-error --fail --silent -o "${versions_file}" \
      -H "Accept: application/json" "${versions_url}"
+
+# Remove "preview" from versions file if it exists and update the file
+jq 'map(select(. != "preview"))' < "./${versions_file}" > "./${versions_file}.tmp"
+mv "./${versions_file}.tmp" "./${versions_file}"
 
 ## Dynamic Versioned API Version
 CURRENT_API_REVISION=$(jq -r '.[-1]' < "./${versions_file}")

--- a/tools/scripts/fetch.sh
+++ b/tools/scripts/fetch.sh
@@ -20,17 +20,11 @@ OPENAPI_FILE_NAME=${OPENAPI_FILE_NAME:-"atlas-api.yaml"}
 ## Folder used for fetching files
 OPENAPI_FOLDER=${OPENAPI_FOLDER:-"../openapi"}
 
-## Root V2 URL
-if [ "${BRANCH_NAME:-"main"}" == "dev-latest" ]; then
-    root_v2_url=https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/v2
-else
-    root_v2_url=https://raw.githubusercontent.com/mongodb/openapi/refs/heads/main/openapi/v2
-fi
-
+API_BASE_URL=${API_BASE_URL:https://raw.githubusercontent.com/mongodb/openapi/refs/heads/main/openapi/v2
 versions_file="versions.json"
 
 pushd "${OPENAPI_FOLDER}"
-versions_url="${root_v2_url}/${versions_file}"
+versions_url="${API_BASE_URL}/${versions_file}"
 echo "Fetching versions from $versions_url"
 
 curl --show-error --fail --silent -o "${versions_file}" \
@@ -40,7 +34,7 @@ curl --show-error --fail --silent -o "${versions_file}" \
 CURRENT_API_REVISION=$(jq -r '.[-1]' < "./${versions_file}")
 
 echo "Fetching OAS file for version $CURRENT_API_REVISION"
-openapi_url=${root_v2_url}/openapi-${CURRENT_API_REVISION}.yaml
+openapi_url=${API_BASE_URL}/openapi-${CURRENT_API_REVISION}.yaml
 
 echo "Fetching api from $openapi_url to $OPENAPI_FILE_NAME"
 

--- a/tools/scripts/fetch.sh
+++ b/tools/scripts/fetch.sh
@@ -22,7 +22,7 @@ OPENAPI_FOLDER=${OPENAPI_FOLDER:-"../openapi"}
 
 
 # Base URL for fetching the openapi file
-API_BASE_URL=${API_BASE_URL:-}https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/v2
+API_BASE_URL=${API_BASE_URL:-}https://raw.githubusercontent.com/mongodb/openapi/refs/heads/main/openapi/v2
 versions_file="versions.json"
 
 pushd "${OPENAPI_FOLDER}"


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.


Local tests 
```shell
➜  tools git:(update-versions) ✗ ./scripts/fetch.sh             
~/workplace/atlas-sdk-go/openapi ~/workplace/atlas-sdk-go/tools
Fetching versions from https://raw.githubusercontent.com/mongodb/openapi/refs/heads/main/openapi/v2/versions.json
Fetching OAS file for version 2025-02-19
Fetching api from https://raw.githubusercontent.com/mongodb/openapi/refs/heads/main/openapi/v2/openapi-2025-02-19.yaml to atlas-api.yaml
~/workplace/atlas-sdk-go/openapi
➜  tools git:(update-versions) ✗ ./releaser/scripts/extract-version.sh
Extracted version from version.go file: 'v20241113005.0.0'. Resource Version: '20241113'
Major: v20241113005' Minor: 0
Extracted version versions.json: '20250219'.
```
Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

