### PR TITLE
chore(deps): bump js-yaml from 3.15.0 to 3.15.1 in /tools

### DIFF
--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -4352,9 +4352,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9056,9 +9056,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
Resolves Dependabot alert [#100](https://github.com/mongodb/atlas-sdk-go/security/dependabot/100).

CVE-2026-59870: quadratic CPU consumption in `!!omap` resolution (high severity, affects js-yaml `>= 3.0.0, < 3.15.1`).

`js-yaml` is a transitive **dev** dependency: `jest -> @jest/core -> @jest/transform -> babel-plugin-istanbul -> @istanbuljs/load-nyc-config -> js-yaml`. The consumer already allows `^3.13.1`, so this is a lockfile-only refresh (`npm update js-yaml` in `tools/`) — no `package.json` change required.