### PR TITLE
chore: Add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/autoupdate-preview.yaml
+++ b/.github/workflows/autoupdate-preview.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
    - cron: '30 8 * * 1,3,5'
   
+permissions:
+  contents: read
+
 jobs:
   generate-client:
     runs-on: ubuntu-latest

--- a/.github/workflows/autoupdate-prod.yaml
+++ b/.github/workflows/autoupdate-prod.yaml
@@ -4,6 +4,9 @@ on:
    - cron: '30 5 * * *'
  workflow_dispatch:
   
+permissions:
+  contents: read
+
 jobs:
   generate-client:
     runs-on: ubuntu-latest

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -5,11 +5,18 @@
   on:
     issues:
       types: [opened, reopened, closed]
+
+  permissions:
+    contents: read
+
   jobs:
     jira_task:
       name: Create Jira issue
       if: github.event.action == 'opened'
       runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        issues: write
       env:
         GITHUB_TOKEN: ${{ secrets.APIX_BOT_PAT }}
       steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   code-health:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "**/**.sh"
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: shellcheck

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Adds explicit least-privilege `permissions:` blocks to the GitHub Actions workflows that CodeQL flagged with `actions/missing-workflow-permissions`. Each workflow now declares the minimal `GITHUB_TOKEN` scopes it actually uses: `contents: read` by default, with `issues: write` / `pull-requests: write` only where a workflow labels or comments (`stale.yml`, the `jira_task` job in `issues.yml`). The PR-creating autoupdate workflows write via the `APIX_BOT_PAT` secret, so their default token only needs `contents: read`. No change to CI or release behavior; the alerts auto-close once CodeQL re-scans `main` after merge.

Sensitive workflows are intentionally out of scope and left untouched: `autorelease.yaml` keeps its alerts open and will be hardened separately, only after confirming the exact scopes its release jobs require.

Link to any related issue(s): CLOUDP-409142

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments
