### PR TITLE
chore: Fixes unbound variable when there aren't non breaking changes in a release

### DIFF
--- a/tools/releaser/scripts/setghenv.sh
+++ b/tools/releaser/scripts/setghenv.sh
@@ -34,7 +34,7 @@ if [ "$SDK_MINOR_VERSION" = "0" ] && [ "$SDK_PATCH_VERSION" = "0" ]; then
     fi
 else
     # For minor versions, include non-breaking changes directly
-    if [ -n "$NON_BREAKING_CHANGES" ]; then
+    if [ -n "${NON_BREAKING_CHANGES:-}" ]; then
         echo "Adding non-breaking changes to release notes"
         RELEASE_NOTES=$(echo -e "${RELEASE_NOTES}\n\n## Changes\n${NON_BREAKING_CHANGES}")
     fi


### PR DESCRIPTION
## Description

Fixes unbound variable when there aren't non breaking changes in a release

**Problem**: The setghenv.sh script was failing with an "unbound variable"([failure](https://github.com/mongodb/atlas-sdk-go/actions/runs/17209131709/job/48816349653)) error on line 37 because it was trying to check the NON_BREAKING_CHANGES variable without it being initialized first. Since the script uses set -ueo pipefail, any reference to an unbound variable causes it to exit with an error.
**Root Cause**: The extract-version.sh script (which is sourced by setghenv.sh) only sets version-related variables but doesn't initialize NON_BREAKING_CHANGES.

### Before the fix:
If NON_BREAKING_CHANGES was set and non-empty → if block executes ✅
If NON_BREAKING_CHANGES was set but empty → if block skips ✅
If NON_BREAKING_CHANGES was unset → script crashes ❌
### After the fix:
If NON_BREAKING_CHANGES is set and non-empty → if block executes ✅
If NON_BREAKING_CHANGES is set but empty → if block skips ✅
If NON_BREAKING_CHANGES is unset → if block skips ✅

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

