### PR TITLE
feat: Add helper to detect ai agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ if agent, ok := detectaiagent.Detect(); ok {
 	userAgent += " " + agent.UserAgentIdentifier
 	// agent.ID can also be used for telemetry.
 }
+// pass userAgent to the SDK via admin.UseUserAgent(userAgent).
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ The services of a client divide the API into logical chunks and correspond to
 the structure of the Atlas API documentation at
 https://www.mongodb.com/docs/atlas/reference/api-resources-spec/.
 
+### AI agent detection
+
+The SDK provides an opt-in helper for tools to detect known AI agents that invoke them and add
+an identifier to their User-Agent:
+
+```go
+import "go.mongodb.org/atlas-sdk/v20250312023/detectaiagent"
+
+userAgent := "my-tool/1.0"
+if agent, ok := detectaiagent.Detect(); ok {
+	userAgent += " " + agent.UserAgentIdentifier
+	// agent.ID can also be used for telemetry.
+}
+```
+
 ## Documentation
 
 Please refer to the [docs](./docs)

--- a/detectaiagent/detect.go
+++ b/detectaiagent/detect.go
@@ -1,0 +1,151 @@
+// Package detectaiagent identifies AI agents that invoke SDK consumers.
+// Detection is based on known environment and filesystem markers used by AI agents.
+package detectaiagent
+
+import "os"
+
+const userAgentPrefix = "ai-agent/"
+
+// DetectedAgent describes an AI agent found by Detect.
+type DetectedAgent struct {
+	// ID is the agent identifier.
+	ID string
+	// UserAgentIdentifier is the agent identifier formatted for a User-Agent header (ai-agent/<ID>).
+	UserAgentIdentifier string
+}
+
+type agentDefinition struct {
+	id      string
+	markers []marker
+}
+
+type marker struct {
+	envVar   string
+	value    string
+	filePath string
+}
+
+var agentDefinitions = []agentDefinition{
+	{
+		id: "cursor",
+		markers: []marker{
+			{envVar: "CURSOR_AGENT"},
+			{envVar: "CURSOR_EXTENSION_HOST_ROLE", value: "agent-exec"},
+		},
+	},
+	{
+		id: "kimi",
+		markers: []marker{
+			{envVar: "KIMI_PLUGIN_ROOT"},
+		},
+	},
+	{
+		id: "gemini_cli",
+		markers: []marker{
+			{envVar: "GEMINI_CLI"},
+		},
+	},
+	{
+		id: "cline",
+		markers: []marker{
+			{envVar: "CLINE_ACTIVE"},
+		},
+	},
+	{
+		id: "codex_cli",
+		markers: []marker{
+			{envVar: "CODEX_SANDBOX"},
+			{envVar: "CODEX_CI"},
+			{envVar: "CODEX_THREAD_ID"},
+		},
+	},
+	{
+		id: "antigravity",
+		markers: []marker{
+			{envVar: "ANTIGRAVITY_AGENT"},
+			{envVar: "ANTIGRAVITY_CLI_ALIAS"},
+		},
+	},
+	{
+		id: "auggie_cli",
+		markers: []marker{
+			{envVar: "AUGMENT_AGENT"},
+		},
+	},
+	{
+		id: "opencode_client",
+		markers: []marker{
+			{envVar: "OPENCODE_CLIENT"},
+			{envVar: "OPENCODE"},
+		},
+	},
+	{
+		id: "goose",
+		markers: []marker{
+			{envVar: "AGENT", value: "goose"},
+		},
+	},
+	{
+		id: "amp",
+		markers: []marker{
+			{envVar: "AGENT", value: "amp"},
+		},
+	},
+	{
+		id: "pi",
+		markers: []marker{
+			{envVar: "AI_AGENT", value: "pi"},
+		},
+	},
+	{
+		id: "claude_code",
+		markers: []marker{
+			{envVar: "CLAUDECODE"},
+			{envVar: "CLAUDE_CODE"},
+		},
+	},
+	{
+		id: "copilot",
+		markers: []marker{
+			{envVar: "COPILOT_AGENT_SESSION_ID"},
+		},
+	},
+	{
+		id: "devin",
+		markers: []marker{
+			{filePath: "/opt/.devin"},
+		},
+	},
+	{
+		id: "trae_ai",
+		markers: []marker{
+			{envVar: "TRAE_AI_SHELL_ID"},
+		},
+	},
+}
+
+// Detect returns the first AI agent detected from known markers.
+func Detect() (DetectedAgent, bool) {
+	for _, agent := range agentDefinitions {
+		for _, marker := range agent.markers {
+			found := false
+
+			if marker.envVar != "" {
+				value, ok := os.LookupEnv(marker.envVar)
+				found = ok && value != "" && (marker.value == "" || value == marker.value)
+			} else {
+				_, err := os.Stat(marker.filePath)
+				found = err == nil
+			}
+
+			if found {
+				return DetectedAgent{
+					ID:                  agent.id,
+					UserAgentIdentifier: userAgentPrefix + agent.id,
+				}, true
+			}
+		}
+	}
+
+	return DetectedAgent{}, false
+}

--- a/detectaiagent/detect.go
+++ b/detectaiagent/detect.go
@@ -131,8 +131,8 @@ func Detect() (DetectedAgent, bool) {
 			found := false
 
 			if marker.envVar != "" {
-				value, ok := os.LookupEnv(marker.envVar)
-				found = ok && value != "" && (marker.value == "" || value == marker.value)
+				value := os.Getenv(marker.envVar)
+				found = value != "" && (marker.value == "" || value == marker.value)
 			} else {
 				_, err := os.Stat(marker.filePath)
 				found = err == nil

--- a/detectaiagent/detect_test.go
+++ b/detectaiagent/detect_test.go
@@ -1,0 +1,208 @@
+package detectaiagent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setAgentDefinitions(t *testing.T, definitions []agentDefinition) {
+	t.Helper()
+
+	original := agentDefinitions
+	agentDefinitions = definitions
+
+	t.Cleanup(func() {
+		agentDefinitions = original
+	})
+}
+
+func TestDetectEnvironmentMarkers(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		markerValue   string
+		envValue      string
+		expectedAgent DetectedAgent
+		expectedOK    bool
+	}{
+		{
+			name:        "matches any non-empty value",
+			markerValue: "",
+			envValue:    "value",
+			expectedAgent: DetectedAgent{
+				ID:                  "test_agent",
+				UserAgentIdentifier: "ai-agent/test_agent",
+			},
+			expectedOK: true,
+		},
+		{
+			name:        "rejects empty value",
+			markerValue: "",
+			envValue:    "",
+			expectedOK:  false,
+		},
+		{
+			name:        "matches exact value",
+			markerValue: "value",
+			envValue:    "value",
+			expectedAgent: DetectedAgent{
+				ID:                  "test_agent",
+				UserAgentIdentifier: "ai-agent/test_agent",
+			},
+			expectedOK: true,
+		},
+		{
+			name:        "rejects different value",
+			markerValue: "value",
+			envValue:    "othervalue",
+			expectedOK:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setAgentDefinitions(t, []agentDefinition{
+				{
+					id: "test_agent",
+					markers: []marker{
+						{envVar: "AGENT_MARKER", value: tc.markerValue},
+					},
+				},
+			})
+			t.Setenv("AGENT_MARKER", tc.envValue)
+
+			got, ok := Detect()
+
+			if ok != tc.expectedOK {
+				t.Errorf("Detect() ok = %t, expected %t", ok, tc.expectedOK)
+			}
+			if got != tc.expectedAgent {
+				t.Errorf("Detect() agent = %v, expected %v", got, tc.expectedAgent)
+			}
+		})
+	}
+}
+
+func TestDetectFileMarker(t *testing.T) {
+	tempDir := t.TempDir()
+	agentMarkerFile := filepath.Join(tempDir, "agent-marker")
+	if err := os.WriteFile(agentMarkerFile, nil, 0o600); err != nil {
+		t.Fatalf("failed to create test agent marker file: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name          string
+		filePath      string
+		expectedAgent DetectedAgent
+		expectedOK    bool
+	}{
+		{
+			name:     "matches existing file",
+			filePath: agentMarkerFile,
+			expectedAgent: DetectedAgent{
+				ID:                  "test_agent",
+				UserAgentIdentifier: "ai-agent/test_agent",
+			},
+			expectedOK: true,
+		},
+		{
+			name:       "rejects missing file",
+			filePath:   filepath.Join(tempDir, "missing"),
+			expectedOK: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setAgentDefinitions(t, []agentDefinition{
+				{
+					id: "test_agent",
+					markers: []marker{
+						{filePath: tc.filePath},
+					},
+				},
+			})
+
+			got, ok := Detect()
+
+			if ok != tc.expectedOK {
+				t.Errorf("Detect() ok = %t, expected %t", ok, tc.expectedOK)
+			}
+			if got != tc.expectedAgent {
+				t.Errorf("Detect() agent = %v, expected %v", got, tc.expectedAgent)
+			}
+		})
+	}
+}
+
+func TestDetectMultipleMarkers(t *testing.T) {
+	setAgentDefinitions(t, []agentDefinition{
+		{
+			id: "first_agent",
+			markers: []marker{
+				{envVar: "FIRST_AGENT_MARKER"},
+				{envVar: "FIRST_AGENT_SECOND_MARKER"},
+			},
+		},
+		{
+			id: "second_agent",
+			markers: []marker{
+				{envVar: "SECOND_AGENT_MARKER"},
+			},
+		},
+	})
+
+	for _, tc := range []struct {
+		name          string
+		envVars       map[string]string
+		expectedAgent DetectedAgent
+		expectedOK    bool
+	}{
+		{
+			name: "matches second marker of agent",
+			envVars: map[string]string{
+				"FIRST_AGENT_MARKER":        "",
+				"FIRST_AGENT_SECOND_MARKER": "value",
+			},
+			expectedAgent: DetectedAgent{
+				ID:                  "first_agent",
+				UserAgentIdentifier: "ai-agent/first_agent",
+			},
+			expectedOK: true,
+		},
+		{
+			name: "returns first matching agent",
+			envVars: map[string]string{
+				"FIRST_AGENT_MARKER":  "value",
+				"SECOND_AGENT_MARKER": "value",
+			},
+			expectedAgent: DetectedAgent{
+				ID:                  "first_agent",
+				UserAgentIdentifier: "ai-agent/first_agent",
+			},
+			expectedOK: true,
+		},
+		{
+			name: "skips agent with no matching markers",
+			envVars: map[string]string{
+				"SECOND_AGENT_MARKER": "value",
+			},
+			expectedAgent: DetectedAgent{
+				ID:                  "second_agent",
+				UserAgentIdentifier: "ai-agent/second_agent",
+			},
+			expectedOK: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for envVar, value := range tc.envVars {
+				t.Setenv(envVar, value)
+			}
+
+			got, ok := Detect()
+
+			if ok != tc.expectedOK {
+				t.Errorf("Detect() ok = %t, expected %t", ok, tc.expectedOK)
+			}
+			if got != tc.expectedAgent {
+				t.Errorf("Detect() agent = %v, expected %v", got, tc.expectedAgent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds a helper under a new `detectaiagent` package that identifies AI agents that invoke SDK consumers based on known markers (env vars & files).

Link to any related issue(s): CLOUDP-432500

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

