### PR TITLE
doc: DOCSP-58416 -- Update the MongoDB Atlas Go SDK examples in using Service Account instead of PAK

### DIFF
--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -16,7 +16,7 @@ import (
  */
 func main() {
 	ctx := context.Background()
-	// Values provided as part of env variables
+	// Service Account is the recommended way to authenticate programmatically with the MongoDB Atlas API
 	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -16,7 +16,7 @@ import (
  */
 func main() {
 	ctx := context.Background()
-	// Service Account is the recommended way to authenticate programmatically with the MongoDB Atlas API
+	// Service Accounts are the recommended way to authenticate programmatically with the MongoDB Atlas API
 	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -17,7 +17,7 @@ import (
 func main() {
 	ctx := context.Background()
 	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/atlas/app-services/service-accounts/
+	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -17,14 +17,18 @@ import (
 func main() {
 	ctx := context.Background()
 	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/atlas/app-services/authentication/api-key/
-	apiKey := os.Getenv("MONGODB_ATLAS_PUBLIC_KEY")
-	apiSecret := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
+	// See: https://www.mongodb.com/docs/atlas/app-services/service-accounts/
+	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
+	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")
 
+	if clientID == "" || clientSecret == "" {
+		log.Fatal("MONGODB_ATLAS_CLIENT_ID and MONGODB_ATLAS_CLIENT_SECRET must be set")
+	}
+
 	sdk, err := admin.NewClient(
-		admin.UseDigestAuth(apiKey, apiSecret),
-		admin.UseBaseURL(url))
+		admin.UseBaseURL(url),
+		admin.UseOAuthAuth(ctx, clientID, clientSecret))
 	examples.HandleErr(err, nil)
 
 	// -- 1. Get first project

--- a/examples/cluster/aws_cluster/aws.go
+++ b/examples/cluster/aws_cluster/aws.go
@@ -26,7 +26,7 @@ import (
 func main() {
 	ctx := context.Background()
 	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/atlas/app-services/service-accounts/
+	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")

--- a/examples/cluster/aws_cluster/aws.go
+++ b/examples/cluster/aws_cluster/aws.go
@@ -25,7 +25,7 @@ import (
  */
 func main() {
 	ctx := context.Background()
-	// Values provided as part of env variables
+	// Service Account is the recommended way to authenticate programmatically with the MongoDB Atlas API
 	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")

--- a/examples/cluster/aws_cluster/aws.go
+++ b/examples/cluster/aws_cluster/aws.go
@@ -26,14 +26,18 @@ import (
 func main() {
 	ctx := context.Background()
 	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/atlas/app-services/authentication/api-key/
-	apiKey := os.Getenv("MONGODB_ATLAS_PUBLIC_KEY")
-	apiSecret := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
+	// See: https://www.mongodb.com/docs/atlas/app-services/service-accounts/
+	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
+	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")
 
+	if clientID == "" || clientSecret == "" {
+		log.Fatal("MONGODB_ATLAS_CLIENT_ID and MONGODB_ATLAS_CLIENT_SECRET must be set")
+	}
+
 	sdk, err := admin.NewClient(
-		admin.UseDigestAuth(apiKey, apiSecret),
 		admin.UseBaseURL(url),
+		admin.UseOAuthAuth(ctx, clientID, clientSecret),
 		admin.UseDebug(false))
 	examples.HandleErr(err, nil)
 

--- a/examples/cluster/aws_cluster/aws.go
+++ b/examples/cluster/aws_cluster/aws.go
@@ -25,7 +25,7 @@ import (
  */
 func main() {
 	ctx := context.Background()
-	// Service Account is the recommended way to authenticate programmatically with the MongoDB Atlas API
+	// Service Accounts are the recommended way to authenticate programmatically with the MongoDB Atlas API
 	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")

--- a/examples/db_users/db_users.go
+++ b/examples/db_users/db_users.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"context"
@@ -22,14 +23,18 @@ const (
 func main() {
 	ctx := context.Background()
 	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/atlas/app-services/authentication/api-key/
-	apiKey := os.Getenv("MONGODB_ATLAS_PUBLIC_KEY")
-	apiSecret := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
+	// See: https://www.mongodb.com/docs/atlas/app-services/service-accounts/
+	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
+	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")
 
+	if clientID == "" || clientSecret == "" {
+		log.Fatal("MONGODB_ATLAS_CLIENT_ID and MONGODB_ATLAS_CLIENT_SECRET must be set")
+	}
+
 	sdk, err := admin.NewClient(
-		admin.UseDigestAuth(apiKey, apiSecret),
 		admin.UseBaseURL(url),
+		admin.UseOAuthAuth(ctx, clientID, clientSecret),
 		admin.UseDebug(true))
 	examples.HandleErr(err, nil)
 

--- a/examples/db_users/db_users.go
+++ b/examples/db_users/db_users.go
@@ -22,7 +22,7 @@ const (
  */
 func main() {
 	ctx := context.Background()
-	// Service Account is the recommended way to authenticate programmatically with the MongoDB Atlas API
+	// Service Accounts are the recommended way to authenticate programmatically with the MongoDB Atlas API
 	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")

--- a/examples/db_users/db_users.go
+++ b/examples/db_users/db_users.go
@@ -23,7 +23,7 @@ const (
 func main() {
 	ctx := context.Background()
 	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/atlas/app-services/service-accounts/
+	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")

--- a/examples/db_users/db_users.go
+++ b/examples/db_users/db_users.go
@@ -22,7 +22,7 @@ const (
  */
 func main() {
 	ctx := context.Background()
-	// Values provided as part of env variables
+	// Service Account is the recommended way to authenticate programmatically with the MongoDB Atlas API
 	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")

--- a/examples/download/downloadLogs.go
+++ b/examples/download/downloadLogs.go
@@ -16,7 +16,7 @@ import (
  */
 func main() {
 	ctx := context.Background()
-	// Values provided as part of env variables
+	// Service Account is the recommended way to authenticate programmatically with the MongoDB Atlas API
 	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")

--- a/examples/download/downloadLogs.go
+++ b/examples/download/downloadLogs.go
@@ -16,7 +16,7 @@ import (
  */
 func main() {
 	ctx := context.Background()
-	// Service Account is the recommended way to authenticate programmatically with the MongoDB Atlas API
+	// Service Accounts are the recommended way to authenticate programmatically with the MongoDB Atlas API
 	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")

--- a/examples/download/downloadLogs.go
+++ b/examples/download/downloadLogs.go
@@ -17,7 +17,7 @@ import (
 func main() {
 	ctx := context.Background()
 	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/atlas/app-services/service-accounts/
+	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")

--- a/examples/download/downloadLogs.go
+++ b/examples/download/downloadLogs.go
@@ -17,14 +17,18 @@ import (
 func main() {
 	ctx := context.Background()
 	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/atlas/app-services/authentication/api-key/
-	apiKey := os.Getenv("MONGODB_ATLAS_PUBLIC_KEY")
-	apiSecret := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
+	// See: https://www.mongodb.com/docs/atlas/app-services/service-accounts/
+	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
+	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")
 
+	if clientID == "" || clientSecret == "" {
+		log.Fatal("MONGODB_ATLAS_CLIENT_ID and MONGODB_ATLAS_CLIENT_SECRET must be set")
+	}
+
 	sdk, err := admin.NewClient(
-		admin.UseDigestAuth(apiKey, apiSecret),
 		admin.UseBaseURL(url),
+		admin.UseOAuthAuth(ctx, clientID, clientSecret),
 		admin.UseDebug(false))
 	examples.HandleErr(err, nil)
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -6,9 +6,10 @@ replace go.mongodb.org/atlas-sdk/v20250312018 => ../
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/mongodb-forks/digest v1.1.0
 	go.mongodb.org/atlas-sdk/v20250312018 v20250312018.2.0
 )
+
+require github.com/mongodb-forks/digest v1.1.0 // indirect
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/examples/invoice/invoice.go
+++ b/examples/invoice/invoice.go
@@ -17,17 +17,17 @@ func main() {
 	if url == "" {
 		url = "https://cloud.mongodb.com"
 	}
-	apiKey := os.Getenv("MONGODB_ATLAS_PUBLIC_KEY")
-	apiSecret := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
+	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
+	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	invoiceID := os.Getenv("MONGODB_ATLAS_INVOICE_ID")
-	if apiKey == "" || apiSecret == "" || orgID == "" || invoiceID == "" {
-		log.Fatal("Environment variables MONGODB_ATLAS_PUBLIC_KEY, MONGODB_ATLAS_PRIVATE_KEY, MONGODB_ATLAS_ORG_ID and MONGODB_ATLAS_INVOICE_ID are required")
+	if clientID == "" || clientSecret == "" || orgID == "" || invoiceID == "" {
+		log.Fatal("Environment variables MONGODB_ATLAS_CLIENT_ID, MONGODB_ATLAS_CLIENT_SECRET, MONGODB_ATLAS_ORG_ID and MONGODB_ATLAS_INVOICE_ID are required")
 	}
 
 	sdk, err := admin.NewClient(
-		admin.UseDigestAuth(apiKey, apiSecret),
-		admin.UseBaseURL(url))
+		admin.UseBaseURL(url),
+		admin.UseOAuthAuth(ctx, clientID, clientSecret))
 	examples.HandleErr(err, nil)
 
 	invoice, response, err := sdk.InvoicesApi.GetInvoice(ctx, orgID, invoiceID).Execute()

--- a/examples/regions/regions.go
+++ b/examples/regions/regions.go
@@ -16,7 +16,7 @@ import (
  */
 func main() {
 	ctx := context.Background()
-	// Values provided as part of env variables
+	// Service Account is the recommended way to authenticate programmatically with the MongoDB Atlas API
 	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")

--- a/examples/regions/regions.go
+++ b/examples/regions/regions.go
@@ -16,7 +16,7 @@ import (
  */
 func main() {
 	ctx := context.Background()
-	// Service Account is the recommended way to authenticate programmatically with the MongoDB Atlas API
+	// Service Accounts are the recommended way to authenticate programmatically with the MongoDB Atlas API
 	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")

--- a/examples/regions/regions.go
+++ b/examples/regions/regions.go
@@ -17,7 +17,7 @@ import (
 func main() {
 	ctx := context.Background()
 	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/atlas/app-services/service-accounts/
+	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")

--- a/examples/regions/regions.go
+++ b/examples/regions/regions.go
@@ -17,14 +17,18 @@ import (
 func main() {
 	ctx := context.Background()
 	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/atlas/app-services/authentication/api-key/
-	apiKey := os.Getenv("MONGODB_ATLAS_PUBLIC_KEY")
-	apiSecret := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
+	// See: https://www.mongodb.com/docs/atlas/app-services/service-accounts/
+	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
+	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")
 
+	if clientID == "" || clientSecret == "" {
+		log.Fatal("MONGODB_ATLAS_CLIENT_ID and MONGODB_ATLAS_CLIENT_SECRET must be set")
+	}
+
 	sdk, err := admin.NewClient(
-		admin.UseDigestAuth(apiKey, apiSecret),
 		admin.UseBaseURL(url),
+		admin.UseOAuthAuth(ctx, clientID, clientSecret),
 		admin.UseDebug(false))
 	examples.HandleErr(err, nil)
 

--- a/examples/retry/retry.go
+++ b/examples/retry/retry.go
@@ -22,7 +22,7 @@ import (
  */
 func main() {
 	ctx := context.Background()
-	// Service Account is the recommended way to authenticate programmatically with the MongoDB Atlas API
+	// Service Accounts are the recommended way to authenticate programmatically with the MongoDB Atlas API
 	// See: See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")

--- a/examples/retry/retry.go
+++ b/examples/retry/retry.go
@@ -22,7 +22,7 @@ import (
 func main() {
 	ctx := context.Background()
 	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/atlas/app-services/service-accounts/
+	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")

--- a/examples/retry/retry.go
+++ b/examples/retry/retry.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 
 	"context"
@@ -11,7 +10,6 @@ import (
 	"go.mongodb.org/atlas-sdk/v20250312018/admin"
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
-	"github.com/mongodb-forks/digest"
 )
 
 /*
@@ -24,10 +22,14 @@ import (
 func main() {
 	ctx := context.Background()
 	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/atlas/app-services/authentication/api-key/
-	apiKey := os.Getenv("MONGODB_ATLAS_PUBLIC_KEY")
-	apiSecret := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
+	// See: https://www.mongodb.com/docs/atlas/app-services/service-accounts/
+	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
+	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")
+
+	if clientID == "" || clientSecret == "" {
+		log.Fatal("MONGODB_ATLAS_CLIENT_ID and MONGODB_ATLAS_CLIENT_SECRET must be set")
+	}
 
 	// Using custom client
 	// This example relies on https://pkg.go.dev/github.com/hashicorp/go-retryablehttp
@@ -37,13 +39,10 @@ func main() {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 3
 
-	retryableClient, err := newRetryableClient(retryClient, apiKey, apiSecret)
-	if err != nil {
-		log.Fatal("Cannot instantiate client")
-	}
 	sdk, err := admin.NewClient(
-		admin.UseHTTPClient(retryableClient),
+		admin.UseHTTPClient(retryClient.StandardClient()),
 		admin.UseBaseURL(url),
+		admin.UseOAuthAuth(ctx, clientID, clientSecret),
 		admin.UseDebug(false))
 	if err != nil {
 		log.Fatal(err)
@@ -62,10 +61,4 @@ func main() {
 
 	fmt.Println("Total Projects", projects.GetTotalCount())
 
-}
-
-func newRetryableClient(retryClient *retryablehttp.Client, apiKey string, apiSecret string) (*http.Client, error) {
-	var transport http.RoundTripper = &retryablehttp.RoundTripper{Client: retryClient}
-	digestRetryAbleTransport := digest.NewTransportWithHTTPRoundTripper(apiKey, apiSecret, transport)
-	return digestRetryAbleTransport.Client()
 }

--- a/examples/retry/retry.go
+++ b/examples/retry/retry.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"go.mongodb.org/atlas-sdk/v20250312018/admin"
+	"go.mongodb.org/atlas-sdk/v20250312018/auth"
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 )
@@ -35,12 +36,15 @@ func main() {
 	// This example relies on https://pkg.go.dev/github.com/hashicorp/go-retryablehttp
 	// retryablehttp performs automatic retries under certain conditions.
 	// Mainly, if an error is returned by the client (connection errors etc),
-	/// or if a 500-range response is received, then a retry is invoked.
+	// or if a 500-range response is received, then a retry is invoked.
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 3
 
+	// Inject the retryable client into the context so that UseOAuthAuth wraps it
+	// rather than http.DefaultClient. This ensures retries apply to all API requests.
+	ctx = context.WithValue(ctx, auth.HTTPClient, retryClient.StandardClient())
+
 	sdk, err := admin.NewClient(
-		admin.UseHTTPClient(retryClient.StandardClient()),
 		admin.UseBaseURL(url),
 		admin.UseOAuthAuth(ctx, clientID, clientSecret),
 		admin.UseDebug(false))

--- a/examples/retry/retry.go
+++ b/examples/retry/retry.go
@@ -22,8 +22,8 @@ import (
  */
 func main() {
 	ctx := context.Background()
-	// Values provided as part of env variables
-	// See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
+	// Service Account is the recommended way to authenticate programmatically with the MongoDB Atlas API
+	// See: See: https://www.mongodb.com/docs/cloud-manager/tutorial/manage-programmatic-api-keys/
 	clientID := os.Getenv("MONGODB_ATLAS_CLIENT_ID")
 	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 	url := os.Getenv("MONGODB_ATLAS_BASE_URL")


### PR DESCRIPTION
## Description

Replaces PAK (Digest Auth) with Service Account (OAuth) across all examples. Updated env vars from ``MONGODB_ATLAS_PUBLIC_KEY/PRIVATE_KEY`` to ``MONGODB_ATLAS_CLIENT_ID/CLIENT_SECRET``. Swapped UseDigestAuth for UseOAuthAuth, ensuring UseBaseURL is called before UseOAuthAuth per SDK requirements.

`examples/retry/retry.go` no longer imports github.com/mongodb-forks/digest directly after replacing the digest-based HTTP transport with UseOAuthAuth. go mod tidy reflects this by moving digest from direct to indirect, as it remains a transitive dependency of the SDK itself.

All modified examples were tested against QA env. 
Link to any related issue(s): [DOCSP-58416](https://jira.mongodb.org/browse/DOCSP-58416)
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

