### PR TITLE
chore: Replace curl|sh with go install for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ check: test lint-fix
 
 .PHONY: install-golangci-lint
 install-golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_VERSION)
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION)
 
 .PHONY: install-goimports
 install-goimports:

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ check: test lint-fix
 
 .PHONY: install-golangci-lint
 install-golangci-lint:
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION)
+	GOBIN=$(shell pwd)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION)
 
 .PHONY: install-goimports
 install-goimports:


### PR DESCRIPTION
## Description

The `curl | sh` install pattern for golangci-lint in `make tools` no longer works on developer machines. This replaces it with `go install` prefixed with `GOBIN=$(shell pwd)/bin` so the binary lands in `./bin/` where `lint` and `lint-fix` expect it, consistent with the repo's existing convention. The version remains pinned via the existing `GOLANGCI_VERSION` variable. More context in CLOUDP-409605.

Link to any related issue(s): CLOUDP-409605

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments