### PR TITLE
task: script extension

### DIFF
--- a/tools/scripts/fetch.sh
+++ b/tools/scripts/fetch.sh
@@ -22,7 +22,7 @@ OPENAPI_FOLDER=${OPENAPI_FOLDER:-"../openapi"}
 
 
 # Base URL for fetching the openapi file
-API_BASE_URL=${API_BASE_URL:-}https://raw.githubusercontent.com/mongodb/openapi/refs/heads/main/openapi/v2
+API_BASE_URL=${API_BASE_URL:-https://raw.githubusercontent.com/mongodb/openapi/refs/heads/main/openapi/v2}
 versions_file="versions.json"
 
 pushd "${OPENAPI_FOLDER}"


### PR DESCRIPTION
## Description

Script extension had wrong bracket.
Covers: https://github.com/mongodb/atlas-sdk-go/actions/runs/13496682941/job/37705444807