### PR TITLE
fix: Generate StreamsProcessor.effectiveTier as optional

### DIFF
--- a/tools/transformer/README.md
+++ b/tools/transformer/README.md
@@ -95,6 +95,12 @@ Useful for situations for schemas where nullability handling is not desired.
 
 This transformation updates the operation IDs in the OpenAPI file if the operation has an `x-xgen-operation-id-override` extension. Then, it removes the Operation ID override extension from the OpenAPI file.
 
+7. Field transformations (optional fields)
+
+Driven by [field.transformations.json](./src/field.transformations.json). Each entry under `optionalFields` maps a schema name to a list of property names to strip from that schema's `required` array, making them optional in the generated SDK (pointer type, `omitempty`, no constructor argument).
+
+Main use case: properties that are both `required` and `readOnly: true` in the spec. Per OpenAPI 3.0, read-only properties must not be sent in requests, and `required` on them applies to responses only. The generator derives pointer type and `omitempty` from `required` alone, so such fields would otherwise be serialized on every request body with their zero value and forced as a constructor argument. Add an entry here for each such field on a request schema (see `StreamsProcessor.effectiveTier`, CLOUDP-437811).
+
 ## Transformation Validation
 
 Transformation engine does perform validation for invalid cases.

--- a/tools/transformer/src/field.transformations.json
+++ b/tools/transformer/src/field.transformations.json
@@ -1,5 +1,6 @@
 {
   "optionalFields": {
-    "StreamProcessorMetricThreshold": ["metricName"]
+    "StreamProcessorMetricThreshold": ["metricName"],
+    "StreamsProcessor": ["effectiveTier"]
   }
 }


### PR DESCRIPTION
## Description

The upcoming spec regen (#843) marks `StreamsProcessor.effectiveTier` as `required` and `readOnly: true`. The generator shapes struct fields from `required` alone, so the field would generate as a non-pointer without `omitempty` and as a mandatory constructor argument. Unset callers would send `"effectiveTier":""` on every `createStreamProcessor` request, which the server rejects with `INVALID_ENUM_VALUE`.

Fix: add `StreamsProcessor.effectiveTier` to the transformer's `optionalFields` so it is stripped from `required` before generation and the field generates as a regular optional (`*string`, `omitempty`, no constructor argument). This override was introduced in #557 and is already used for `StreamProcessorMetricThreshold.metricName`. No-op on the current spec, so this PR carries no generated code changes.

This addresses the current case only. Before a more holistic fix, I want to understand what changes on the mms side end up producing the `readOnly` + `required` scenario, and whether it is relevant to actually handle it generically in the SDK. As of now this fix unblocks the SDK release that we would want to trigger today.

Link to any related issue(s): [CLOUDP-437811](https://jira.mongodb.org/browse/CLOUDP-437811)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

Verified by simulating the upcoming spec locally: with `effectiveTier` as required + readOnly on `StreamsProcessor`, the transformer strips it from `required` and the generated model carries `EffectiveTier *string` with `omitempty` and no constructor argument.