### PR TITLE
POC: omit required readOnly fields from request bodies

### DIFF
--- a/admin/model_access_list_item.go
+++ b/admin/model_access_list_item.go
@@ -9,7 +9,7 @@ type AccessListItem struct {
 	CidrBlock *string `json:"cidrBlock,omitempty"`
 	// IP address included in the API access list.
 	// Read only field.
-	IpAddress string `json:"ipAddress"`
+	IpAddress string `json:"ipAddress,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_api_atlas_snapshot_schedule.go
+++ b/admin/model_api_atlas_snapshot_schedule.go
@@ -12,7 +12,7 @@ type ApiAtlasSnapshotSchedule struct {
 	DailySnapshotRetentionDays int `json:"dailySnapshotRetentionDays"`
 	// Unique 24-hexadecimal digit string that identifies the project that contains the cluster.
 	// Read only field.
-	GroupId string `json:"groupId"`
+	GroupId string `json:"groupId,omitempty"`
 	// List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
 	// Read only field.
 	Links *[]Link `json:"links,omitempty"`

--- a/admin/model_api_error.go
+++ b/admin/model_api_error.go
@@ -9,10 +9,10 @@ type ApiError struct {
 	Detail *string `json:"detail,omitempty"`
 	// HTTP status code returned with this error.
 	// Read only field.
-	Error int `json:"error"`
+	Error int `json:"error,omitempty"`
 	// Application error code returned with this error.
 	// Read only field.
-	ErrorCode string `json:"errorCode"`
+	ErrorCode string `json:"errorCode,omitempty"`
 	// Parameters used to give more information about the error.
 	// Read only field.
 	Parameters *[]any `json:"parameters,omitempty"`

--- a/admin/model_api_key.go
+++ b/admin/model_api_key.go
@@ -6,16 +6,16 @@ package admin
 type ApiKey struct {
 	// List of network addresses granted access to this API using this API key.
 	// Read only field.
-	AccessList []AccessListItem `json:"accessList"`
+	AccessList []AccessListItem `json:"accessList,omitempty"`
 	// Unique 24-hexadecimal digit string that identifies this organization API key.
 	// Read only field.
-	Id string `json:"id"`
+	Id string `json:"id,omitempty"`
 	// Public API key value set for the specified organization API key.
 	// Read only field.
-	PublicKey string `json:"publicKey"`
+	PublicKey string `json:"publicKey,omitempty"`
 	// List that contains roles that the API key needs to have. All roles you provide must be valid for the specified project or organization. Each request must include a minimum of one valid role. The resource returns all project and organization roles assigned to the Cloud user.
 	// Read only field.
-	Roles []CloudAccessRoleAssignment `json:"roles"`
+	Roles []CloudAccessRoleAssignment `json:"roles,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_available_clusters_deployment.go
+++ b/admin/model_available_clusters_deployment.go
@@ -15,28 +15,28 @@ type AvailableClustersDeployment struct {
 	DbSizeBytes *int64 `json:"dbSizeBytes,omitempty"`
 	// Version of MongoDB features that this cluster supports.
 	// Read only field.
-	FeatureCompatibilityVersion string `json:"featureCompatibilityVersion"`
+	FeatureCompatibilityVersion string `json:"featureCompatibilityVersion,omitempty"`
 	// Flag that indicates whether Automation manages this cluster.
 	// Read only field.
-	Managed bool `json:"managed"`
+	Managed bool `json:"managed,omitempty"`
 	// Version of MongoDB that this cluster runs.
 	// Read only field.
-	MongoDBVersion string `json:"mongoDBVersion"`
+	MongoDBVersion string `json:"mongoDBVersion,omitempty"`
 	// Human-readable label that identifies this cluster.
 	// Read only field.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// Size of the Oplog on disk at the time of the request expressed in MB.
 	// Read only field.
 	OplogSizeMB *int `json:"oplogSizeMB,omitempty"`
 	// Flag that indicates whether someone configured this cluster as a sharded cluster.  - If `true`, this cluster serves as a sharded cluster. - If `false`, this cluster serves as a replica set.
 	// Read only field.
-	Sharded bool `json:"sharded"`
+	Sharded bool `json:"sharded,omitempty"`
 	// Number of shards that comprise this cluster.
 	// Read only field.
 	ShardsSize *int `json:"shardsSize,omitempty"`
 	// Flag that indicates whether someone enabled TLS for this cluster.
 	// Read only field.
-	TlsEnabled bool `json:"tlsEnabled"`
+	TlsEnabled bool `json:"tlsEnabled,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_cloud_app_user.go
+++ b/admin/model_cloud_app_user.go
@@ -16,7 +16,7 @@ type CloudAppUser struct {
 	// Email address that belongs to the MongoDB Cloud user.
 	// Read only field.
 	// Deprecated
-	EmailAddress string `json:"emailAddress"`
+	EmailAddress string `json:"emailAddress,omitempty"`
 	// First or given name that belongs to the MongoDB Cloud user.
 	FirstName string `json:"firstName"`
 	// Unique 24-hexadecimal digit string that identifies the MongoDB Cloud user.

--- a/admin/model_cloud_search_metrics.go
+++ b/admin/model_cloud_search_metrics.go
@@ -6,19 +6,19 @@ package admin
 type CloudSearchMetrics struct {
 	// Unique 24-hexadecimal digit string that identifies the project.
 	// Read only field.
-	GroupId string `json:"groupId"`
+	GroupId string `json:"groupId,omitempty"`
 	// List that contains all host compute, memory, and storage utilization dedicated to Atlas Search when MongoDB Atlas received this request.
 	// Read only field.
-	HardwareMetrics []FTSMetric `json:"hardwareMetrics"`
+	HardwareMetrics []FTSMetric `json:"hardwareMetrics,omitempty"`
 	// List that contains all performance and utilization measurements that Atlas Search index performed by the time MongoDB Atlas received this request.
 	// Read only field.
-	IndexMetrics []FTSMetric `json:"indexMetrics"`
+	IndexMetrics []FTSMetric `json:"indexMetrics,omitempty"`
 	// List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
 	// Read only field.
 	Links *[]Link `json:"links,omitempty"`
 	// Hostname and port that identifies the process.
 	// Read only field.
-	ProcessId string `json:"processId"`
+	ProcessId string `json:"processId,omitempty"`
 	// List that contains all available Atlas Search status metrics when MongoDB Atlas received this request.
 	StatusMetrics []FTSMetric `json:"statusMetrics"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).

--- a/admin/model_coll_stats_latency_namespace_metric.go
+++ b/admin/model_coll_stats_latency_namespace_metric.go
@@ -6,10 +6,10 @@ package admin
 type CollStatsLatencyNamespaceMetric struct {
 	// Human-readable label that identifies this metric.
 	// Read only field.
-	MetricName string `json:"metricName"`
+	MetricName string `json:"metricName,omitempty"`
 	// Unit of measurement that applies to this metric.
 	// Read only field.
-	Units string `json:"units"`
+	Units string `json:"units,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_coll_stats_latency_namespace_metrics.go
+++ b/admin/model_coll_stats_latency_namespace_metrics.go
@@ -6,13 +6,13 @@ package admin
 type CollStatsLatencyNamespaceMetrics struct {
 	// Unique 24-hexadecimal digit string that identifies the project.
 	// Read only field.
-	GroupId string `json:"groupId"`
+	GroupId string `json:"groupId,omitempty"`
 	// List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
 	// Read only field.
 	Links *[]Link `json:"links,omitempty"`
 	// List of Coll Stats Latency metric names and their respective units.
 	// Read only field.
-	Metrics []CollStatsLatencyNamespaceMetric `json:"metrics"`
+	Metrics []CollStatsLatencyNamespaceMetric `json:"metrics,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_coll_stats_ranked_namespaces.go
+++ b/admin/model_coll_stats_ranked_namespaces.go
@@ -12,7 +12,7 @@ type CollStatsRankedNamespaces struct {
 	IdentifierId *string `json:"identifierId,omitempty"`
 	// Ordered list of the hottest namespaces, highest value first.
 	// Read only field.
-	RankedNamespaces []string `json:"rankedNamespaces"`
+	RankedNamespaces []string `json:"rankedNamespaces,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_connected_org_config.go
+++ b/admin/model_connected_org_config.go
@@ -16,7 +16,7 @@ type ConnectedOrgConfig struct {
 	InstantUserProvisioningDisabled *bool `json:"instantUserProvisioningDisabled,omitempty"`
 	// Unique 24-hexadecimal digit string that identifies the connected organization configuration.
 	// Read only field.
-	OrgId string `json:"orgId"`
+	OrgId string `json:"orgId,omitempty"`
 	// Atlas roles that are granted to a user in this organization after authenticating. Roles are a human-readable label that identifies the collection of privileges that MongoDB Cloud grants a specific MongoDB Cloud user. These roles can only be organization specific roles.
 	PostAuthRoleGrants *[]string `json:"postAuthRoleGrants,omitempty"`
 	// Role mappings that are configured in this organization.

--- a/admin/model_data_federation_limit.go
+++ b/admin/model_data_federation_limit.go
@@ -15,7 +15,7 @@ type DataFederationLimit struct {
 	MaximumLimit *int64 `json:"maximumLimit,omitempty"`
 	// Human-readable label that identifies the user-managed limit to modify.
 	// Read only field.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// Amount to set the limit to.
 	Value int64 `json:"value"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).

--- a/admin/model_data_federation_tenant_query_limit.go
+++ b/admin/model_data_federation_tenant_query_limit.go
@@ -22,7 +22,7 @@ type DataFederationTenantQueryLimit struct {
 	MaximumLimit *int64 `json:"maximumLimit,omitempty"`
 	// Human-readable label that identifies the user-managed limit to modify.
 	// Read only field.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// Only used for Data Federation limits. Action to take when the usage limit is exceeded. If limit span is set to QUERY, this is ignored because MongoDB Cloud stops the query when it exceeds the usage limit.
 	OverrunPolicy *string `json:"overrunPolicy,omitempty"`
 	// Human-readable label that identifies the Federated Database Instance. If specified, the usage limit is for the specified federated database instance only. If omitted, the usage limit is for all federated database instances in the project.

--- a/admin/model_disk_backup_collection_response.go
+++ b/admin/model_disk_backup_collection_response.go
@@ -9,7 +9,7 @@ type DiskBackupCollectionResponse struct {
 	Links *[]Link `json:"links,omitempty"`
 	// Human-readable label that identifies the collection in the database within the snapshot.
 	// Read only field.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_disk_backup_database_response.go
+++ b/admin/model_disk_backup_database_response.go
@@ -9,7 +9,7 @@ type DiskBackupDatabaseResponse struct {
 	Links *[]Link `json:"links,omitempty"`
 	// Human-readable label that identifies the database within the snapshot.
 	// Read only field.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_disk_backup_export_job.go
+++ b/admin/model_disk_backup_export_job.go
@@ -18,7 +18,7 @@ type DiskBackupExportJob struct {
 	CustomData *[]BackupLabel `json:"customData,omitempty"`
 	// Unique 24-hexadecimal character string that identifies the Export Bucket.
 	// Read only field.
-	ExportBucketId string        `json:"exportBucketId"`
+	ExportBucketId string        `json:"exportBucketId,omitempty"`
 	ExportStatus   *ExportStatus `json:"exportStatus,omitempty"`
 	// Date and time when this Export Job completed. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC.
 	// Read only field.

--- a/admin/model_disk_backup_sharded_cluster_snapshot_member.go
+++ b/admin/model_disk_backup_sharded_cluster_snapshot_member.go
@@ -6,13 +6,13 @@ package admin
 type DiskBackupShardedClusterSnapshotMember struct {
 	// Human-readable label that identifies the cloud provider.
 	// Read only field.
-	CloudProvider string `json:"cloudProvider"`
+	CloudProvider string `json:"cloudProvider,omitempty"`
 	// Unique 24-hexadecimal digit string that identifies the snapshot.
 	// Read only field.
-	Id string `json:"id"`
+	Id string `json:"id,omitempty"`
 	// Human-readable label that identifies the shard or config host from which MongoDB Cloud took this snapshot.
 	// Read only field.
-	ReplicaSetName string `json:"replicaSetName"`
+	ReplicaSetName string `json:"replicaSetName,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_endpoint_service.go
+++ b/admin/model_endpoint_service.go
@@ -6,7 +6,7 @@ package admin
 type EndpointService struct {
 	// Cloud service provider that serves the requested endpoint service.
 	// Read only field.
-	CloudProvider string `json:"cloudProvider"`
+	CloudProvider string `json:"cloudProvider,omitempty"`
 	// Error message returned when requesting private connection resource. The resource returns `null` if the request succeeded.
 	// Read only field.
 	ErrorMessage *string `json:"errorMessage,omitempty"`

--- a/admin/model_enveloped_drop_index_suggestions_response.go
+++ b/admin/model_enveloped_drop_index_suggestions_response.go
@@ -13,7 +13,7 @@ type EnvelopedDropIndexSuggestionsResponse struct {
 	Locations *[]string `json:"locations,omitempty"`
 	// HTTP status code returned with this response.
 	// Read only field.
-	Status int `json:"status"`
+	Status int `json:"status,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_enveloped_performance_advisor_response.go
+++ b/admin/model_enveloped_performance_advisor_response.go
@@ -13,7 +13,7 @@ type EnvelopedPerformanceAdvisorResponse struct {
 	Locations *[]string `json:"locations,omitempty"`
 	// HTTP status code returned with this response.
 	// Read only field.
-	Status int `json:"status"`
+	Status int `json:"status,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_enveloped_schema_advisor_response.go
+++ b/admin/model_enveloped_schema_advisor_response.go
@@ -13,7 +13,7 @@ type EnvelopedSchemaAdvisorResponse struct {
 	Locations *[]string `json:"locations,omitempty"`
 	// HTTP status code returned with this response.
 	// Read only field.
-	Status int `json:"status"`
+	Status int `json:"status,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_federation_identity_provider.go
+++ b/admin/model_federation_identity_provider.go
@@ -19,7 +19,7 @@ type FederationIdentityProvider struct {
 	DisplayName *string `json:"displayName,omitempty"`
 	// Unique 24-hexadecimal digit string that identifies the identity provider.
 	// Read only field.
-	Id string `json:"id"`
+	Id string `json:"id,omitempty"`
 	// String enum that indicates the type of the identity provider. Default is WORKFORCE.
 	IdpType *string `json:"idpType,omitempty"`
 	// Unique string that identifies the issuer of the SAML Assertion or OIDC metadata/discovery document URL.

--- a/admin/model_federation_oidc_identity_provider.go
+++ b/admin/model_federation_oidc_identity_provider.go
@@ -25,7 +25,7 @@ type FederationOidcIdentityProvider struct {
 	GroupsClaim *string `json:"groupsClaim,omitempty"`
 	// Unique 24-hexadecimal digit string that identifies the identity provider.
 	// Read only field.
-	Id string `json:"id"`
+	Id string `json:"id,omitempty"`
 	// String enum that indicates the type of the identity provider. Default is WORKFORCE.
 	IdpType *string `json:"idpType,omitempty"`
 	// Unique string that identifies the issuer of the SAML Assertion or OIDC metadata/discovery document URL.

--- a/admin/model_fts_metric.go
+++ b/admin/model_fts_metric.go
@@ -6,10 +6,10 @@ package admin
 type FTSMetric struct {
 	// Human-readable label that identifies this Atlas Search hardware, status, or index measurement.
 	// Read only field.
-	MetricName string `json:"metricName"`
+	MetricName string `json:"metricName,omitempty"`
 	// Unit of measurement that applies to this Atlas Search metric.
 	// Read only field.
-	Units string `json:"units"`
+	Units string `json:"units,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_group.go
+++ b/admin/model_group.go
@@ -10,10 +10,10 @@ import (
 type Group struct {
 	// Quantity of MongoDB Cloud clusters deployed in this project.
 	// Read only field.
-	ClusterCount int64 `json:"clusterCount"`
+	ClusterCount int64 `json:"clusterCount,omitempty"`
 	// Date and time when MongoDB Cloud created this project. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
 	// Read only field.
-	Created time.Time `json:"created"`
+	Created time.Time `json:"created,omitempty"`
 	// Unique 24-hexadecimal digit string that identifies the MongoDB Cloud project.
 	// Read only field.
 	Id *string `json:"id,omitempty"`

--- a/admin/model_group_paginated_event.go
+++ b/admin/model_group_paginated_event.go
@@ -9,7 +9,7 @@ type GroupPaginatedEvent struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []EventViewForNdsGroup `json:"results"`
+	Results []EventViewForNdsGroup `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_group_user_response.go
+++ b/admin/model_group_user_response.go
@@ -10,16 +10,16 @@ import (
 type GroupUserResponse struct {
 	// Unique 24-hexadecimal digit string that identifies the MongoDB Cloud user.
 	// Read only field.
-	Id string `json:"id"`
+	Id string `json:"id,omitempty"`
 	// String enum that indicates the user's organization membership status: ACTIVE (member), PENDING (invited), `INVITATION_EXPIRED` (invitation expired), or `INVITATION_REJECTED` (invitation declined).
 	// Read only field.
-	OrgMembershipStatus string `json:"orgMembershipStatus"`
+	OrgMembershipStatus string `json:"orgMembershipStatus,omitempty"`
 	// One or more project-level roles assigned to the MongoDB Cloud user.
 	// Read only field.
-	Roles []string `json:"roles"`
+	Roles []string `json:"roles,omitempty"`
 	// Email address that represents the username of the MongoDB Cloud user.
 	// Read only field.
-	Username string `json:"username"`
+	Username string `json:"username,omitempty"`
 	// Date and time when MongoDB Cloud sent the invitation. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC. This field is absent for active users.
 	// Read only field.
 	InvitationCreatedAt *time.Time `json:"invitationCreatedAt,omitempty"`

--- a/admin/model_invoice_report_response.go
+++ b/admin/model_invoice_report_response.go
@@ -21,17 +21,17 @@ type InvoiceReportResponse struct {
 	FormatSpecVersion *string `json:"formatSpecVersion,omitempty"`
 	// Unique 24-hexadecimal digit string that identifies the invoice.
 	// Read only field.
-	InvoiceId string `json:"invoiceId"`
+	InvoiceId string `json:"invoiceId,omitempty"`
 	// Format of the generated report.
 	ReportFormat string `json:"reportFormat"`
 	// Unique 24-hexadecimal digit string that identifies the report.
 	// Read only field.
-	ReportId string `json:"reportId"`
+	ReportId string `json:"reportId,omitempty"`
 	// Type of the generated report.
 	ReportType string `json:"reportType"`
 	// Current state of the report generation.
 	// Read only field.
-	State string `json:"state"`
+	State string `json:"state,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_live_import_available_project.go
+++ b/admin/model_live_import_available_project.go
@@ -10,10 +10,10 @@ type LiveImportAvailableProject struct {
 	MigrationHosts []string `json:"migrationHosts"`
 	// Human-readable label that identifies this project.
 	// Read only field.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// Unique 24-hexadecimal digit string that identifies the project to be migrated.
 	// Read only field.
-	ProjectId string `json:"projectId"`
+	ProjectId string `json:"projectId,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_metric_integration_response.go
+++ b/admin/model_metric_integration_response.go
@@ -17,7 +17,7 @@ type MetricIntegrationResponse struct {
 	IntegrationType string `json:"integrationType"`
 	// Unique identifier of the metric integration configuration.
 	// Read only field.
-	MetricIntegrationId string `json:"metricIntegrationId"`
+	MetricIntegrationId string `json:"metricIntegrationId,omitempty"`
 	// Array of metric categories to export. Determines which types of metrics are sent to the integration.
 	MetricSelection []string `json:"metricSelection"`
 	// The provider type for the metric integration. Identifies the third-party service provider.

--- a/admin/model_network_permission_entry_status.go
+++ b/admin/model_network_permission_entry_status.go
@@ -6,7 +6,7 @@ package admin
 type NetworkPermissionEntryStatus struct {
 	// State of the access list entry when MongoDB Cloud made this request.  `ACTIVE`: This access list entry applies to all relevant cloud providers.  `PENDING`: MongoDB Cloud has started to add access list entry. This access list entry may not apply to all cloud providers at the time of this request.  `FAILED`: MongoDB Cloud didn't succeed in adding this access list entry.
 	// Read only field.
-	STATUS string `json:"STATUS"`
+	STATUS string `json:"STATUS,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_org_paginated_event.go
+++ b/admin/model_org_paginated_event.go
@@ -9,7 +9,7 @@ type OrgPaginatedEvent struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []EventViewForOrg `json:"results"`
+	Results []EventViewForOrg `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_org_user_response.go
+++ b/admin/model_org_user_response.go
@@ -10,17 +10,17 @@ import (
 type OrgUserResponse struct {
 	// Unique 24-hexadecimal digit string that identifies the MongoDB Cloud user.
 	// Read only field.
-	Id string `json:"id"`
+	Id string `json:"id,omitempty"`
 	// String enum that indicates the user's organization membership status: ACTIVE (member), PENDING (invited), `INVITATION_EXPIRED` (invitation expired), or `INVITATION_REJECTED` (invitation declined).
 	// Read only field.
-	OrgMembershipStatus string               `json:"orgMembershipStatus"`
+	OrgMembershipStatus string               `json:"orgMembershipStatus,omitempty"`
 	Roles               OrgUserRolesResponse `json:"roles"`
 	// List of unique 24-hexadecimal digit strings that identifies the teams to which this MongoDB Cloud user belongs.
 	// Read only field.
 	TeamIds *[]string `json:"teamIds,omitempty"`
 	// Email address that represents the username of the MongoDB Cloud user.
 	// Read only field.
-	Username string `json:"username"`
+	Username string `json:"username,omitempty"`
 	// Date and time when MongoDB Cloud sent the invitation. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC. This field is absent for active users.
 	// Read only field.
 	InvitationCreatedAt *time.Time `json:"invitationCreatedAt,omitempty"`

--- a/admin/model_paginated_alert.go
+++ b/admin/model_paginated_alert.go
@@ -9,7 +9,7 @@ type PaginatedAlert struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []AlertViewForNdsGroup `json:"results"`
+	Results []AlertViewForNdsGroup `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_alert_config.go
+++ b/admin/model_paginated_alert_config.go
@@ -9,7 +9,7 @@ type PaginatedAlertConfig struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []GroupAlertsConfig `json:"results"`
+	Results []GroupAlertsConfig `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_api_user.go
+++ b/admin/model_paginated_api_api_user.go
@@ -9,7 +9,7 @@ type PaginatedApiApiUser struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ApiKeyUserDetails `json:"results"`
+	Results []ApiKeyUserDetails `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_app_user.go
+++ b/admin/model_paginated_api_app_user.go
@@ -9,7 +9,7 @@ type PaginatedApiAppUser struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []CloudAppUser `json:"results"`
+	Results []CloudAppUser `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_checkpoint.go
+++ b/admin/model_paginated_api_atlas_checkpoint.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasCheckpoint struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ApiAtlasCheckpoint `json:"results"`
+	Results []ApiAtlasCheckpoint `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_collection_restore_collection_state.go
+++ b/admin/model_paginated_api_atlas_collection_restore_collection_state.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasCollectionRestoreCollectionState struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ApiAtlasCollectionRestoreCollectionStateResponse `json:"results"`
+	Results []ApiAtlasCollectionRestoreCollectionStateResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_collection_restore_job.go
+++ b/admin/model_paginated_api_atlas_collection_restore_job.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasCollectionRestoreJob struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ApiAtlasCollectionRestoreJobResponse `json:"results"`
+	Results []ApiAtlasCollectionRestoreJobResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_database_user.go
+++ b/admin/model_paginated_api_atlas_database_user.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasDatabaseUser struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []CloudDatabaseUser `json:"results"`
+	Results []CloudDatabaseUser `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_disk_backup_collection.go
+++ b/admin/model_paginated_api_atlas_disk_backup_collection.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasDiskBackupCollection struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []DiskBackupCollectionResponse `json:"results"`
+	Results []DiskBackupCollectionResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_disk_backup_database.go
+++ b/admin/model_paginated_api_atlas_disk_backup_database.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasDiskBackupDatabase struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []DiskBackupDatabaseResponse `json:"results"`
+	Results []DiskBackupDatabaseResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_disk_backup_export_job.go
+++ b/admin/model_paginated_api_atlas_disk_backup_export_job.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasDiskBackupExportJob struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []DiskBackupExportJob `json:"results"`
+	Results []DiskBackupExportJob `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_ear_private_endpoint.go
+++ b/admin/model_paginated_api_atlas_ear_private_endpoint.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasEARPrivateEndpoint struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []EARPrivateEndpoint `json:"results"`
+	Results []EARPrivateEndpoint `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_flex_backup_restore_job20241113.go
+++ b/admin/model_paginated_api_atlas_flex_backup_restore_job20241113.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasFlexBackupRestoreJob20241113 struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []FlexBackupRestoreJob20241113 `json:"results"`
+	Results []FlexBackupRestoreJob20241113 `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_flex_backup_snapshot20241113.go
+++ b/admin/model_paginated_api_atlas_flex_backup_snapshot20241113.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasFlexBackupSnapshot20241113 struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []FlexBackupSnapshot20241113 `json:"results"`
+	Results []FlexBackupSnapshot20241113 `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_object_storage_private_endpoint_response.go
+++ b/admin/model_paginated_api_atlas_object_storage_private_endpoint_response.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasObjectStoragePrivateEndpointResponse struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ObjectStoragePrivateEndpointResponse `json:"results"`
+	Results []ObjectStoragePrivateEndpointResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_provider_regions.go
+++ b/admin/model_paginated_api_atlas_provider_regions.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasProviderRegions struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []CloudProviderRegions `json:"results"`
+	Results []CloudProviderRegions `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_serverless_backup_restore_job.go
+++ b/admin/model_paginated_api_atlas_serverless_backup_restore_job.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasServerlessBackupRestoreJob struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ServerlessBackupRestoreJob `json:"results"`
+	Results []ServerlessBackupRestoreJob `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_atlas_serverless_backup_snapshot.go
+++ b/admin/model_paginated_api_atlas_serverless_backup_snapshot.go
@@ -9,7 +9,7 @@ type PaginatedApiAtlasServerlessBackupSnapshot struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ServerlessBackupSnapshot `json:"results"`
+	Results []ServerlessBackupSnapshot `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_invoice.go
+++ b/admin/model_paginated_api_invoice.go
@@ -9,7 +9,7 @@ type PaginatedApiInvoice struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []BillingInvoice `json:"results"`
+	Results []BillingInvoice `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_invoice_metadata.go
+++ b/admin/model_paginated_api_invoice_metadata.go
@@ -9,7 +9,7 @@ type PaginatedApiInvoiceMetadata struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []BillingInvoiceMetadata `json:"results"`
+	Results []BillingInvoiceMetadata `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_sku.go
+++ b/admin/model_paginated_api_sku.go
@@ -9,7 +9,7 @@ type PaginatedApiSKU struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []SkuResponse `json:"results"`
+	Results []SkuResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_streams_connection.go
+++ b/admin/model_paginated_api_streams_connection.go
@@ -9,7 +9,7 @@ type PaginatedApiStreamsConnection struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []StreamsConnection `json:"results"`
+	Results []StreamsConnection `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_streams_failover_connection.go
+++ b/admin/model_paginated_api_streams_failover_connection.go
@@ -9,7 +9,7 @@ type PaginatedApiStreamsFailoverConnection struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []StreamsFailoverConnection `json:"results"`
+	Results []StreamsFailoverConnection `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_streams_private_link.go
+++ b/admin/model_paginated_api_streams_private_link.go
@@ -9,7 +9,7 @@ type PaginatedApiStreamsPrivateLink struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []StreamsPrivateLinkConnection `json:"results"`
+	Results []StreamsPrivateLinkConnection `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_streams_stream_processor_with_stats.go
+++ b/admin/model_paginated_api_streams_stream_processor_with_stats.go
@@ -9,7 +9,7 @@ type PaginatedApiStreamsStreamProcessorWithStats struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []StreamsProcessorWithStats `json:"results"`
+	Results []StreamsProcessorWithStats `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_streams_tenant.go
+++ b/admin/model_paginated_api_streams_tenant.go
@@ -9,7 +9,7 @@ type PaginatedApiStreamsTenant struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []StreamsTenant `json:"results"`
+	Results []StreamsTenant `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_streams_vpc_peering_connection.go
+++ b/admin/model_paginated_api_streams_vpc_peering_connection.go
@@ -9,7 +9,7 @@ type PaginatedApiStreamsVPCPeeringConnection struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []VPCPeeringConnection `json:"results"`
+	Results []VPCPeeringConnection `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_api_user_access_list_response.go
+++ b/admin/model_paginated_api_user_access_list_response.go
@@ -9,7 +9,7 @@ type PaginatedApiUserAccessListResponse struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []UserAccessListResponse `json:"results"`
+	Results []UserAccessListResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_atlas_ai_model_api_keys_response.go
+++ b/admin/model_paginated_atlas_ai_model_api_keys_response.go
@@ -9,7 +9,7 @@ type PaginatedAtlasAiModelApiKeysResponse struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []AiModelApiKeyResponse `json:"results"`
+	Results []AiModelApiKeyResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_atlas_ai_model_rate_limits_response.go
+++ b/admin/model_paginated_atlas_ai_model_rate_limits_response.go
@@ -9,7 +9,7 @@ type PaginatedAtlasAiModelRateLimitsResponse struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []AiModelRateLimitResponse `json:"results"`
+	Results []AiModelRateLimitResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_atlas_group.go
+++ b/admin/model_paginated_atlas_group.go
@@ -9,7 +9,7 @@ type PaginatedAtlasGroup struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []Group `json:"results"`
+	Results []Group `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_available_version.go
+++ b/admin/model_paginated_available_version.go
@@ -9,7 +9,7 @@ type PaginatedAvailableVersion struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []MdbAvailableVersion `json:"results"`
+	Results []MdbAvailableVersion `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_backup_snapshot_export_buckets.go
+++ b/admin/model_paginated_backup_snapshot_export_buckets.go
@@ -9,7 +9,7 @@ type PaginatedBackupSnapshotExportBuckets struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []DiskBackupSnapshotExportBucketResponse `json:"results"`
+	Results []DiskBackupSnapshotExportBucketResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_cloud_backup_replica_set.go
+++ b/admin/model_paginated_cloud_backup_replica_set.go
@@ -9,7 +9,7 @@ type PaginatedCloudBackupReplicaSet struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []DiskBackupReplicaSet `json:"results"`
+	Results []DiskBackupReplicaSet `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_cloud_backup_restore_job.go
+++ b/admin/model_paginated_cloud_backup_restore_job.go
@@ -9,7 +9,7 @@ type PaginatedCloudBackupRestoreJob struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []DiskBackupSnapshotRestoreJob `json:"results"`
+	Results []DiskBackupSnapshotRestoreJob `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_cloud_backup_sharded_cluster_snapshot.go
+++ b/admin/model_paginated_cloud_backup_sharded_cluster_snapshot.go
@@ -9,7 +9,7 @@ type PaginatedCloudBackupShardedClusterSnapshot struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []DiskBackupShardedClusterSnapshot `json:"results"`
+	Results []DiskBackupShardedClusterSnapshot `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_cloud_provider_container.go
+++ b/admin/model_paginated_cloud_provider_container.go
@@ -9,7 +9,7 @@ type PaginatedCloudProviderContainer struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []CloudProviderContainer `json:"results"`
+	Results []CloudProviderContainer `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_cluster_description20240805.go
+++ b/admin/model_paginated_cluster_description20240805.go
@@ -9,7 +9,7 @@ type PaginatedClusterDescription20240805 struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ClusterDescription20240805 `json:"results"`
+	Results []ClusterDescription20240805 `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_connected_org_configs.go
+++ b/admin/model_paginated_connected_org_configs.go
@@ -9,7 +9,7 @@ type PaginatedConnectedOrgConfigs struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ConnectedOrgConfig `json:"results"`
+	Results []ConnectedOrgConfig `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_container_peer.go
+++ b/admin/model_paginated_container_peer.go
@@ -9,7 +9,7 @@ type PaginatedContainerPeer struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []BaseNetworkPeeringConnectionSettings `json:"results"`
+	Results []BaseNetworkPeeringConnectionSettings `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_database.go
+++ b/admin/model_paginated_database.go
@@ -9,7 +9,7 @@ type PaginatedDatabase struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []MesurementsDatabase `json:"results"`
+	Results []MesurementsDatabase `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_disk_partition.go
+++ b/admin/model_paginated_disk_partition.go
@@ -9,7 +9,7 @@ type PaginatedDiskPartition struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []MeasurementDiskPartition `json:"results"`
+	Results []MeasurementDiskPartition `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_event_type_details_response.go
+++ b/admin/model_paginated_event_type_details_response.go
@@ -9,7 +9,7 @@ type PaginatedEventTypeDetailsResponse struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []EventTypeDetails `json:"results"`
+	Results []EventTypeDetails `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_federation_identity_provider.go
+++ b/admin/model_paginated_federation_identity_provider.go
@@ -9,7 +9,7 @@ type PaginatedFederationIdentityProvider struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []FederationIdentityProvider `json:"results"`
+	Results []FederationIdentityProvider `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_flex_clusters20241113.go
+++ b/admin/model_paginated_flex_clusters20241113.go
@@ -9,7 +9,7 @@ type PaginatedFlexClusters20241113 struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []FlexClusterDescription20241113 `json:"results"`
+	Results []FlexClusterDescription20241113 `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_group_mcp_config.go
+++ b/admin/model_paginated_group_mcp_config.go
@@ -9,7 +9,7 @@ type PaginatedGroupMcpConfig struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []GroupMcpConfigResponse `json:"results"`
+	Results []GroupMcpConfigResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_group_service_accounts.go
+++ b/admin/model_paginated_group_service_accounts.go
@@ -9,7 +9,7 @@ type PaginatedGroupServiceAccounts struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []GroupServiceAccount `json:"results"`
+	Results []GroupServiceAccount `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_group_user.go
+++ b/admin/model_paginated_group_user.go
@@ -9,7 +9,7 @@ type PaginatedGroupUser struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []GroupUserResponse `json:"results"`
+	Results []GroupUserResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_host_view_atlas.go
+++ b/admin/model_paginated_host_view_atlas.go
@@ -9,7 +9,7 @@ type PaginatedHostViewAtlas struct {
 	Links *[]LinkAtlas `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ApiHostViewAtlas `json:"results"`
+	Results []ApiHostViewAtlas `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_integration.go
+++ b/admin/model_paginated_integration.go
@@ -9,7 +9,7 @@ type PaginatedIntegration struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ThirdPartyIntegration `json:"results"`
+	Results []ThirdPartyIntegration `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_invoice_report.go
+++ b/admin/model_paginated_invoice_report.go
@@ -9,7 +9,7 @@ type PaginatedInvoiceReport struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []InvoiceReportResponse `json:"results"`
+	Results []InvoiceReportResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_log_integration_response.go
+++ b/admin/model_paginated_log_integration_response.go
@@ -9,7 +9,7 @@ type PaginatedLogIntegrationResponse struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []LogIntegrationResponse `json:"results"`
+	Results []LogIntegrationResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_mcp_config_secret.go
+++ b/admin/model_paginated_mcp_config_secret.go
@@ -9,7 +9,7 @@ type PaginatedMcpConfigSecret struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ServiceAccountSecret `json:"results"`
+	Results []ServiceAccountSecret `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_metric_integration_response.go
+++ b/admin/model_paginated_metric_integration_response.go
@@ -9,7 +9,7 @@ type PaginatedMetricIntegrationResponse struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []MetricIntegrationResponse `json:"results"`
+	Results []MetricIntegrationResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_network_access.go
+++ b/admin/model_paginated_network_access.go
@@ -9,7 +9,7 @@ type PaginatedNetworkAccess struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []NetworkPermissionEntry `json:"results"`
+	Results []NetworkPermissionEntry `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_online_archive.go
+++ b/admin/model_paginated_online_archive.go
@@ -9,7 +9,7 @@ type PaginatedOnlineArchive struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []BackupOnlineArchive `json:"results"`
+	Results []BackupOnlineArchive `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_org_group.go
+++ b/admin/model_paginated_org_group.go
@@ -9,7 +9,7 @@ type PaginatedOrgGroup struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []OrgGroup `json:"results"`
+	Results []OrgGroup `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_org_mcp_config.go
+++ b/admin/model_paginated_org_mcp_config.go
@@ -9,7 +9,7 @@ type PaginatedOrgMcpConfig struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []OrgMcpConfigResponse `json:"results"`
+	Results []OrgMcpConfigResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_org_service_accounts.go
+++ b/admin/model_paginated_org_service_accounts.go
@@ -9,7 +9,7 @@ type PaginatedOrgServiceAccounts struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []OrgServiceAccount `json:"results"`
+	Results []OrgServiceAccount `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_org_user.go
+++ b/admin/model_paginated_org_user.go
@@ -9,7 +9,7 @@ type PaginatedOrgUser struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []OrgUserResponse `json:"results"`
+	Results []OrgUserResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_organization.go
+++ b/admin/model_paginated_organization.go
@@ -9,7 +9,7 @@ type PaginatedOrganization struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []AtlasOrganization `json:"results"`
+	Results []AtlasOrganization `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_private_network_endpoint_id_entry.go
+++ b/admin/model_paginated_private_network_endpoint_id_entry.go
@@ -9,7 +9,7 @@ type PaginatedPrivateNetworkEndpointIdEntry struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []PrivateNetworkEndpointIdEntry `json:"results"`
+	Results []PrivateNetworkEndpointIdEntry `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_public_api_usage_details_line_item.go
+++ b/admin/model_paginated_public_api_usage_details_line_item.go
@@ -9,7 +9,7 @@ type PaginatedPublicApiUsageDetailsLineItem struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []PublicApiUsageDetailsLineItem `json:"results"`
+	Results []PublicApiUsageDetailsLineItem `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_query_shapes.go
+++ b/admin/model_paginated_query_shapes.go
@@ -9,7 +9,7 @@ type PaginatedQueryShapes struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []QueryShapeResponse `json:"results"`
+	Results []QueryShapeResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_rate_limit_endpoint_sets.go
+++ b/admin/model_paginated_rate_limit_endpoint_sets.go
@@ -9,7 +9,7 @@ type PaginatedRateLimitEndpointSets struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []RateLimitEndpointSetResponse `json:"results"`
+	Results []RateLimitEndpointSetResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_restore_job.go
+++ b/admin/model_paginated_restore_job.go
@@ -9,7 +9,7 @@ type PaginatedRestoreJob struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []BackupRestoreJob `json:"results"`
+	Results []BackupRestoreJob `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_role_mapping.go
+++ b/admin/model_paginated_role_mapping.go
@@ -9,7 +9,7 @@ type PaginatedRoleMapping struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []AuthFederationRoleMapping `json:"results"`
+	Results []AuthFederationRoleMapping `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_serverless_instance_description.go
+++ b/admin/model_paginated_serverless_instance_description.go
@@ -9,7 +9,7 @@ type PaginatedServerlessInstanceDescription struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ServerlessInstanceDescription `json:"results"`
+	Results []ServerlessInstanceDescription `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_service_account_group.go
+++ b/admin/model_paginated_service_account_group.go
@@ -9,7 +9,7 @@ type PaginatedServiceAccountGroup struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ServiceAccountGroup `json:"results"`
+	Results []ServiceAccountGroup `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_service_account_ip_access_entry.go
+++ b/admin/model_paginated_service_account_ip_access_entry.go
@@ -9,7 +9,7 @@ type PaginatedServiceAccountIPAccessEntry struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []ServiceAccountIPAccessListEntry `json:"results"`
+	Results []ServiceAccountIPAccessListEntry `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_snapshot.go
+++ b/admin/model_paginated_snapshot.go
@@ -9,7 +9,7 @@ type PaginatedSnapshot struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []BackupSnapshot `json:"results"`
+	Results []BackupSnapshot `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_team.go
+++ b/admin/model_paginated_team.go
@@ -9,7 +9,7 @@ type PaginatedTeam struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []TeamResponse `json:"results"`
+	Results []TeamResponse `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_team_role.go
+++ b/admin/model_paginated_team_role.go
@@ -9,7 +9,7 @@ type PaginatedTeamRole struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []TeamRole `json:"results"`
+	Results []TeamRole `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_paginated_user_cert.go
+++ b/admin/model_paginated_user_cert.go
@@ -9,7 +9,7 @@ type PaginatedUserCert struct {
 	Links *[]Link `json:"links,omitempty"`
 	// List of returned documents that MongoDB Cloud provides when completing this request.
 	// Read only field.
-	Results []UserCert `json:"results"`
+	Results []UserCert `json:"results,omitempty"`
 	// Total number of documents available. MongoDB Cloud omits this value if `includeCount` is set to `false`. The total number is an estimate and may not be exact.
 	// Read only field.
 	TotalCount *int `json:"totalCount,omitempty"`

--- a/admin/model_pinned_namespaces.go
+++ b/admin/model_pinned_namespaces.go
@@ -12,7 +12,7 @@ type PinnedNamespaces struct {
 	GroupId *string `json:"groupId,omitempty"`
 	// List of all pinned namespaces.
 	// Read only field.
-	PinnedNamespaces []string `json:"pinnedNamespaces"`
+	PinnedNamespaces []string `json:"pinnedNamespaces,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_private_link_endpoint.go
+++ b/admin/model_private_link_endpoint.go
@@ -6,7 +6,7 @@ package admin
 type PrivateLinkEndpoint struct {
 	// Cloud service provider that serves the requested endpoint.
 	// Read only field.
-	CloudProvider string `json:"cloudProvider"`
+	CloudProvider string `json:"cloudProvider,omitempty"`
 	// Flag that indicates whether MongoDB Cloud received a request to remove the specified private endpoint from the private endpoint service.
 	// Read only field.
 	DeleteRequested *bool `json:"deleteRequested,omitempty"`

--- a/admin/model_query_shape_response.go
+++ b/admin/model_query_shape_response.go
@@ -15,7 +15,7 @@ type QueryShapeResponse struct {
 	QueryShape *string `json:"queryShape,omitempty"`
 	// A hexadecimal string that represents the hash of a MongoDB query shape.
 	// Read only field.
-	QueryShapeHash string `json:"queryShapeHash"`
+	QueryShapeHash string `json:"queryShapeHash,omitempty"`
 	// The rejection status of a query shape. Use REJECTED to prevent the query shape from executing on the cluster, or UNREJECTED to allow it to execute.
 	Status string `json:"status"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).

--- a/admin/model_redacted_header.go
+++ b/admin/model_redacted_header.go
@@ -6,10 +6,10 @@ package admin
 type RedactedHeader struct {
 	// Header name.
 	// Read only field.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// Redacted header value.
 	// Read only field.
-	Value string `json:"value"`
+	Value string `json:"value,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/admin/model_service_account_secret.go
+++ b/admin/model_service_account_secret.go
@@ -10,13 +10,13 @@ import (
 type ServiceAccountSecret struct {
 	// The date that the secret was created on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
 	// Read only field.
-	CreatedAt time.Time `json:"createdAt"`
+	CreatedAt time.Time `json:"createdAt,omitempty"`
 	// The date for the expiration of the secret. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
 	// Read only field.
-	ExpiresAt time.Time `json:"expiresAt"`
+	ExpiresAt time.Time `json:"expiresAt,omitempty"`
 	// Unique 24-hexadecimal digit string that identifies the secret.
 	// Read only field.
-	Id string `json:"id"`
+	Id string `json:"id,omitempty"`
 	// The last time the secret was used. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
 	// Read only field.
 	LastUsedAt *time.Time `json:"lastUsedAt,omitempty"`

--- a/admin/model_streams_processor_with_stats.go
+++ b/admin/model_streams_processor_with_stats.go
@@ -6,7 +6,7 @@ package admin
 type StreamsProcessorWithStats struct {
 	// Unique 24-hexadecimal character string that identifies the stream processor.
 	// Read only field.
-	Id string `json:"_id"`
+	Id string `json:"_id,omitempty"`
 	// Flag that indicates whether the stream processor is eligible for failover.
 	// Read only field.
 	EligibleForFailover *bool `json:"eligibleForFailover,omitempty"`
@@ -18,14 +18,14 @@ type StreamsProcessorWithStats struct {
 	Links *[]Link `json:"links,omitempty"`
 	// Human-readable name of the stream processor.
 	// Read only field.
-	Name    string          `json:"name"`
+	Name    string          `json:"name,omitempty"`
 	Options *StreamsOptions `json:"options,omitempty"`
 	// Stream aggregation pipeline you want to apply to your streaming data.
 	// Read only field.
-	Pipeline []any `json:"pipeline"`
+	Pipeline []any `json:"pipeline,omitempty"`
 	// The state of the stream processor. Commonly occurring states are 'CREATED', 'STARTED', 'STOPPED' and 'FAILED'.
 	// Read only field.
-	State string `json:"state"`
+	State string `json:"state,omitempty"`
 	// The stats associated with the stream processor.
 	// Read only field.
 	Stats any `json:"stats,omitempty"`

--- a/admin/model_system_status.go
+++ b/admin/model_system_status.go
@@ -7,16 +7,16 @@ type SystemStatus struct {
 	ApiKey ApiKey `json:"apiKey"`
 	// Human-readable label that identifies the service from which you requested this response.
 	// Read only field.
-	AppName string `json:"appName"`
+	AppName string `json:"appName,omitempty"`
 	// Unique 40-hexadecimal digit hash that identifies the latest git commit merged for this application.
 	// Read only field.
-	Build string `json:"build"`
+	Build string `json:"build,omitempty"`
 	// List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.
 	// Read only field.
 	Links *[]Link `json:"links,omitempty"`
 	// Flag that indicates whether someone enabled throttling on this service.
 	// Read only field.
-	Throttling bool `json:"throttling"`
+	Throttling bool `json:"throttling,omitempty"`
 	// NullFields is an internal field that is never sent as part of the payload (see the `json:"-"` tag below).
 	// It holds a list of field names (e.g. "FieldName") to send as an explicit JSON null instead of their actual value.
 	NullFields []string `json:"-"`

--- a/test/readonly_fields_test.go
+++ b/test/readonly_fields_test.go
@@ -1,0 +1,86 @@
+package test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+)
+
+// TestReadOnlyRequiredFieldsOmittedWhenUnset verifies that fields marked as both
+// required and readOnly in the Atlas OpenAPI spec (e.g. Group.clusterCount) are
+// omitted from serialized request bodies when they hold their zero value.
+// Per OpenAPI 3.0 a readOnly property must not be sent in requests; sending the
+// zero value can be rejected by the server, e.g. an empty string is not a valid
+// enum value.
+func TestReadOnlyRequiredFieldsOmittedWhenUnset(t *testing.T) {
+	group := &admin.Group{}
+	group.SetName("test-group")
+	group.SetOrgId("65f2a1b3c4d5e6f7a8b9c0d1")
+
+	raw, err := json.Marshal(group)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+
+	// readOnly required fields are omitted while unset
+	assert.NotContains(t, payload, "clusterCount")
+	// note: created is a time.Time struct, and encoding/json's omitempty cannot
+	// omit zero-value structs, so it keeps being sent as "0001-01-01T00:00:00Z"
+	// exactly as before this fix
+	assert.Contains(t, payload, "created")
+	// writable required fields are always sent, even with zero values
+	assert.Contains(t, payload, "name")
+	assert.Contains(t, payload, "orgId")
+}
+
+// TestReadOnlyRequiredStringFieldOmittedWhenUnset covers the string case:
+// an unset readOnly required string (e.g. an enum such as
+// ConnectedOrgConfig.orgId) must not be sent as "" in request bodies.
+func TestReadOnlyRequiredStringFieldOmittedWhenUnset(t *testing.T) {
+	config := &admin.ConnectedOrgConfig{}
+	config.SetDomainRestrictionEnabled(false)
+
+	raw, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+
+	assert.NotContains(t, payload, "orgId")
+	assert.Contains(t, payload, "domainRestrictionEnabled")
+}
+
+// TestReadOnlyRequiredFieldsSentWhenSet verifies that an explicitly set
+// required readOnly field is still serialized.
+func TestReadOnlyRequiredFieldsSentWhenSet(t *testing.T) {
+	group := &admin.Group{}
+	group.SetClusterCount(3)
+
+	raw, err := json.Marshal(group)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+
+	assert.Equal(t, float64(3), payload["clusterCount"])
+}
+
+// TestReadOnlyRequiredFieldsUnmarshal verifies that responses carrying
+// required readOnly fields still populate them.
+func TestReadOnlyRequiredFieldsUnmarshal(t *testing.T) {
+	const response = `{"clusterCount":2,"created":"2026-08-21T10:00:00Z","name":"g","orgId":"o"}`
+
+	var group admin.Group
+	require.NoError(t, json.Unmarshal([]byte(response), &group))
+
+	assert.Equal(t, int64(2), group.GetClusterCount())
+	assert.Equal(t,
+		time.Date(2026, 8, 21, 10, 0, 0, 0, time.UTC),
+		group.GetCreated().UTC(),
+	)
+}

--- a/tools/config/go-templates/model_simple.mustache
+++ b/tools/config/go-templates/model_simple.mustache
@@ -26,7 +26,7 @@ type {{classname}} struct {
 {{#deprecated}}
 	// Deprecated
 {{/deprecated}}
-	{{name}} {{^required}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{#isFreeFormObject}}{{#isMap}}*{{/isMap}}{{/isFreeFormObject}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}`
+	{{name}} {{^required}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{#isFreeFormObject}}{{#isMap}}*{{/isMap}}{{/isFreeFormObject}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}{{#required}}{{#isReadOnly}},omitempty{{/isReadOnly}}{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}`
 {{/vars}}
 {{#isAdditionalPropertiesTrue}}
 	AdditionalProperties map[string]any

--- a/tools/transformer/__tests__/transformations.test.js
+++ b/tools/transformer/__tests__/transformations.test.js
@@ -6,6 +6,7 @@ const {
   transformOneOf,
   applyOperationIdOverrides,
   applyServersValidation,
+  applyFieldTransformations,
 } = require("../src/transformations");
 const cases = require("./transformations-snapshots");
 
@@ -91,6 +92,58 @@ test("applyOperationIdOverrides", () => {
   expect(
     api.paths["/api/atlas/v2/example/info"].get["x-xgen-operation-id-override"],
   ).toBeFalsy();
+});
+
+describe("applyFieldTransformations", () => {
+  const apiWithStreamsProcessor = () => ({
+    components: {
+      schemas: {
+        StreamsProcessor: {
+          description: "An atlas stream processor.",
+          properties: {
+            effectiveTier: {
+              description: "Effective tier of the stream processor.",
+              enum: ["SP30", "SP50"],
+              readOnly: true,
+              type: "string",
+            },
+            name: {
+              description: "Human-readable name of the stream processor.",
+              type: "string",
+            },
+          },
+          required: ["effectiveTier", "name"],
+          type: "object",
+        },
+      },
+    },
+  });
+
+  test("removes configured readOnly field from required, keeping the rest", () => {
+    const result = applyFieldTransformations(apiWithStreamsProcessor());
+    // effectiveTier is a readOnly field, so it must not be required in request bodies
+    expect(result.components.schemas.StreamsProcessor.required).toEqual([
+      "name",
+    ]);
+  });
+
+  test("drops the required array when no required fields remain", () => {
+    const input = apiWithStreamsProcessor();
+    input.components.schemas.StreamsProcessor.required = ["effectiveTier"];
+    const result = applyFieldTransformations(input);
+    expect(result.components.schemas.StreamsProcessor.required).toBeUndefined();
+  });
+
+  test("leaves schemas without configured fields untouched", () => {
+    const input = apiWithStreamsProcessor();
+    input.components.schemas.Unrelated = {
+      properties: { id: { type: "string" } },
+      required: ["id"],
+      type: "object",
+    };
+    const result = applyFieldTransformations(input);
+    expect(result.components.schemas.Unrelated.required).toEqual(["id"]);
+  });
 });
 
 describe("applyServersValidation", () => {

--- a/tools/transformer/src/field.transformations.json
+++ b/tools/transformer/src/field.transformations.json
@@ -1,5 +1,6 @@
 {
   "optionalFields": {
-    "StreamProcessorMetricThreshold": ["metricName"]
+    "StreamProcessorMetricThreshold": ["metricName"],
+    "StreamsProcessor": ["effectiveTier"]
   }
 }


### PR DESCRIPTION
## POC: handling required + readOnly fields in SDK generation

Proof of concept for discussion, not intended for merge as is.

### Problem

The Go SDK generator shapes struct fields from `required` alone and ignores `readOnly`. A property that is both `required` and `readOnly: true` generates as a non-pointer field with no `omitempty`, so it is serialized on every request body. Per OpenAPI 3.0, a readOnly property must not be sent in requests; when also listed in `required`, the requirement applies to responses only.

Concrete failure: `StreamsProcessor.effectiveTier` (required + readOnly enum) generates as a mandatory constructor arg serialized as `""` when unset, and the server rejects it with `INVALID_ENUM_VALUE`, breaking every stream processor create that leaves it unset.

### Approach in this POC

Two complementary changes:

1. **Template (`model_simple.mustache`)**: required + readOnly fields get `,omitempty` in their JSON tag, so unset (zero) values are omitted from request bodies. No type, constructor, or accessor changes, so the Go API surface is unchanged (gorelease clean). Known limitation: `omitempty` cannot omit zero-value structs, so `time.Time` fields (e.g. `Group.created`) behave exactly as before.
2. **Transformer config (`field.transformations.json`)**: `StreamsProcessor.effectiveTier` added to `optionalFields`, reusing the existing per-field mechanism. On the next spec regen it becomes a regular optional field (`*string`, `omitempty`, out of the `NewStreamsProcessor()` constructor), so no forced dummy arg ever ships. No-op on the current spec.

### Blast radius of the template change

148 fields in 114 models get the tag change, but only 6 models are reachable from request bodies, so runtime behavior changes only there:

| Field | Sent in | Before (unset) | After (unset) |
|---|---|---|---|
| `Group.clusterCount` | `createGroup` | `"clusterCount":0` | omitted |
| `ConnectedOrgConfig.orgId` | `updateConnectedOrgConfig` | `"orgId":""` | omitted |
| `ApiAtlasSnapshotSchedule.groupId` | `updateClusterSnapshotSchedule` | `"groupId":""` | omitted |
| `DataFederationLimit.name` | `setGroupLimit` | `"name":""` | omitted |
| `DataFederationTenantQueryLimit.name` | `setDataFederationLimit` | `"name":""` | omitted |
| `CloudAppUser.emailAddress` | `createUser` | `"emailAddress":""` | omitted |

The other 108 models are response-only (`Paginated*`, `Enveloped*`, views); consumers only unmarshal them, so the tag change is cosmetic there.

### Alternatives considered

- **Config entry only** (narrowest): zero diff on current models, but the generic generator bug remains and each future occurrence needs a manual entry.
- **Generic transformer strip of readOnly from `required`** (broadest): semantically purest, but flips all 148 fields to pointers and removes them from constructors (e.g. `NewGroup(clusterCount, created, name, orgId)` loses args, `Paginated*.Results` becomes `*[]T`). Large breaking change and worse response ergonomics (nil checks on guaranteed fields).

### Verification

- Full regen (`make clean_and_generate`) is idempotent and limited to the expected tag lines.
- New Go regression tests in `test/readonly_fields_test.go` (unset fields omitted, set fields sent, responses still populate them).
- New transformer unit tests for the `optionalFields` entry.
- Simulated the upcoming spec change locally: transformer strips `effectiveTier` from `required` as expected.
- `go build`, `go test ./...` (root and examples), golangci-lint, transformer jest suite and prettier all pass.