### PR TITLE
docs: Clarify json.Number comparison behavior in JSON precision migration guide

### DIFF
--- a/docs/mig_1_json_precision.md
+++ b/docs/mig_1_json_precision.md
@@ -66,6 +66,32 @@ case string:
 }
 ```
 
+## Number comparison behavior change
+
+With `float64`, the values `10` and `10.0` decoded to the same `float64(10)` and compared equal. With `json.Number`, they are distinct strings (`json.Number("10") != json.Number("10.0")`), so equality checks that previously passed may now fail.
+
+This affects any code that compares values from dynamic fields, including JSON marshaling round-trips where the Atlas API returns `10.0` for a value the client originally sent as `10`.
+
+If you need `10` and `10.0` to compare as equal, normalize before comparing by trying `Int64` first (preserves precision above 2^53), then falling back to `Float64`:
+
+```go
+func numbersEqual(a, b json.Number) bool {
+    if ia, err := a.Int64(); err == nil {
+        if ib, err := b.Int64(); err == nil {
+            return ia == ib
+        }
+    }
+    fa, errA := a.Float64()
+    fb, errB := b.Float64()
+    return errA == nil && errB == nil && fa == fb
+}
+
+// numbersEqual(json.Number("10"), json.Number("10.0")) == true
+// numbersEqual(json.Number("9007199254740993"), json.Number("9007199254740992")) == false
+```
+
+Note: comparing via `Float64()` alone would silently return `true` for those last two values since both round to the same `float64`.
+
 ## Testing your migration
 
 Add round-trip tests with integers above 2^53 in dynamic fields to catch precision loss:

--- a/docs/mig_1_json_precision.md
+++ b/docs/mig_1_json_precision.md
@@ -66,11 +66,15 @@ case string:
 }
 ```
 
-## Number comparison behavior change
+## Number decoding behavior change and its effects
 
-With `float64`, the values `10` and `10.0` decoded to the same `float64(10)` and compared equal. With `json.Number`, they are distinct strings (`json.Number("10") != json.Number("10.0")`), so equality checks that previously passed may now fail.
+The SDK change is in deserialization: the decoder now produces `json.Number("10.0")` instead of `float64(10)` for a JSON `10.0` in a dynamic field. This has two downstream effects.
 
-This affects any code that compares values from dynamic fields, including JSON marshaling round-trips where the Atlas API returns `10.0` for a value the client originally sent as `10`.
+**Re-serialization**: `float64(10)` marshaled back to `"10"` (Go normalizes float64 to its shortest representation), but `json.Number("10.0")` marshals back to `"10.0"` (the wire representation is preserved). Code that deserializes a response and re-serializes it to a string will now produce `"10.0"` where it previously produced `"10"`.
+
+**Direct comparison**: `float64(10.0) == float64(10)` was true before, but `json.Number("10.0") == json.Number("10")` is false after, since `json.Number` is just a string type.
+
+Both effects surface in JSON marshaling round-trips where the Atlas API returns `10.0` for a value the client originally sent as `10`.
 
 If you need `10` and `10.0` to compare as equal, normalize the string representation first by stripping a purely-zero fractional part, then compare:
 

--- a/docs/mig_1_json_precision.md
+++ b/docs/mig_1_json_precision.md
@@ -72,25 +72,26 @@ With `float64`, the values `10` and `10.0` decoded to the same `float64(10)` and
 
 This affects any code that compares values from dynamic fields, including JSON marshaling round-trips where the Atlas API returns `10.0` for a value the client originally sent as `10`.
 
-If you need `10` and `10.0` to compare as equal, normalize before comparing by trying `Int64` first (preserves precision above 2^53), then falling back to `Float64`:
+If you need `10` and `10.0` to compare as equal, normalize the string representation first by stripping a purely-zero fractional part, then compare:
 
 ```go
-func numbersEqual(a, b json.Number) bool {
-    if ia, err := a.Int64(); err == nil {
-        if ib, err := b.Int64(); err == nil {
-            return ia == ib
-        }
+import "strings"
+
+func normalizeNumber(n json.Number) json.Number {
+    s := string(n)
+    if idx := strings.IndexByte(s, '.'); idx != -1 && strings.TrimLeft(s[idx+1:], "0") == "" {
+        return json.Number(s[:idx])
     }
-    fa, errA := a.Float64()
-    fb, errB := b.Float64()
-    return errA == nil && errB == nil && fa == fb
+    return n
+}
+
+func numbersEqual(a, b json.Number) bool {
+    return normalizeNumber(a) == normalizeNumber(b)
 }
 
 // numbersEqual(json.Number("10"), json.Number("10.0")) == true
 // numbersEqual(json.Number("9007199254740993"), json.Number("9007199254740992")) == false
 ```
-
-Note: comparing via `Float64()` alone would silently return `true` for those last two values since both round to the same `float64`.
 
 ## Testing your migration
 

--- a/docs/mig_1_json_precision.md
+++ b/docs/mig_1_json_precision.md
@@ -75,7 +75,10 @@ This affects any code that compares values from dynamic fields, including JSON m
 If you need `10` and `10.0` to compare as equal, normalize the string representation first by stripping a purely-zero fractional part, then compare:
 
 ```go
-import "strings"
+import (
+    "encoding/json"
+    "strings"
+)
 
 func normalizeNumber(n json.Number) json.Number {
     s := string(n)


### PR DESCRIPTION
## Description

Adds a section to `docs/mig_1_json_precision.md` clarifying a subtle behavior change introduced by the `UseNumber()` decoder: `json.Number("10")` and `json.Number("10.0")` are now distinct values, whereas previously both decoded to the same `float64(10)` and compared equal.

The new section explains the impact on equality checks and provides a `numbersEqual` helper built on a `normalizeNumber` function that strips all-zero fractional parts (e.g. `.0`, `.00`) from a `json.Number` string before comparing. This handles `10 == 10.0` without any float conversion, so large integers above 2^53 are compared exactly, avoiding the silent precision loss that a `Float64()` fallback would reintroduce.

Link to any related issue(s): CLOUDP-406599

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments