### PR TITLE
chore: Fixes compliance step access to release tag value

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -18,9 +18,7 @@ jobs:
       - name: Release env
         id: set_tag
         working-directory: ./tools
-        run: |
-          ./releaser/scripts/setghenv.sh
-          echo "release_tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
+        run: ./releaser/scripts/setghenv.sh
       - name: Create Release 
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
         with:

--- a/tools/releaser/scripts/setghenv.sh
+++ b/tools/releaser/scripts/setghenv.sh
@@ -46,3 +46,8 @@ fi
   echo "$RELEASE_NOTES"
   echo "$EOF"
 } >> "$GITHUB_ENV"
+
+# Set the release_tag output for GitHub Actions
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "release_tag=${SDK_VERSION}" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
## Description

Fixes compliance step access to release tag value. Now it's not correctly accessing the variable. Can be seen in this [action run](https://github.com/mongodb/atlas-sdk-go/actions/runs/15976024137/job/45058624254) that the RELEASE_TAG has not value

**Before the fix:**

The workflow tried to set the release_tag output in the release job by referencing an environment variable (RELEASE_TAG) that was only available to subsequent steps, not the current one. This resulted in the output being empty, so downstream jobs like compliance could not access the release tag value.

**After the fix:**
The script setghenv.sh was updated to write the output directly to the special file pointed to by $GITHUB_OUTPUT:
```
if [ -n "${GITHUB_OUTPUT:-}" ]; then
  echo "release_tag=${SDK_VERSION}" >> "$GITHUB_OUTPUT"
fi
```
This is the official GitHub Actions mechanism for setting step outputs. Now, the workflow step simply runs the script, and the output is set correctly and made available as a job output. Downstream jobs can reliably access the release tag using ${{ needs.release.outputs.release_tag }}.

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

