### PR TITLE
chore: Upgrades golangci-lint to v2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,10 +17,9 @@ jobs:
           go-version-file: go.mod
           cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
       - name: lint
-        uses: golangci/golangci-lint-action@v6.5.1
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd
         with:
-          version: v1.64.7
-          args: --timeout=10m
+          version: v2.0.2 # Also update GOLANGCI_VERSION variable in Makefile when updating this version
       - name: tests
         run: make test
       - name: example-tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,83 +1,85 @@
-linters-settings:
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - octalLiteral
-      # We cannot control openapi format
-      - hugeParam
-      # Types are dynamic/OpenAPI driven.
-      - paramTypeCombine
-      - wrapperFunc
-      - ptrToRefParam
-      - emptyFallthrough
-      - nestingReduce
-      - sloppyReassign
-      - typeAssertChain
-      - builtinShadow
-  gocyclo:
-    min-complexity: 15
-  revive:
-    # see https://github.com/mgechev/revive#available-rules for details.
-    ignore-generated-header: true
-    severity: warning
-    rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: errorf
-      - name: exported
-      # - name: indent-error-flow
-      - name: if-return
-      - name: increment-decrement
-      # We want to maintain OpenAPI consistency and ignore golang standards
-      # - name: var-naming
-      # - name: var-declaration
-      # - name: receiver-naming
-      - name: package-comments
-      - name: range
-      - name: time-naming
-      - name: unexported-return
-      - name: errorf
-      - name: empty-block
-      - name: superfluous-else
-      - name: struct-tag
-      # OpenAPI paths can have 0 parameters
-      # - name: unused-parameter
-      # We still want empty methods for consistency - do not control if method will be empty.
-      # - name: unused-receiver
-      - name: unreachable-code
+version: "2"
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
-    - bodyclose # checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
-    - dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f()) [fast: true, auto-fix: false]
-    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
-    - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13. [fast: false, auto-fix: false]
-    - gochecknoinits # Checks that no init functions are present in Go code [fast: true, auto-fix: false]
-    - gocritic # Provides many diagnostics that check for bugs, performance and style issues. [fast: false, auto-fix: false]
-    - goprintffuncname # Checks that printf-like functions are named with `f` at the end [fast: true, auto-fix: false]
-    - gosec # Inspects source code for security problems [fast: false, auto-fix: false]
-    - gosimple # Linter for Go source code that specializes in simplifying a code [fast: false, auto-fix: false]
-    - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: false, auto-fix: false]
-    - misspell # Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
-    - nakedret # Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
-    - nolintlint # Reports ill-formed or insufficient nolint directives [fast: true, auto-fix: false]
-    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
-    - rowserrcheck # checks whether Err of rows is checked successfully [fast: false, auto-fix: false]
-    - staticcheck  # Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: false, auto-fix: false]
-    - thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers [fast: false, auto-fix: false]
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code [fast: false, auto-fix: false]
-    - unconvert # Remove unnecessary type conversions [fast: false, auto-fix: false]
-    - unparam # Reports unused function parameters [fast: false, auto-fix: false]
-    - unused # Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
+    - bodyclose
+    - dogsled
+    - errcheck
+    - errorlint
+    - gochecknoinits
+    - gocritic
+    - goprintffuncname
+    - gosec
+    - govet
+    - misspell
+    - nakedret
+    - nolintlint
+    - revive
+    - rowserrcheck
+    - staticcheck
+    - thelper
+    - unconvert
+    - unparam
+    - unused
+  settings:
+    gocritic:
+      disabled-checks:
+        - octalLiteral
+        - hugeParam
+        - paramTypeCombine
+        - wrapperFunc
+        - ptrToRefParam
+        - emptyFallthrough
+        - nestingReduce
+        - sloppyReassign
+        - typeAssertChain
+        - builtinShadow
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    revive:
+      severity: warning
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: errorf
+        - name: exported
+        - name: if-return
+        - name: increment-decrement
+        - name: package-comments
+        - name: range
+        - name: time-naming
+        - name: unexported-return
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: struct-tag
+        - name: unreachable-code
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,9 @@ linters:
     gocritic:
       disabled-checks:
         - octalLiteral
+        # We cannot control OpenAPI format
         - hugeParam
+        # Types are dynamic/OpenAPI driven.
         - paramTypeCombine
         - wrapperFunc
         - ptrToRefParam
@@ -64,7 +66,15 @@ linters:
         - name: empty-block
         - name: superfluous-else
         - name: struct-tag
+        # OpenAPI paths can have 0 parameters
+        # - name: unused-parameter
+        # We still want empty methods for consistency - do not control if method will be empty.
+        # - name: unused-receiver
         - name: unreachable-code
+        # We want to maintain OpenAPI consistency and ignore golang standards
+        # - name: var-naming
+        # - name: var-declaration
+        # - name: receiver-naming
   exclusions:
     generated: lax
     presets:
@@ -72,14 +82,17 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+    rules: # Exceptions for auto-generated code from OpenAPI spec
+      - text: "ST1023:"
+        path: (.+)\.go$
+        comment: "ST1023: should omit type XXX from declaration; it will be inferred from the right-hand side (staticcheck)"
+      - text: "QF1011:"
+        path: (.+)\.go$
+        comment: "QF1011: could omit type XXX from declaration; it will be inferred from the right-hand side (staticcheck)"
+      - text: "QF1004:"
+        path: (.+)\.go$
+        comment: "QF1004: could use strings.ReplaceAll instead (staticcheck)"
 formatters:
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SOURCE_FILES?=./...
-GOLANGCI_VERSION=v1.64.7
+GOLANGCI_VERSION=v2.0.2 # Also update golangci-lint GH action in pr.yml when updating this version
+
 GOIMPORTS_VERSION=v0.21.0
 COVERAGE=coverage.out
 

--- a/auth/clientcredentials/clientcredentials.go
+++ b/auth/clientcredentials/clientcredentials.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"golang.org/x/oauth2"
 
 	"go.mongodb.org/atlas-sdk/v20250312001/auth"
 	"go.mongodb.org/atlas-sdk/v20250312001/internal/core"


### PR DESCRIPTION
## Description

Upgrades golangci-lint to v2 using the [migration guide](https://golangci-lint.run/product/migration-guide/), follow example in: https://github.com/mongodb/openapi/pull/616

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

