### PR TITLE
chore: Decouple NewConfiguration default URL from spec servers URL

### DIFF
--- a/admin/configuration.go
+++ b/admin/configuration.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"go.mongodb.org/atlas-sdk/v20250312023/internal/core"
 )
 
 // contextKeys are used to identify the type of value in the context.
@@ -82,7 +84,8 @@ func NewConfiguration() *Configuration {
 		Debug:         false,
 		Servers: ServerConfigurations{
 			{
-				URL:         "https://cloud.mongodb.com",
+				// Default base URL is decoupled from the spec servers URL so spec changes do not affect generated code.
+				URL:         core.DefaultCloudURL,
 				Description: "No description provided",
 			},
 		},

--- a/admin/configuration.go
+++ b/admin/configuration.go
@@ -84,7 +84,6 @@ func NewConfiguration() *Configuration {
 		Debug:         false,
 		Servers: ServerConfigurations{
 			{
-				// Default base URL is decoupled from the spec servers URL so spec changes do not affect generated code.
 				URL:         core.DefaultCloudURL,
 				Description: "No description provided",
 			},

--- a/tools/config/go-templates/configuration.mustache
+++ b/tools/config/go-templates/configuration.mustache
@@ -111,7 +111,9 @@ func NewConfiguration() *Configuration {
 		Servers:          ServerConfigurations{
 		{{/-first}}
 			{
-				// Default base URL is decoupled from the spec servers URL so spec changes do not affect generated code.
+				{{! X-XGEN-MODIFIED }}
+				{{! Default base URL is decoupled from the spec servers URL so spec changes do not affect generated code. }}
+				{{! Assumes a single root server in the spec, enforced by validation in the transformer. }}
 				URL: core.DefaultCloudURL,
 				Description: "{{{description}}}{{^description}}No description provided{{/description}}",
 				{{#variables}}

--- a/tools/config/go-templates/configuration.mustache
+++ b/tools/config/go-templates/configuration.mustache
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"go.mongodb.org/atlas-sdk/v20250312023/internal/core"
 )
 
 // contextKeys are used to identify the type of value in the context.
@@ -109,7 +111,8 @@ func NewConfiguration() *Configuration {
 		Servers:          ServerConfigurations{
 		{{/-first}}
 			{
-				URL: "{{{url}}}",
+				// Default base URL is decoupled from the spec servers URL so spec changes do not affect generated code.
+				URL: core.DefaultCloudURL,
 				Description: "{{{description}}}{{^description}}No description provided{{/description}}",
 				{{#variables}}
 				{{#-first}}

--- a/tools/transformer/__tests__/transformations.test.js
+++ b/tools/transformer/__tests__/transformations.test.js
@@ -5,6 +5,7 @@ const {
   transformAllOf,
   transformOneOf,
   applyOperationIdOverrides,
+  applyServersValidation,
 } = require("../src/transformations");
 const cases = require("./transformations-snapshots");
 
@@ -90,4 +91,68 @@ test("applyOperationIdOverrides", () => {
   expect(
     api.paths["/api/atlas/v2/example/info"].get["x-xgen-operation-id-override"],
   ).toBeFalsy();
+});
+
+describe("applyServersValidation", () => {
+  const singleRootServer = {
+    servers: [{ url: "https://cloud.mongodb.com" }],
+    paths: {
+      "/api/atlas/v2/groups": { get: { operationId: "listGroups" } },
+    },
+  };
+
+  test("passes with exactly one root server and no operation-level servers", () => {
+    expect(applyServersValidation(singleRootServer)).toBe(singleRootServer);
+  });
+
+  test("throws when root servers are missing", () => {
+    expect(() => applyServersValidation({ paths: {} })).toThrow(
+      /exactly one root server/,
+    );
+  });
+
+  test("throws when multiple root servers are defined", () => {
+    const multipleServers = {
+      servers: [
+        { url: "https://cloud.mongodb.com" },
+        { url: "https://api.mongodb.com" },
+      ],
+      paths: {},
+    };
+    expect(() => applyServersValidation(multipleServers)).toThrow(
+      /exactly one root server/,
+    );
+  });
+
+  test("throws when a path-level servers block is defined", () => {
+    const pathServers = {
+      servers: [{ url: "https://cloud.mongodb.com" }],
+      paths: {
+        "/api/atlas/v2/groups": {
+          servers: [{ url: "https://api.mongodb.com" }],
+          get: { operationId: "listGroups" },
+        },
+      },
+    };
+    expect(() => applyServersValidation(pathServers)).toThrow(
+      /servers block at path level/,
+    );
+  });
+
+  test("throws when an operation-level servers block is defined", () => {
+    const operationServers = {
+      servers: [{ url: "https://cloud.mongodb.com" }],
+      paths: {
+        "/api/atlas/v2/groups": {
+          get: {
+            operationId: "listGroups",
+            servers: [{ url: "https://api.mongodb.com" }],
+          },
+        },
+      },
+    };
+    expect(() => applyServersValidation(operationServers)).toThrow(
+      /servers block at operation level/,
+    );
+  });
 });

--- a/tools/transformer/src/atlasTransformations.js
+++ b/tools/transformer/src/atlasTransformations.js
@@ -11,6 +11,7 @@ const {
   reorderResponseBodies,
   applyFieldTransformations,
   applyOperationIdOverrides,
+  applyServersValidation,
 } = require("./transformations");
 const { resolveOpenAPIReference } = require("./engine/transformers");
 
@@ -55,6 +56,9 @@ function runFlatteningTransformations(openapi) {
 }
 
 function runAllTransformations(openapi) {
+  // SDK templates assume a single root server and no operation-level servers
+  applyServersValidation(openapi);
+
   openapi = runFlatteningTransformations(openapi);
 
   // SDK specific transformations

--- a/tools/transformer/src/transformations/index.js
+++ b/tools/transformer/src/transformations/index.js
@@ -17,6 +17,7 @@ const { removeRefsFromParameters } = require("./removeInvalidParams");
 const { reorderResponseBodies } = require("./reorderResponseBodies");
 const { applyFieldTransformations } = require("./fields");
 const { applyOperationIdOverrides } = require("./operationId");
+const { applyServersValidation } = require("./validateServers");
 
 module.exports = {
   applyModelNameTransformations,
@@ -35,4 +36,5 @@ module.exports = {
   reorderResponseBodies,
   applyFieldTransformations,
   applyOperationIdOverrides,
+  applyServersValidation,
 };

--- a/tools/transformer/src/transformations/validateServers.js
+++ b/tools/transformer/src/transformations/validateServers.js
@@ -1,0 +1,58 @@
+const validHttpMethods = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+];
+
+const GUIDANCE =
+  "atlas-sdk-go decouples the generated default base URL from the spec servers " +
+  "block (see tools/config/go-templates/configuration.mustache) and assumes the " +
+  "spec defines exactly one root server and no operation-level servers. Before " +
+  "changing the spec servers, review that template and internal/core DefaultCloudURL.";
+
+/**
+ * Validates the servers assumptions made by the Go SDK templates:
+ * exactly one root server and no operation-level servers.
+ * Throws an error with guidance if any assumption is broken.
+ *
+ * @param {*} api OpenAPI JSON File
+ * @returns {*} unchanged OpenAPI JSON File
+ */
+function applyServersValidation(api) {
+  if (!Array.isArray(api.servers) || api.servers.length !== 1) {
+    throw new Error(
+      `Expected exactly one root server in the OpenAPI spec, found ${
+        Array.isArray(api.servers) ? api.servers.length : 0
+      }. ${GUIDANCE}`,
+    );
+  }
+
+  Object.keys(api.paths || {}).forEach((pathKey) => {
+    const pathItem = api.paths[pathKey];
+    if (!pathItem) {
+      return;
+    }
+    if (pathItem.servers) {
+      throw new Error(
+        `Unexpected servers block at path level for "${pathKey}". ${GUIDANCE}`,
+      );
+    }
+    validHttpMethods.forEach((method) => {
+      const operation = pathItem[method];
+      if (operation && operation.servers) {
+        throw new Error(
+          `Unexpected servers block at operation level for "${method.toUpperCase()} ${pathKey}". ${GUIDANCE}`,
+        );
+      }
+    });
+  });
+
+  return api;
+}
+
+module.exports = { applyServersValidation };


### PR DESCRIPTION
## Description

`admin.NewConfiguration()` bakes the spec's servers URL into generated code at generation time via `configuration.mustache`. If that URL were to ever change in the spec, regenerating the SDK would silently change the default base URL for consumers on the `NewConfiguration()` + `NewAPIClient` path, a behavior change that could be treated as breaking and force a major version bump.

This PR adjusts `configuration.mustache` so `NewConfiguration()` reuses the existing hand-written `core.DefaultCloudURL` constant (already used by the recommended admin.NewClient path) instead of the spec's servers URL. Generation is now decoupled from the spec servers block, so any future spec URL change will not alter generated code.

## Verification:
Regenerated the SDK against a spec copy with a different servers URL and confirmed the default base URL in generated code does not change. `go build ./...` and `go test ./test` pass.

Link to any related issue(s): CLOUDP-422448

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

No automated test was added: the fix lives in the generation template and was verified by regenerating against a spec with a different servers URL (produces no diff in the generated default base URL). Consumers overriding the base URL (UseBaseURL, or mutating cfg.Servers directly, e.g. for `cloud-dev.mongodb.com`) are unaffected.