### PR TITLE
chore: migrate SilkBomb workflows to ECR

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -38,13 +38,26 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     env:
-      SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
+      ECR_REGISTRY: 901841024863.dkr.ecr.us-east-1.amazonaws.com
+      ECR_ROLE_ARN: arn:aws:iam::901841024863:role/ecr-role-gha-ro
+      SILKBOMB_IMG: 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0
       RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ env.RELEASE_TAG }}
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Authenticate Docker to DevProd Platforms ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 |
+            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${SILKBOMB_IMG}"
       - name: Generate PURLs and SBOM
         run: make gen-purls gen-sbom
       - name: Upload SBOM to Kondukto
@@ -61,7 +74,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   generate-ssdlc-report:
-    needs: compliance
+    needs: [release, compliance]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -42,7 +42,7 @@ jobs:
     env:
       ECR_REGISTRY: 901841024863.dkr.ecr.us-east-1.amazonaws.com
       ECR_ROLE_ARN: arn:aws:iam::901841024863:role/ecr-role-gha-ro
-      SILKBOMB_IMG: 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0
+      SILKBOMB_IMG: 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0@sha256:fd89d36841f1f7f286f1dbddffdb50f3e9d893d867ee3ddd441187a96539ee08
       RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -40,9 +40,9 @@ jobs:
       contents: write
       id-token: write
     env:
-      ECR_REGISTRY: 901841024863.dkr.ecr.us-east-1.amazonaws.com
-      ECR_ROLE_ARN: arn:aws:iam::901841024863:role/ecr-role-gha-ro
-      SILKBOMB_IMG: 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0@sha256:fd89d36841f1f7f286f1dbddffdb50f3e9d893d867ee3ddd441187a96539ee08
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
+      SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
       RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/generate-augmented-sbom.yml
+++ b/.github/workflows/generate-augmented-sbom.yml
@@ -16,12 +16,26 @@ jobs:
   augment-sbom:
     runs-on: ubuntu-latest
     env:
+      ECR_REGISTRY: 901841024863.dkr.ecr.us-east-1.amazonaws.com
+      ECR_ROLE_ARN: arn:aws:iam::901841024863:role/ecr-role-gha-ro
       KONDUKTO_TOKEN: ${{ secrets.KONDUKTO_TOKEN }}
       KONDUKTO_REPO: ${{ vars.KONDUKTO_REPO }}
       KONDUKTO_BRANCH_PREFIX: ${{ vars.KONDUKTO_BRANCH_PREFIX }}
-      SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
+      SILKBOMB_IMG: 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Authenticate Docker to DevProd Platforms ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 |
+            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${SILKBOMB_IMG}"
 
       - name: Get current date
         id: date

--- a/.github/workflows/generate-augmented-sbom.yml
+++ b/.github/workflows/generate-augmented-sbom.yml
@@ -16,12 +16,12 @@ jobs:
   augment-sbom:
     runs-on: ubuntu-latest
     env:
-      ECR_REGISTRY: 901841024863.dkr.ecr.us-east-1.amazonaws.com
-      ECR_ROLE_ARN: arn:aws:iam::901841024863:role/ecr-role-gha-ro
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
       KONDUKTO_TOKEN: ${{ secrets.KONDUKTO_TOKEN }}
       KONDUKTO_REPO: ${{ vars.KONDUKTO_REPO }}
       KONDUKTO_BRANCH_PREFIX: ${{ vars.KONDUKTO_BRANCH_PREFIX }}
-      SILKBOMB_IMG: 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0@sha256:fd89d36841f1f7f286f1dbddffdb50f3e9d893d867ee3ddd441187a96539ee08
+      SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 

--- a/.github/workflows/generate-augmented-sbom.yml
+++ b/.github/workflows/generate-augmented-sbom.yml
@@ -21,7 +21,7 @@ jobs:
       KONDUKTO_TOKEN: ${{ secrets.KONDUKTO_TOKEN }}
       KONDUKTO_REPO: ${{ vars.KONDUKTO_REPO }}
       KONDUKTO_BRANCH_PREFIX: ${{ vars.KONDUKTO_BRANCH_PREFIX }}
-      SILKBOMB_IMG: 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0
+      SILKBOMB_IMG: 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0@sha256:fd89d36841f1f7f286f1dbddffdb50f3e9d893d867ee3ddd441187a96539ee08
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,30 @@ permissions:
   contents: read
 
 jobs:
+  # Temporary validation for the SilkBomb ECR migration. Remove after this PR passes.
+  silkbomb-ecr-access:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      ECR_REGISTRY: 901841024863.dkr.ecr.us-east-1.amazonaws.com
+      ECR_ROLE_ARN: arn:aws:iam::901841024863:role/ecr-role-gha-ro
+      SILKBOMB_IMG: 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0
+    steps:
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Pull and run SilkBomb from ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 |
+            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${SILKBOMB_IMG}"
+          docker run --platform="linux/amd64" --rm "${SILKBOMB_IMG}" --help
+
   code-health:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,30 +12,6 @@ permissions:
   contents: read
 
 jobs:
-  # Temporary validation for the SilkBomb ECR migration. Remove after this PR passes.
-  silkbomb-ecr-access:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    env:
-      ECR_REGISTRY: 901841024863.dkr.ecr.us-east-1.amazonaws.com
-      ECR_ROLE_ARN: arn:aws:iam::901841024863:role/ecr-role-gha-ro
-      SILKBOMB_IMG: 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0
-    steps:
-      - name: Configure AWS credentials for DevProd Platforms ECR
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
-        with:
-          role-to-assume: ${{ env.ECR_ROLE_ARN }}
-          aws-region: us-east-1
-      - name: Pull and run SilkBomb from ECR
-        run: |
-          aws ecr get-login-password --region us-east-1 |
-            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
-          docker pull "${SILKBOMB_IMG}"
-          docker run --platform="linux/amd64" --rm "${SILKBOMB_IMG}" --help
-
   code-health:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- replace the retired Artifactory SilkBomb image with the DevProd Platforms ECR image
- configure the registry, role ARN, and digest-pinned SilkBomb image through GitHub Actions repository variables
- authenticate GitHub Actions to ECR through the shared read-only OIDC role
- fix the SSDLC report job dependency on the release output

## Testing
- actionlint on all modified workflows
- ECR role assumption, image pull, and SilkBomb execution succeeded: https://github.com/mongodb/atlas-sdk-go/actions/runs/31637673485/job/94251979611