### PR TITLE
chore: Add explicit permissions to autorelease workflow jobs

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       release_tag: ${{ steps.set_tag.outputs.release_tag }}
     steps:
@@ -34,6 +36,8 @@ jobs:
   compliance:
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
       RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
@@ -59,6 +63,8 @@ jobs:
   generate-ssdlc-report:
     needs: compliance
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
     steps:


### PR DESCRIPTION
## Description

Addresses the 3 open CodeQL `actions/missing-workflow-permissions` alerts ([code scanning](https://github.com/mongodb/atlas-sdk-go/security/code-scanning?query=is%3Aopen)) by adding explicit least-privilege `permissions` blocks to the jobs in `autorelease.yaml`:

- `release`: `contents: write` (creates the GitHub release via `softprops/action-gh-release` with the default workflow token).
- `compliance`: `contents: write` (uploads the SBOM as a release artifact with `GITHUB_TOKEN`).
- `generate-ssdlc-report`: `contents: read` (checkout only; the SSDLC report commit is pushed via the APIx bot PAT, not the workflow token).

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
