### PR TITLE
chore: Re-enable auto release when merging to main

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -1,12 +1,11 @@
 name: Autorelease
 on:
   workflow_dispatch: {} # workflow can be run manually
-  # TODO: temporarily removing auto-release on main to safely revert changes
-  # push:
-  #   branches:
-  #     - main
-  #   paths: 
-  #     - "internal/core/version.go"
+  push:
+    branches:
+      - main
+    paths: 
+      - "internal/core/version.go"
   
 jobs:
   release:


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-342283

Original PR which disabled auto-release https://github.com/mongodb/atlas-sdk-go/pull/647

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

