### PR TITLE
chore: Fix instance size of sharded cluster example

### DIFF
--- a/examples/aws_cluster/aws.go
+++ b/examples/aws_cluster/aws.go
@@ -126,7 +126,7 @@ func createClusterRequest(projectId string) *admin.ClusterDescription20240805 {
 	// Size
 	priority := int(7)
 	nodeCount := int(3)
-	instanceSize := "M10"
+	instanceSize := "M30"
 
 	return &admin.ClusterDescription20240805{
 		Name:        &clusterName,


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-311082

In prod sharded clusters must have instance size >= M30.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

