### PR TITLE
chore: Pin SHAs in Github Actions

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Release env
         working-directory: ./tools
         run: |

--- a/.github/workflows/autoupdate-preview.yaml
+++ b/.github/workflows/autoupdate-preview.yaml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a
         with:
           go-version-file: 'go.mod'
       - run: make install-goimports
@@ -40,7 +40,7 @@ jobs:
         working-directory: ./tools
         if: env.FILES_CHANGED == 'true'
         run: make generate_mocks  
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         if: env.FILES_CHANGED == 'true'
         with:
           token: ${{ secrets.APIX_BOT_PAT }}

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a
         with:
           go-version-file: 'go.mod'
       - run: make install-goimports
@@ -59,7 +59,7 @@ jobs:
         working-directory: ./tools
         if: env.FILES_CHANGED == 'true'
         run: make generate_mocks  
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         if: env.FILES_CHANGED == 'true'
         with:
           token: ${{ secrets.APIX_BOT_PAT }}

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -55,7 +55,7 @@
           echo "The following JIRA ticket has been created: ${JIRA_TICKET_ID}"
           echo "jira-ticket-id=${JIRA_TICKET_ID}" >> "${GITHUB_OUTPUT}"
       - name: Add comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,8 +11,8 @@ jobs:
   code-health:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a
         with:
           go-version-file: go.mod
           cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
@@ -29,8 +29,8 @@ jobs:
     needs: code-health # only run if code-health passes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 18
           cache: npm

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,6 +10,6 @@ jobs:
     name: shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run ShellCheck
         uses: bewuethr/shellcheck-action@399ea5969c0215b8706a22205de0558cebdcc3cc

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
         id: stale
         with:
           stale-issue-message: 'This issue has gone 30 days without any activity and meets the project’s definition of "stale". This will be auto-closed if there is no new activity over the next 30 days. If the issue is still relevant and active, you can simply comment with a "bump" to keep it open, or add the label "not_stale". Thanks for keeping our repository healthy!'


### PR DESCRIPTION
## Description

Pin SHAs in Github Actions following security best practices.  This is a follow-up to https://github.com/mongodb/atlas-sdk-go/pull/550

Link to any related issue(s): CLOUDP-306816.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

