### PR TITLE
feat: Operation ID override support to transformation

### DIFF
--- a/tools/transformer/README.md
+++ b/tools/transformer/README.md
@@ -93,7 +93,7 @@ Useful for situations for schemas where nullability handling is not desired.
 
 6. Apply Operation ID Overrides
 
-This transformation updates the operation IDs in the OpenAPI file if the operation has an `x-xgen-operation-id-override` extension. Then, it removed the Operation ID override extension from the OpenAPI file.
+This transformation updates the operation IDs in the OpenAPI file if the operation has an `x-xgen-operation-id-override` extension. Then, it removes the Operation ID override extension from the OpenAPI file.
 
 ## Transformation Validation
 

--- a/tools/transformer/README.md
+++ b/tools/transformer/README.md
@@ -93,7 +93,7 @@ Useful for situations for schemas where nullability handling is not desired.
 
 6. Apply Operation ID Overrides
 
-This transformation updates the operation IDs in the OpenAPI file if the operation has an `x-xgen-operation-id-override` extension.
+This transformation updates the operation IDs in the OpenAPI file if the operation has an `x-xgen-operation-id-override` extension. Then, it removed the Operation ID override extension from the OpenAPI file.
 
 ## Transformation Validation
 

--- a/tools/transformer/README.md
+++ b/tools/transformer/README.md
@@ -16,7 +16,7 @@ Additionally, framework enables us to extend it by additional rules per usage to
 
 Transformations should be generic - they should be reusable across OpenAPI files and be generally an unopinionated way of
 handling OpenAPI file. That means that they would improve any public OpenAPI for.
-Parameters for transformations (actuall scripts) can be more finetuned to current OpenAPI file.
+Parameters for transformations (actual scripts) can be more finetuned to current OpenAPI file.
 
 ## Usage
 
@@ -91,10 +91,14 @@ Enums in current form are hard to ensure backwards compatibility.
 This transformation removes all openapi `nullable` fields from the schema.
 Useful for situations for schemas where nullability handling is not desired.
 
+6. Apply Operation ID Overrides
+
+This transformation updates the operation IDs in the OpenAPI file if the operation has an `x-xgen-operation-id-override` extension.
+
 ## Transformation Validation
 
 Transformation engine does perform validation for invalid cases.
-If transformation fails it usualy means that OpenAPI file is not correct and has issues that require human attention.
+If transformation fails it usually means that OpenAPI file is not correct and has issues that require human attention.
 
 The process of fixing OpenAPI always involves:
 

--- a/tools/transformer/__tests__/input.json
+++ b/tools/transformer/__tests__/input.json
@@ -34,6 +34,7 @@
       "get": {
         "description": "Info description.",
         "operationId": "versionedExample",
+        "x-xgen-operation-id-override": "getVersionedExample",
         "responses": {
           "200": {
             "content": {

--- a/tools/transformer/__tests__/transformations.test.js
+++ b/tools/transformer/__tests__/transformations.test.js
@@ -4,6 +4,7 @@ const {
   applyModelNameTransformations,
   transformAllOf,
   transformOneOf,
+  applyOperationIdOverrides,
 } = require("../src/transformations");
 const cases = require("./transformations-snapshots");
 
@@ -61,4 +62,19 @@ test("applyModelNameTransformations", () => {
     expect(modelKey.startsWith("Api")).toBeFalsy();
     expect(modelKey.endsWith("View")).toBeFalsy();
   }
+});
+
+test("applyOperationIdOverrides", () => {
+  api = applyOperationIdOverrides(api);
+  expect(
+    api.paths["/api/atlas/v1.5/groups/{groupId}/clusters"].post.operationId,
+  ).toEqual("createCluster");
+  expect(api.paths["/api/atlas/v2/example/info"].get.operationId).toEqual(
+    "getVersionedExample",
+  );
+  expect(
+    api.paths["/api/atlas/v2/example/info"].get[
+      "x-xgen-operation-id-override"
+    ],
+  ).toBeFalsy();
 });

--- a/tools/transformer/__tests__/transformations.test.js
+++ b/tools/transformer/__tests__/transformations.test.js
@@ -73,8 +73,6 @@ test("applyOperationIdOverrides", () => {
     "getVersionedExample",
   );
   expect(
-    api.paths["/api/atlas/v2/example/info"].get[
-      "x-xgen-operation-id-override"
-    ],
+    api.paths["/api/atlas/v2/example/info"].get["x-xgen-operation-id-override"],
   ).toBeFalsy();
 });

--- a/tools/transformer/src/atlasTransformations.js
+++ b/tools/transformer/src/atlasTransformations.js
@@ -10,6 +10,7 @@ const {
   removeRefsFromParameters,
   reorderResponseBodies,
   applyFieldTransformations,
+  applyOperationIdOverrides,
 } = require("./transformations");
 const { resolveOpenAPIReference } = require("./engine/transformers");
 
@@ -70,6 +71,8 @@ module.exports = function runTransformations(openapi) {
     "#/components/parameters/envelope",
     "#/components/parameters/pretty",
   ]);
+
+  openapi = applyOperationIdOverrides(openapi);
 
   return openapi;
 };

--- a/tools/transformer/src/transformations/index.js
+++ b/tools/transformer/src/transformations/index.js
@@ -16,6 +16,7 @@ const { applyRemoveNullableTransformations } = require("./removeNullable");
 const { removeRefsFromParameters } = require("./removeInvalidParams");
 const { reorderResponseBodies } = require("./reorderResponseBodies");
 const { applyFieldTransformations } = require("./fields");
+const { applyOperationIdOverrides } = require("./operationId");
 
 module.exports = {
   applyModelNameTransformations,
@@ -33,4 +34,5 @@ module.exports = {
   removeRefsFromParameters,
   reorderResponseBodies,
   applyFieldTransformations,
+  applyOperationIdOverrides,
 };

--- a/tools/transformer/src/transformations/operationId.js
+++ b/tools/transformer/src/transformations/operationId.js
@@ -1,7 +1,8 @@
 const OP_ID_OVERRIDE_EXTENSION = "x-xgen-operation-id-override";
 
 /**
- * Replaces Operation IDs if operation ID overrides are present.
+ * Replaces Operation IDs if operation ID overrides are present and removes the
+ * override extension.
  *
  * @param {*} api OpenAPI JSON File
  * @returns {*} transformed OpenAPI JSON File

--- a/tools/transformer/src/transformations/operationId.js
+++ b/tools/transformer/src/transformations/operationId.js
@@ -1,0 +1,41 @@
+const OP_ID_OVERRIDE_EXTENSION = "x-xgen-operation-id-override";
+
+/**
+ * Replaces Operation IDs if operation ID overrides are present.
+ *
+ * @param {*} api OpenAPI JSON File
+ * @returns {*} transformed OpenAPI JSON File
+ */
+function applyOperationIdOverrides(api) {
+  const hasPaths = api && api.paths;
+  if (!hasPaths) {
+    throw new Error("Missing paths in openapi");
+  }
+
+  Object.keys(api.paths).forEach((pathKey) => {
+    const pathItem = api.paths[pathKey];
+    if (!pathItem) {
+      throw new Error("Missing path item in openapi");
+    }
+
+    Object.keys(pathItem).forEach((operationKey) => {
+      const operationItem = api.paths[pathKey][operationKey];
+      if (!operationItem) {
+        throw new Error("Missing operation item in openapi");
+      }
+
+      // Update Operation ID based on override extension
+      if (operationItem[OP_ID_OVERRIDE_EXTENSION]) {
+        api.paths[pathKey][operationKey].operationId =
+          operationItem[OP_ID_OVERRIDE_EXTENSION];
+        delete api.paths[pathKey][operationKey][OP_ID_OVERRIDE_EXTENSION];
+      }
+    });
+  });
+
+  return api;
+}
+
+module.exports = {
+  applyOperationIdOverrides,
+};

--- a/tools/transformer/src/transformations/operationId.js
+++ b/tools/transformer/src/transformations/operationId.js
@@ -1,4 +1,14 @@
 const OP_ID_OVERRIDE_EXTENSION = "x-xgen-operation-id-override";
+const validHttpMethods = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+];
 
 /**
  * Replaces Operation IDs if operation ID overrides are present and removes the
@@ -19,17 +29,13 @@ function applyOperationIdOverrides(api) {
       throw new Error("Missing path item in openapi");
     }
 
-    Object.keys(pathItem).forEach((operationKey) => {
-      const operationItem = api.paths[pathKey][operationKey];
-      if (!operationItem) {
-        throw new Error("Missing operation item in openapi");
-      }
-
-      // Update Operation ID based on override extension
-      if (operationItem[OP_ID_OVERRIDE_EXTENSION]) {
-        api.paths[pathKey][operationKey].operationId =
+    validHttpMethods.forEach((method) => {
+      const operationItem = api.paths[pathKey][method];
+      if (operationItem && operationItem[OP_ID_OVERRIDE_EXTENSION]) {
+        // Update Operation ID based on override extension
+        api.paths[pathKey][method].operationId =
           operationItem[OP_ID_OVERRIDE_EXTENSION];
-        delete api.paths[pathKey][operationKey][OP_ID_OVERRIDE_EXTENSION];
+        delete api.paths[pathKey][method][OP_ID_OVERRIDE_EXTENSION];
       }
     });
   });


### PR DESCRIPTION
## Description

Adds support for using `x-xgen-operation-id-override` to override operation IDs in the OAS transformation. The transformation will replace operation IDs with the value of `x-xgen-operation-id-override` for the operation (if present), and then remove the extension from the transformed spec.

No changes to the client code since the OAS does not yet have `x-xgen-operation-id-override` values. When these are added to existing operations, breaking changes will occur.

Jira: [CLOUDP-331824](https://jira.mongodb.org/browse/CLOUDP-331824)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code

## Further comments

Usage of `x-xgen-operation-id-override` and breaking changes TBD in a later ticket.