### PR TITLE
chore: Export SDK functions needed by Terraform UntypedAPICall func

### DIFF
--- a/admin/client.go
+++ b/admin/client.go
@@ -34,8 +34,9 @@ var (
 // APIClient manages communication with the MongoDB Atlas Administration API API
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
-	cfg    *Configuration
-	common service // Reuse a single struct instead of allocating one for each service on the heap.
+	cfg           *Configuration
+	common        service       // Reuse a single struct instead of allocating one for each service on the heap.
+	UntypedClient UntypedClient // Make callls withouth a model.
 
 	// API Services
 
@@ -154,6 +155,7 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 	c := &APIClient{}
 	c.cfg = cfg
 	c.common.client = c
+	c.UntypedClient.client = c
 
 	// API Services
 	c.AWSClustersDNSApi = (*AWSClustersDNSApiService)(&c.common)
@@ -356,7 +358,8 @@ type formFile struct {
 // prepareRequest build the request
 func (c *APIClient) prepareRequest(
 	ctx context.Context,
-	path string, method string,
+	path string,
+	method string,
 	postBody any,
 	headerParams map[string]string,
 	queryParams url.Values,
@@ -688,4 +691,28 @@ func FormatErrorMessageWithDetails(status, path, method string, v ApiError) stri
 	return fmt.Sprintf("%v %v: HTTP %v (Error code: %q) Detail: %v Reason: %v. Params: %v, BadRequestDetail: %v",
 		method, path, status, v.GetErrorCode(),
 		v.GetDetail(), v.GetReason(), v.GetParameters(), badRequestDetailString)
+}
+
+type UntypedClient struct {
+	client *APIClient
+}
+
+func (c *UntypedClient) PrepareRequest(
+	ctx context.Context,
+	path string,
+	method string,
+	postBody any,
+	headerParams map[string]string,
+	queryParams url.Values,
+	formParams url.Values,
+	formFiles []formFile) (localVarRequest *http.Request, err error) {
+	return c.client.prepareRequest(ctx, path, method, postBody, headerParams, queryParams, formParams, formFiles)
+}
+
+func (c *UntypedClient) CallAPI(request *http.Request) (*http.Response, error) {
+	return c.client.callAPI(request)
+}
+
+func (c *UntypedClient) MakeApiError(res *http.Response, httpMethod, httpPath string) error {
+	return c.client.makeApiError(res, httpMethod, httpPath)
 }

--- a/admin/client.go
+++ b/admin/client.go
@@ -36,7 +36,7 @@ var (
 type APIClient struct {
 	cfg           *Configuration
 	common        service       // Reuse a single struct instead of allocating one for each service on the heap.
-	UntypedClient UntypedClient // Make callls withouth a model.
+	UntypedClient UntypedClient // Make API calls without using a typed model.
 
 	// API Services
 

--- a/admin/client.go
+++ b/admin/client.go
@@ -697,7 +697,7 @@ type UntypedClient struct {
 	client *APIClient
 }
 
-func (c *UntypedClient) PrepareRequest(
+func (u *UntypedClient) PrepareRequest(
 	ctx context.Context,
 	path string,
 	method string,
@@ -706,13 +706,13 @@ func (c *UntypedClient) PrepareRequest(
 	queryParams url.Values,
 	formParams url.Values,
 	formFiles []formFile) (localVarRequest *http.Request, err error) {
-	return c.client.prepareRequest(ctx, path, method, postBody, headerParams, queryParams, formParams, formFiles)
+	return u.client.prepareRequest(ctx, path, method, postBody, headerParams, queryParams, formParams, formFiles)
 }
 
-func (c *UntypedClient) CallAPI(request *http.Request) (*http.Response, error) {
-	return c.client.callAPI(request)
+func (u *UntypedClient) CallAPI(request *http.Request) (*http.Response, error) {
+	return u.client.callAPI(request)
 }
 
-func (c *UntypedClient) MakeApiError(res *http.Response, httpMethod, httpPath string) error {
-	return c.client.makeApiError(res, httpMethod, httpPath)
+func (u *UntypedClient) MakeApiError(res *http.Response, httpMethod, httpPath string) error {
+	return u.client.makeApiError(res, httpMethod, httpPath)
 }

--- a/tools/config/go-templates/client.mustache
+++ b/tools/config/go-templates/client.mustache
@@ -40,6 +40,7 @@ var (
 type APIClient struct {
 	cfg    *Configuration
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
+	UntypedClient UntypedClient // Make callls withouth a model.
 
 	// API Services
 {{#apiInfo}}
@@ -66,6 +67,7 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 	c := &APIClient{}
 	c.cfg = cfg
 	c.common.client = c
+	c.UntypedClient.client = c
 
 {{#apiInfo}}
 	// API Services
@@ -227,7 +229,8 @@ type formFile struct {
 // prepareRequest build the request
 func (c *APIClient) prepareRequest(
 	ctx context.Context,
-	path string, method string,
+	path string, 
+	method string,
 	postBody any,
 	headerParams map[string]string,
 	queryParams url.Values,
@@ -578,4 +581,28 @@ func FormatErrorMessageWithDetails(status, path, method string, v ApiError) stri
 	return fmt.Sprintf("%v %v: HTTP %v (Error code: %q) Detail: %v Reason: %v. Params: %v, BadRequestDetail: %v",
 		method, path, status, v.GetErrorCode(),
 		v.GetDetail(), v.GetReason(), v.GetParameters(), badRequestDetailString)
+}
+
+type UntypedClient struct {
+	client *APIClient
+}
+
+func (c *UntypedClient) PrepareRequest(
+	ctx context.Context,
+	path string, 
+	method string,
+	postBody any,
+	headerParams map[string]string,
+	queryParams url.Values,
+	formParams url.Values,
+	formFiles []formFile) (localVarRequest *http.Request, err error) {
+		return c.client.prepareRequest(ctx, path, method, postBody, headerParams, queryParams, formParams, formFiles)
+}
+
+func (c *UntypedClient) CallAPI(request *http.Request) (*http.Response, error) {
+	return c.client.callAPI(request)
+}
+
+func (c *UntypedClient) MakeApiError(res *http.Response, httpMethod, httpPath string) error {
+	return c.client.makeApiError(res, httpMethod, httpPath)
 }

--- a/tools/config/go-templates/client.mustache
+++ b/tools/config/go-templates/client.mustache
@@ -40,7 +40,7 @@ var (
 type APIClient struct {
 	cfg    *Configuration
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
-	UntypedClient UntypedClient // Make callls withouth a model.
+	UntypedClient UntypedClient // Make API calls without using a typed model.
 
 	// API Services
 {{#apiInfo}}

--- a/tools/config/go-templates/client.mustache
+++ b/tools/config/go-templates/client.mustache
@@ -587,7 +587,7 @@ type UntypedClient struct {
 	client *APIClient
 }
 
-func (c *UntypedClient) PrepareRequest(
+func (u *UntypedClient) PrepareRequest(
 	ctx context.Context,
 	path string, 
 	method string,
@@ -596,13 +596,13 @@ func (c *UntypedClient) PrepareRequest(
 	queryParams url.Values,
 	formParams url.Values,
 	formFiles []formFile) (localVarRequest *http.Request, err error) {
-		return c.client.prepareRequest(ctx, path, method, postBody, headerParams, queryParams, formParams, formFiles)
+		return u.client.prepareRequest(ctx, path, method, postBody, headerParams, queryParams, formParams, formFiles)
 }
 
-func (c *UntypedClient) CallAPI(request *http.Request) (*http.Response, error) {
-	return c.client.callAPI(request)
+func (u *UntypedClient) CallAPI(request *http.Request) (*http.Response, error) {
+	return u.client.callAPI(request)
 }
 
-func (c *UntypedClient) MakeApiError(res *http.Response, httpMethod, httpPath string) error {
-	return c.client.makeApiError(res, httpMethod, httpPath)
+func (u *UntypedClient) MakeApiError(res *http.Response, httpMethod, httpPath string) error {
+	return u.client.makeApiError(res, httpMethod, httpPath)
 }


### PR DESCRIPTION
## Description

Export SDK functions needed by Terraform `UntypedAPICall`.   Manual changes in this PR are only in client.mustache.

A new struct `UntypedClient` is created so `APICient` namespace is not polluted. Changes are minimized so current private functions are kept unchanged.

This was discussed and prefered to have duplicated code like in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3326.

Although they are exported functions that potentially can be used by anybody, we don't expect them to be used as they're not documented, and breaking changes are acceptable in these functions.

Link to any related issue(s): CLOUDP-316444

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

