### PR TITLE
chore: Bump fixed version of mockery docker image

### DIFF
--- a/tools/scripts/generate_mocks.sh
+++ b/tools/scripts/generate_mocks.sh
@@ -3,7 +3,7 @@ rm -Rf ../mockadmin
 
 # install only if not already present
 if ! which mockery ; then
-	docker run --rm -u "$(id -u):$(id -g)" -v "$(dirname "$PWD")":/src --workdir=/src vektra/mockery:v2.42.1
+	docker run --rm -u "$(id -u):$(id -g)" -v "$(dirname "$PWD")":/src --workdir=/src vektra/mockery:v2.53.2
 else
 	mockery --dir ../mockadmin
 fi


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-306814

### Context

- dependabot udpated go version from 1.22 to 1.23 [Pull Request #531](https://github.com/mongodb/atlas-sdk-go/pull/531)
- mocked generation was not made in https://github.com/mongodb/atlas-sdk-go/pull/533 due to error when calling mockery image
  - `err: exit status 1: stderr: go: go.mod requires go >= 1.23.0 (running go 1.22.1; GOTOOLCHAIN=local)`

### Fix

Fix implies using updated version of mockery image which support Go 1.24.1: https://hub.docker.com/layers/vektra/mockery/v2.53.2/images/sha256-cecc555d7d3369479590834cff7885413675017ff53133a7751c9b6294745d13. Ran both the failing version and new version locally, no changes required in generated mocks.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

