### PR TITLE
chore: Remove hardcoded debug logging from examples

### DIFF
--- a/admin/atlas_client.go
+++ b/admin/atlas_client.go
@@ -96,6 +96,11 @@ func UseHTTPClient(client *http.Client) ClientModifier {
 }
 
 // UseDebug enable debug level logging.
+//
+// Warning: debug logging writes full unredacted HTTP requests and responses,
+// including credentials and other secrets (for example database user passwords),
+// to the process logs. Enable it only for local troubleshooting, never in
+// production or shared environments.
 func UseDebug(debug bool) ClientModifier {
 	return func(c *Configuration) error {
 		c.Debug = debug

--- a/examples/db_users/db_users.go
+++ b/examples/db_users/db_users.go
@@ -34,8 +34,7 @@ func main() {
 
 	sdk, err := admin.NewClient(
 		admin.UseBaseURL(url),
-		admin.UseOAuthAuth(ctx, clientID, clientSecret),
-		admin.UseDebug(true))
+		admin.UseOAuthAuth(ctx, clientID, clientSecret))
 	examples.HandleErr(err, nil)
 
 	current := new(admin.CloudDatabaseUser)

--- a/examples/service_account_token_store/cached_token.go
+++ b/examples/service_account_token_store/cached_token.go
@@ -50,7 +50,6 @@ func main() {
 	}()
 	sdk, err := admin.NewClient(
 		admin.UseBaseURL(host),
-		admin.UseDebug(true),
 		admin.UseHTTPClient(auth.NewClient(ctx, src)),
 	)
 

--- a/tools/config/go-templates/atlas_client.mustache
+++ b/tools/config/go-templates/atlas_client.mustache
@@ -96,6 +96,11 @@ func UseHTTPClient(client *http.Client) ClientModifier {
 }
 
 // UseDebug enable debug level logging.
+//
+// Warning: debug logging writes full unredacted HTTP requests and responses,
+// including credentials and other secrets (for example database user passwords),
+// to the process logs. Enable it only for local troubleshooting, never in
+// production or shared environments.
 func UseDebug(debug bool) ClientModifier {
 	return func(c *Configuration) error {
 		c.Debug = debug


### PR DESCRIPTION
## Summary

Fixes [SECBUG-4401](https://jira.mongodb.org/browse/SECBUG-4401): shipped examples enabled full unredacted HTTP debug logging, which writes plaintext database-user passwords and complete Atlas API request/response traffic to process logs on every run.

## Changes

- examples/db_users/db_users.go: remove hardcoded admin.UseDebug(true). This example sends the plaintext database-user password in the update request body, which was dumped unredacted to the logs.
- examples/service_account_token_store/cached_token.go: remove hardcoded admin.UseDebug(true).
- admin/atlas_client.go and tools/config/go-templates/atlas_client.mustache: add a security warning to UseDebug documenting that debug logging writes full unredacted HTTP traffic, including credentials and secrets, to process logs and must only be used for local troubleshooting. Template and generated file kept in sync.

Debug dumping in callAPI itself is unchanged: it remains opt-in (default Debug=false) for troubleshooting.

## Verification

- go build ./... and go vet pass in the root and examples modules
- go test ./test/... passes (generated SDK validation)
- No remaining UseDebug(true) occurrences in the repo