### PR TITLE
chore: Exclude upcoming OpenAPI versions

### DIFF
--- a/tools/scripts/fetch.sh
+++ b/tools/scripts/fetch.sh
@@ -32,8 +32,8 @@ echo "Fetching versions from $versions_url"
 curl --show-error --fail --silent -o "${versions_file}" \
      -H "Accept: application/json" "${versions_url}"
 
-# Remove "preview" from versions file if it exists and update the file
-jq 'map(select(. != "preview"))' < "./${versions_file}" > "./${versions_file}.tmp"
+# Remove "preview" and versions with ".upcoming" suffix from versions file and update the file
+jq 'map(select(. != "preview" and (endswith(".upcoming") | not)))' < "./${versions_file}" > "./${versions_file}.tmp"
 mv "./${versions_file}.tmp" "./${versions_file}"
 
 ## Dynamic Versioned API Version


### PR DESCRIPTION
## Description

Exclude upcoming OpenAPI versions. This will fix the SDK Preview PRs.

Example of generated SDK Preview PR: https://github.com/mongodb/atlas-sdk-go/pull/618

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

