### PR TITLE
fix: Makes specified fields optional in their respective schemas

### DIFF
--- a/admin/model_stream_processor_metric_threshold.go
+++ b/admin/model_stream_processor_metric_threshold.go
@@ -5,7 +5,7 @@ package admin
 // StreamProcessorMetricThreshold Threshold for the metric that, when exceeded, triggers an alert. The metric threshold pertains to event types which reflects changes of measurements and metrics in stream processors.
 type StreamProcessorMetricThreshold struct {
 	// Human-readable label that identifies the metric against which MongoDB Cloud checks the configured **metricThreshold.threshold**.
-	MetricName string `json:"metricName"`
+	MetricName *string `json:"metricName,omitempty"`
 	// MongoDB Cloud computes the current metric value as an average.
 	Mode *string `json:"mode,omitempty"`
 	// Comparison operator to apply when checking the current metric value.
@@ -20,9 +20,8 @@ type StreamProcessorMetricThreshold struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewStreamProcessorMetricThreshold(metricName string) *StreamProcessorMetricThreshold {
+func NewStreamProcessorMetricThreshold() *StreamProcessorMetricThreshold {
 	this := StreamProcessorMetricThreshold{}
-	this.MetricName = metricName
 	var units string = "RAW"
 	this.Units = &units
 	return &this
@@ -38,28 +37,37 @@ func NewStreamProcessorMetricThresholdWithDefaults() *StreamProcessorMetricThres
 	return &this
 }
 
-// GetMetricName returns the MetricName field value
+// GetMetricName returns the MetricName field value if set, zero value otherwise
 func (o *StreamProcessorMetricThreshold) GetMetricName() string {
-	if o == nil {
+	if o == nil || IsNil(o.MetricName) {
 		var ret string
 		return ret
 	}
-
-	return o.MetricName
+	return *o.MetricName
 }
 
-// GetMetricNameOk returns a tuple with the MetricName field value
+// GetMetricNameOk returns a tuple with the MetricName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *StreamProcessorMetricThreshold) GetMetricNameOk() (*string, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.MetricName) {
 		return nil, false
 	}
-	return &o.MetricName, true
+
+	return o.MetricName, true
 }
 
-// SetMetricName sets field value
+// HasMetricName returns a boolean if a field has been set.
+func (o *StreamProcessorMetricThreshold) HasMetricName() bool {
+	if o != nil && !IsNil(o.MetricName) {
+		return true
+	}
+
+	return false
+}
+
+// SetMetricName gets a reference to the given string and assigns it to the MetricName field.
 func (o *StreamProcessorMetricThreshold) SetMetricName(v string) {
-	o.MetricName = v
+	o.MetricName = &v
 }
 
 // GetMode returns the Mode field value if set, zero value otherwise

--- a/internal/core/version.go
+++ b/internal/core/version.go
@@ -5,7 +5,7 @@ package core
 // For more information please see: https://github.com/mongodb/atlas-sdk-go/blob/main/docs/doc_1_concepts.md
 const (
 	// SDK release tag version.
-	Version = "v20250312001.0.0"
+	Version = "v20250312001.1.0"
 	// Resource Version.
 	Resource = "20250312"
 )

--- a/openapi/atlas-api-transformed.yaml
+++ b/openapi/atlas-api-transformed.yaml
@@ -15349,8 +15349,6 @@ components:
           $ref: "#/components/schemas/RawMetricUnits"
           description: Element used to express the quantity. This can be an element of
             time, storage capacity, and the like.
-      required:
-        - metricName
       title: Stream Processor Metric Threshold
       type: object
     StreamsAWSConnectionConfig:

--- a/tools/transformer/src/atlasTransformations.js
+++ b/tools/transformer/src/atlasTransformations.js
@@ -9,6 +9,7 @@ const {
   applyRemoveNullableTransformations,
   removeRefsFromParameters,
   reorderResponseBodies,
+  applyFieldTransformations,
 } = require("./transformations");
 const { resolveOpenAPIReference } = require("./engine/transformers");
 
@@ -29,6 +30,7 @@ module.exports = function runTransformations(openapi) {
   openapi = applyRemoveNullableTransformations(openapi);
   openapi = applyRemoveObjectAdditionalProperties(openapi);
   openapi = reorderResponseBodies(openapi);
+  openapi = applyFieldTransformations(openapi);
 
   openapi = applyModelNameTransformations(
     openapi,
@@ -98,9 +100,9 @@ function searchAPIIssuesTransformation(openapi) {
 
     if (responseParent.discriminator && responseParent.discriminator.mapping) {
       const transformedModel = (openapi.components.schemas[model.newModelName] =
-        {
-          oneOf: [],
-        });
+      {
+        oneOf: [],
+      });
       responseParent.properties[model.property] = {
         $ref: "#/components/schemas/" + model.newModelName,
       };

--- a/tools/transformer/src/atlasTransformations.js
+++ b/tools/transformer/src/atlasTransformations.js
@@ -100,9 +100,9 @@ function searchAPIIssuesTransformation(openapi) {
 
     if (responseParent.discriminator && responseParent.discriminator.mapping) {
       const transformedModel = (openapi.components.schemas[model.newModelName] =
-      {
-        oneOf: [],
-      });
+        {
+          oneOf: [],
+        });
       responseParent.properties[model.property] = {
         $ref: "#/components/schemas/" + model.newModelName,
       };

--- a/tools/transformer/src/field.transformations.json
+++ b/tools/transformer/src/field.transformations.json
@@ -1,0 +1,7 @@
+{
+	"optionalFields": {
+		"StreamProcessorMetricThreshold": [
+			"metricName"
+		]
+	}
+}

--- a/tools/transformer/src/field.transformations.json
+++ b/tools/transformer/src/field.transformations.json
@@ -1,7 +1,5 @@
 {
-	"optionalFields": {
-		"StreamProcessorMetricThreshold": [
-			"metricName"
-		]
-	}
+  "optionalFields": {
+    "StreamProcessorMetricThreshold": ["metricName"]
+  }
 }

--- a/tools/transformer/src/transformations/fields.js
+++ b/tools/transformer/src/transformations/fields.js
@@ -6,22 +6,24 @@ const fieldTransformations = require("../field.transformations.json");
  * @returns OpenAPI JSON File
  */
 function applyFieldTransformations(api) {
-	const { optionalFields } = fieldTransformations;
+  const { optionalFields } = fieldTransformations;
 
-	// Make specified fields optional in their schemas
-	for (const [schemaName, fields] of Object.entries(optionalFields)) {
-		const schema = api.components.schemas[schemaName];
-		if (schema && schema.required) {
-			schema.required = schema.required.filter(field => !fields.includes(field));
-			if (schema.required.length === 0) {
-				delete schema.required;
-			}
-		}
-	}
+  // Make specified fields optional in their schemas
+  for (const [schemaName, fields] of Object.entries(optionalFields)) {
+    const schema = api.components.schemas[schemaName];
+    if (schema && schema.required) {
+      schema.required = schema.required.filter(
+        (field) => !fields.includes(field),
+      );
+      if (schema.required.length === 0) {
+        delete schema.required;
+      }
+    }
+  }
 
-	return api;
+  return api;
 }
 
 module.exports = {
-	applyFieldTransformations,
-}; 
+  applyFieldTransformations,
+};

--- a/tools/transformer/src/transformations/fields.js
+++ b/tools/transformer/src/transformations/fields.js
@@ -1,0 +1,27 @@
+const fieldTransformations = require("../field.transformations.json");
+
+/**
+ * Makes specified fields optional in their respective schemas
+ * @param {*} api OpenAPI JSON File
+ * @returns OpenAPI JSON File
+ */
+function applyFieldTransformations(api) {
+	const { optionalFields } = fieldTransformations;
+
+	// Make specified fields optional in their schemas
+	for (const [schemaName, fields] of Object.entries(optionalFields)) {
+		const schema = api.components.schemas[schemaName];
+		if (schema && schema.required) {
+			schema.required = schema.required.filter(field => !fields.includes(field));
+			if (schema.required.length === 0) {
+				delete schema.required;
+			}
+		}
+	}
+
+	return api;
+}
+
+module.exports = {
+	applyFieldTransformations,
+}; 

--- a/tools/transformer/src/transformations/index.js
+++ b/tools/transformer/src/transformations/index.js
@@ -32,5 +32,5 @@ module.exports = {
   applyRemoveNullableTransformations,
   removeRefsFromParameters,
   reorderResponseBodies,
-  applyFieldTransformations
+  applyFieldTransformations,
 };

--- a/tools/transformer/src/transformations/index.js
+++ b/tools/transformer/src/transformations/index.js
@@ -1,34 +1,25 @@
-const { applyAllOfTransformations, transformAllOf } = require("./allOf");
-const { applyModelNameTransformations } = require("./name");
-const {
-  applyOneOfTransformations,
-  transformOneOf,
-  transformOneOfProperties,
-} = require("./oneOf");
-const { applyDiscriminatorTransformations } = require("./discriminator");
-const { applyArrayTransformations } = require("./swapArray");
-const { applyRemoveEnumsTransformations } = require("./removeEnums");
-const {
-  applyRemoveObjectAdditionalProperties,
-} = require("./additionalPropertiesObject");
+const { applyAllOfTransformations } = require("./allOf");
+const { applyOneOfTransformations } = require("./oneOf");
 const { applyAnyOfTransformations } = require("./anyOf");
+const { applyModelNameTransformations } = require("./name");
+const { applyDiscriminatorTransformations } = require("./discriminator");
+const { applyRemoveEnumsTransformations } = require("./removeEnums");
+const { applyRemoveObjectAdditionalProperties } = require("./additionalPropertiesObject");
 const { applyRemoveNullableTransformations } = require("./removeNullable");
 const { removeRefsFromParameters } = require("./removeInvalidParams");
 const { reorderResponseBodies } = require("./reorderResponseBodies");
+const { applyFieldTransformations } = require("./fields");
 
 module.exports = {
-  applyModelNameTransformations,
-  transformAllOf,
-  transformOneOf,
-  transformOneOfProperties,
   applyAllOfTransformations,
   applyOneOfTransformations,
+  applyAnyOfTransformations,
+  applyModelNameTransformations,
   applyDiscriminatorTransformations,
-  applyArrayTransformations,
   applyRemoveEnumsTransformations,
   applyRemoveObjectAdditionalProperties,
-  applyAnyOfTransformations,
   applyRemoveNullableTransformations,
   removeRefsFromParameters,
   reorderResponseBodies,
+  applyFieldTransformations,
 };

--- a/tools/transformer/src/transformations/index.js
+++ b/tools/transformer/src/transformations/index.js
@@ -1,25 +1,36 @@
-const { applyAllOfTransformations } = require("./allOf");
-const { applyOneOfTransformations } = require("./oneOf");
-const { applyAnyOfTransformations } = require("./anyOf");
+const { applyAllOfTransformations, transformAllOf } = require("./allOf");
 const { applyModelNameTransformations } = require("./name");
+const {
+  applyOneOfTransformations,
+  transformOneOf,
+  transformOneOfProperties,
+} = require("./oneOf");
 const { applyDiscriminatorTransformations } = require("./discriminator");
+const { applyArrayTransformations } = require("./swapArray");
 const { applyRemoveEnumsTransformations } = require("./removeEnums");
-const { applyRemoveObjectAdditionalProperties } = require("./additionalPropertiesObject");
+const {
+  applyRemoveObjectAdditionalProperties,
+} = require("./additionalPropertiesObject");
+const { applyAnyOfTransformations } = require("./anyOf");
 const { applyRemoveNullableTransformations } = require("./removeNullable");
 const { removeRefsFromParameters } = require("./removeInvalidParams");
 const { reorderResponseBodies } = require("./reorderResponseBodies");
 const { applyFieldTransformations } = require("./fields");
 
 module.exports = {
+  applyModelNameTransformations,
+  transformAllOf,
+  transformOneOf,
+  transformOneOfProperties,
   applyAllOfTransformations,
   applyOneOfTransformations,
-  applyAnyOfTransformations,
-  applyModelNameTransformations,
   applyDiscriminatorTransformations,
+  applyArrayTransformations,
   applyRemoveEnumsTransformations,
   applyRemoveObjectAdditionalProperties,
+  applyAnyOfTransformations,
   applyRemoveNullableTransformations,
   removeRefsFromParameters,
   reorderResponseBodies,
-  applyFieldTransformations,
+  applyFieldTransformations
 };


### PR DESCRIPTION
## Description

### Problem description:
Atlas Go SDK was autogenerated and included this [change](https://github.com/mongodb/atlas-sdk-go/pull/545/files#diff-05814b892b574662623416b5fa87eece63ecf7a2e7b5abf8bdafaedbe9fbf414R35) in the release [v20250312](https://github.com/mongodb/atlas-sdk-go/releases/tag/v20250312001.0.0), which removed GreaterThanRawThreshold and replaced it with StreamProcessorMetricThreshold.

In the [OpenAPI spec](https://raw.githubusercontent.com/mongodb/atlas-sdk-go/refs/heads/main/openapi/atlas-api.yaml), GroupAlertsConfig is defined as OneOf of multiple schemas. The latest one added, StreamProcessorMetricAlertConfigViewForNdsGroup has caused a change in the [transformed OpenAPI spec](https://github.com/mongodb/atlas-sdk-go/blob/92ba675c039b5e9427084c208fc35f957dee2385/openapi/atlas-api-transformed.yaml#L9869) of the threshold property changing from to  GreaterThanRawThreshold to [StreamProcessorMetricThreshold](https://github.com/mongodb/atlas-sdk-go/blob/92ba675c039b5e9427084c208fc35f957dee2385/openapi/atlas-api-transformed.yaml#L15329) which defines metricName as required, and in the SDK is a string(instead of a pointer). This causes previously successful API calls(through the SDK in TF) to fail because metricName is included in the request as an empty string (full API calls in the attached file).

### Fix:
Makes metricName field optional in their respective schema

Link to any related issue(s): CLOUDP-307850

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

