### PR TITLE
chore: Removes docs team from codeowners to avoid mandatory review on documentation changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,2 @@
 # Maintained by the API experience team
 * @mongodb/APIx-Integrations
-
-# All docs
-/docs @mongodb/docs-cloud-team
-
-# Docs exemptions
-/docs/docs @mongodb/APIx-Integrations
-/docs/doc_last_reference.md @mongodb/APIx-Integrations
-/docs/README.md @mongodb/APIx-Integrations


### PR DESCRIPTION

## Description

Removes docs team from codeowners to avoid mandatory review on documentation changes. Docs in SDK come from upstream so there is no point on having it reviewed here

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

