### PR TITLE
chore: Fixes new-version.sh to avoid accidentally overwriting version variables when calling breaking-changes script

### DIFF
--- a/internal/core/version.go
+++ b/internal/core/version.go
@@ -5,7 +5,7 @@ package core
 // For more information please see: https://github.com/mongodb/atlas-sdk-go/blob/main/docs/doc_1_concepts.md
 const (
 	// SDK release tag version.
-	Version = "v20241113005.0.0"
+	Version = "v20250219001.0.0"
 	// Resource Version.
 	Resource = "20250219"
 )

--- a/tools/releaser/scripts/new-version.sh
+++ b/tools/releaser/scripts/new-version.sh
@@ -10,6 +10,17 @@ source "$script_path/extract-version.sh"
 # shellcheck source=/dev/null
 source "$script_path/version-paths.sh"
 
+breakingChanges() {
+	# shellcheck source=/dev/null
+	# Create an isolated subshell to contain the sourcing otherwise SDK_VERSION will be overwritten
+	local breaking_changes=$(
+		source "$script_path/breaking-changes.sh"
+		# Output only the variable we want
+		echo "$BREAKING_CHANGES"
+	)
+	export BREAKING_CHANGES="$breaking_changes"
+}
+
 # Update the version.go file with the new version
 if [ "$NEW_RESOURCE_VERSION" == "$SDK_RESOURCE_VERSION" ]; then
 	echo "Resource Version is already up to date. Changing minor version."
@@ -19,8 +30,7 @@ if [ "$NEW_RESOURCE_VERSION" == "$SDK_RESOURCE_VERSION" ]; then
 	SDK_VERSION="${SDK_MAJOR_VERSION}.${new_minor_version}.0"
 
 	echo "Print breaking changes"	
-	# shellcheck source=/dev/null
-	source "$script_path/breaking-changes.sh"
+	breakingChanges
 	if [ -n "$BREAKING_CHANGES" ]; then
 		echo "BREAKING CHANGES DETECTED FOR NON MAJOR VERSION BUMP"
 		# shellcheck source=/dev/null
@@ -34,8 +44,7 @@ else
 	SDK_VERSION="${NEW_MAJOR_VERSION}.0.0" 
 	echo "generate breaking changes file"	
 	export TARGET_BREAKING_CHANGES_FILE=${NEW_MAJOR_VERSION}
-	# shellcheck source=/dev/null
-	source "$script_path/breaking-changes.sh"
+	breakingChanges
 
 	echo "Modifying all instances of version from $SDK_RESOURCE_VERSION to $NEW_RESOURCE_VERSION across the repository."
 	npm install

--- a/tools/releaser/scripts/new-version.sh
+++ b/tools/releaser/scripts/new-version.sh
@@ -11,14 +11,22 @@ source "$script_path/extract-version.sh"
 source "$script_path/version-paths.sh"
 
 breakingChanges() {
-	# shellcheck source=/dev/null
-	# Create an isolated subshell to contain the sourcing otherwise SDK_VERSION will be overwritten
-	local breaking_changes=$(
-		source "$script_path/breaking-changes.sh" >&2
-		# Output only the variable we want
-		echo "$BREAKING_CHANGES"
-	)
-	export BREAKING_CHANGES="$breaking_changes"
+	local breaking_changes
+    # Create an isolated subshell to contain the sourcing otherwise SDK_VERSION will be overwritten
+	breaking_changes=$(
+        {
+			# shellcheck source=/dev/null
+            source "$script_path/breaking-changes.sh" >&2
+            # Output only the variable we want
+            echo "$BREAKING_CHANGES"
+        }
+    )
+    local ret_val=$?
+    if [ $ret_val -ne 0 ]; then
+        echo "Error when sourcing breaking-changes.sh" >&2
+        return $ret_val
+    fi
+    export BREAKING_CHANGES="$breaking_changes"
 }
 
 # Update the version.go file with the new version

--- a/tools/releaser/scripts/new-version.sh
+++ b/tools/releaser/scripts/new-version.sh
@@ -14,7 +14,7 @@ breakingChanges() {
 	# shellcheck source=/dev/null
 	# Create an isolated subshell to contain the sourcing otherwise SDK_VERSION will be overwritten
 	local breaking_changes=$(
-		source "$script_path/breaking-changes.sh"
+		source "$script_path/breaking-changes.sh" >&2
 		# Output only the variable we want
 		echo "$BREAKING_CHANGES"
 	)


### PR DESCRIPTION
## Description

Fixes new-version.sh to avoid leaking version variables when calling breaking-changes script

Link to any related issue(s): CLOUDP-302378

### Testing
- Ran the generation [here](https://github.com/mongodb/atlas-sdk-go/actions/runs/13515826810/job/37764226741) and it updated `version.go` correctly
  - See the resulting PR opened by the bot in #521 

### More background

- As seen by the final line in `Release Update` [step](https://github.com/mongodb/atlas-sdk-go/actions/runs/13450749746/job/37584642959#step:11:466):
`Creating new version.go file with v20241113005.0.0 and resource version: 20250219`
The `SDK_VERSION` got accidentally overwritten.
This is due to the call to
`source "$script_path/breaking-changes.sh"` that was changed in #499 to `source "$script_path/extract-version.sh"`  leading to overwrite of `SDK_VERSION` to the "old" value from `version.go`

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

