### PR TITLE
chore: Add pointer to optional free-form map fields in generated models

### DIFF
--- a/tools/config/go-templates/model_simple.mustache
+++ b/tools/config/go-templates/model_simple.mustache
@@ -26,7 +26,7 @@ type {{classname}} struct {
 {{#deprecated}}
 	// Deprecated
 {{/deprecated}}
-	{{name}} {{^required}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} {{^required}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{#isFreeFormObject}}{{#isMap}}*{{/isMap}}{{/isFreeFormObject}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
 {{#isAdditionalPropertiesTrue}}
 	AdditionalProperties map[string]any
@@ -131,7 +131,7 @@ func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
 		var ret {{vendorExtensions.x-go-base-type}}
 		return ret
 	}
-	return {{^isFreeFormObject}}*{{/isFreeFormObject}}o.{{name}}
+	return {{^isFreeFormObject}}*{{/isFreeFormObject}}{{#isFreeFormObject}}{{#isMap}}*{{/isMap}}{{/isFreeFormObject}}o.{{name}}
 }
 
 // Get{{name}}Ok returns a tuple with the {{name}} field value if set, nil otherwise
@@ -139,14 +139,19 @@ func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
 {{#deprecated}}
 // Deprecated
 {{/deprecated}}
-func (o *{{classname}}) Get{{name}}Ok() ({{^isFreeFormObject}}*{{/isFreeFormObject}}{{vendorExtensions.x-go-base-type}}, bool) {
+func (o *{{classname}}) Get{{name}}Ok() ({{^isFreeFormObject}}*{{/isFreeFormObject}}{{#isFreeFormObject}}{{#isMap}}*{{/isMap}}{{/isFreeFormObject}}{{vendorExtensions.x-go-base-type}}, bool) {
 	if o == nil || IsNil(o.{{name}}) {
 	{{^isFreeFormObject}}
 		return nil, false
 	{{/isFreeFormObject}}
 	{{#isFreeFormObject}}
+	{{#isMap}}
+		return nil, false
+	{{/isMap}}
+	{{^isMap}}
 		var ret {{vendorExtensions.x-go-base-type}}
 		return ret, false
+	{{/isMap}}
 	{{/isFreeFormObject}}
 	}
 
@@ -167,7 +172,7 @@ func (o *{{classname}}) Has{{name}}() bool {
 // Deprecated
 {{/deprecated}}
 func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
-	o.{{name}} = {{^isFreeFormObject}}&{{/isFreeFormObject}}v
+	o.{{name}} = {{^isFreeFormObject}}&{{/isFreeFormObject}}{{#isFreeFormObject}}{{#isMap}}&{{/isMap}}{{/isFreeFormObject}}v
 }
 
 {{/required}}


### PR DESCRIPTION
## Description

Optional fields typed as `map[string]any` (generated from OpenAPI schemas with `additionalProperties: true`) were missing the pointer that optional array fields (`*[]T`) have had since #252. This meant callers could not distinguish between an unset map and an empty map, and setters had no way to express "clear this field."

This change updates the mustache template (`tools/config/go-templates/model_simple.mustache`) so that optional free-form map fields use `*map[string]any` instead of `map[string]any`. Non-map free-form fields (typed as `any`) are unaffected. This is not a breaking change: no existing field in the SDK currently matches this pattern, so no generated Go code changes on `main`. The pointer will apply to new `map[string]any` fields as they are introduced, specifically the `IntelligentWorkloadManagementPolicyOverrides` field being added as part of the IWM project (CLOUDP-387563).

The fix mirrors the approach used for array fields and is consistent with how maps backed by a typed schema (e.g. `SearchMappings.Fields`) already generate `*map[string]T`.

**Template note:** The mustache template uses `{{^isFreeFormObject}}*{{/isFreeFormObject}}{{#isFreeFormObject}}{{#isMap}}*{{/isMap}}{{/isFreeFormObject}}` — the verbose form is necessary because Mustache has no OR operator. It emits `*` for all optional fields except free-form non-map types (`any`), which must remain unpointed since they have no nil sentinel.

Link to any related issue(s): CLOUDP-400281

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments