### PR TITLE
chore: Fix SDK preview linter issues

### DIFF
--- a/.github/workflows/autoupdate-preview.yaml
+++ b/.github/workflows/autoupdate-preview.yaml
@@ -40,6 +40,8 @@ jobs:
         working-directory: ./tools
         if: env.FILES_CHANGED == 'true'
         run: make generate_mocks  
+      - name: Fix import order issues
+        run: goimports -l -w .
       - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         if: env.FILES_CHANGED == 'true'
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           npm install
           npm run ci
-      - run: go install golang.org/x/tools/cmd/goimports@v0.21.0
+      - run: make install-goimports
       - working-directory: ./tools
         run: |
           export PATH=${PATH}:`go env GOPATH`/bin

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 SOURCE_FILES?=./...
 GOLANGCI_VERSION=v2.1.6 # Also update golangci-lint GH action in pr.yml when updating this version
 
-GOIMPORTS_VERSION=v0.21.0
-COVERAGE=coverage.out
-
 export GO111MODULE := on
 export PATH := ./bin:$(PATH)
 
@@ -20,7 +17,7 @@ build:
 
 .PHONY: test
 test:
-	go test $(SOURCE_FILES) -coverprofile $(COVERAGE) -timeout=30s -parallel=4 -cover -race
+	go test $(SOURCE_FILES) -timeout=30s -parallel=4 -race
 
 .PHONY: test-examples
 test-examples:
@@ -48,7 +45,7 @@ install-golangci-lint:
 
 .PHONY: install-goimports
 install-goimports:
-	go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
+	go install golang.org/x/tools/cmd/goimports@latest
 
 .PHONY: tools
 tools: install-golangci-lint install-goimports

--- a/tools/releaser/scripts/preview-version.sh
+++ b/tools/releaser/scripts/preview-version.sh
@@ -21,5 +21,5 @@ npm exec -c "replace-in-file '/$OLD_PACKAGE/g' '$NEW_PACKAGE' $VERSION_UPDATE_PA
 echo "Add preview version to examples go.mod"
 (cd "$examples_path" && go get $NEW_PACKAGE)
 
-# Fix import order issues
-goimports -w .
+echo "Fix import order issues"
+goimports -l -w .

--- a/tools/releaser/scripts/preview-version.sh
+++ b/tools/releaser/scripts/preview-version.sh
@@ -21,3 +21,5 @@ npm exec -c "replace-in-file '/$OLD_PACKAGE/g' '$NEW_PACKAGE' $VERSION_UPDATE_PA
 echo "Add preview version to examples go.mod"
 (cd "$examples_path" && go get $NEW_PACKAGE)
 
+# Fix import order issues
+goimports -w .

--- a/tools/releaser/scripts/preview-version.sh
+++ b/tools/releaser/scripts/preview-version.sh
@@ -20,6 +20,3 @@ npm exec -c "replace-in-file '/$OLD_PACKAGE/g' '$NEW_PACKAGE' $VERSION_UPDATE_PA
 
 echo "Add preview version to examples go.mod"
 (cd "$examples_path" && go get $NEW_PACKAGE)
-
-echo "Fix import order issues"
-goimports -l -w .


### PR DESCRIPTION
## Description

Fix SDK preview linter issues.  

It's failing because file `auth/clientcredentials/clientcredentials_test.go` has imports:
```
"github.com/stretchr/testify/assert"
"go.mongodb.org/atlas-sdk/v20250312003/auth"
```
and when they're changed to use Preview namespace, they become:
```
"github.com/stretchr/testify/assert"
"github.com/mongodb/atlas-sdk-go/auth"
```

So they're not ordered alphabetically anymore and linter fails.

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

