### PR TITLE
fix: Reject dot-segment path parameters in request paths

### DIFF
--- a/test/path_traversal_test.go
+++ b/test/path_traversal_test.go
@@ -1,0 +1,124 @@
+package test
+
+// Path parameters equal to dot-segments ("." or "..") must be rejected
+// client-side before any request is sent: the server normalizes them per
+// RFC 3986, which would route the authenticated request to a different
+// endpoint than intended.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+)
+
+func TestDotSegmentPathParamsRejected(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	sdk, err := admin.NewClient(admin.UseBaseURL(server.URL))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	cases := []struct {
+		name      string
+		paramName string
+		call      func() error
+	}{
+		{"DeleteIndexByName groupId=..", "groupId", func() error {
+			_, err := sdk.AtlasSearchAPI.DeleteIndexByName(ctx, "..", "cluster0", "coll", "db", "idx").Execute()
+			return err
+		}},
+		{"DeleteIndexByName collectionName=..", "collectionName", func() error {
+			_, err := sdk.AtlasSearchAPI.DeleteIndexByName(ctx, "group1", "cluster0", "..", "db", "idx").Execute()
+			return err
+		}},
+		{"DeleteIndexByName collectionName=.", "collectionName", func() error {
+			_, err := sdk.AtlasSearchAPI.DeleteIndexByName(ctx, "group1", "cluster0", ".", "db", "idx").Execute()
+			return err
+		}},
+		{"GetDatabaseUser username=..", "username", func() error {
+			_, _, err := sdk.DatabaseUsersAPI.GetDatabaseUser(ctx, "group1", "admin", "..").Execute()
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before := atomic.LoadInt32(&hits)
+			err := tc.call()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.paramName+" must not be a dot-segment path parameter")
+			assert.Equal(t, before, atomic.LoadInt32(&hits), "rejected call must not reach the network")
+		})
+	}
+}
+
+func TestNonDotSegmentPathParamsStillWork(t *testing.T) {
+	var capturedURI string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURI = r.RequestURI
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	sdk, err := admin.NewClient(admin.UseBaseURL(server.URL))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	cases := []struct {
+		name       string
+		collection string
+		wantInURI  string
+	}{
+		{"dotted name", "my.coll", "/my.coll/"},
+		{"three dots is not a dot-segment", "...", "/.../"},
+		{"dots inside a name", "a..b", "/a..b/"},
+		{"slashes still escaped, not a traversal", "a/../b", "/a%2F..%2Fb/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			capturedURI = ""
+			_, err := sdk.AtlasSearchAPI.DeleteIndexByName(ctx, "group1", "cluster0", tc.collection, "db", "idx").Execute()
+			require.NoError(t, err)
+			assert.Contains(t, capturedURI, tc.wantInURI)
+		})
+	}
+}
+
+func TestPrepareRequestRejectsDotSegments(t *testing.T) {
+	sdk, err := admin.NewClient(admin.UseBaseURL("https://cloud.mongodb.com"))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	badPaths := []string{
+		"https://cloud.mongodb.com/api/atlas/v2/groups/g1/databaseUsers/admin/..",
+		"https://cloud.mongodb.com/api/atlas/v2/groups/g1/./databaseUsers",
+		"https://cloud.mongodb.com/api/atlas/v2/groups/g1/databaseUsers/%2E%2E",
+	}
+	for _, p := range badPaths {
+		_, err := sdk.UntypedClient.PrepareRequest(ctx, p, http.MethodGet, nil, map[string]string{}, url.Values{}, url.Values{}, nil)
+		require.Error(t, err, p)
+		assert.Contains(t, err.Error(), "dot-segment")
+	}
+
+	req, err := sdk.UntypedClient.PrepareRequest(ctx,
+		"https://cloud.mongodb.com/api/atlas/v2/groups/g1/databaseUsers",
+		http.MethodGet, nil, map[string]string{}, url.Values{}, url.Values{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/api/atlas/v2/groups/g1/databaseUsers", req.URL.Path)
+}

--- a/test/path_traversal_test.go
+++ b/test/path_traversal_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // closeBody closes the response body when present and returns the call error.

--- a/test/path_traversal_test.go
+++ b/test/path_traversal_test.go
@@ -19,6 +19,14 @@ import (
 	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
+// closeBody closes the response body when present and returns the call error.
+func closeBody(resp *http.Response, err error) error {
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	return err
+}
+
 func TestDotSegmentPathParamsRejected(t *testing.T) {
 	var hits int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -39,20 +47,20 @@ func TestDotSegmentPathParamsRejected(t *testing.T) {
 		call      func() error
 	}{
 		{"DeleteIndexByName groupId=..", "groupId", func() error {
-			_, err := sdk.AtlasSearchAPI.DeleteIndexByName(ctx, "..", "cluster0", "coll", "db", "idx").Execute()
-			return err
+			resp, err := sdk.AtlasSearchAPI.DeleteIndexByName(ctx, "..", "cluster0", "coll", "db", "idx").Execute()
+			return closeBody(resp, err)
 		}},
 		{"DeleteIndexByName collectionName=..", "collectionName", func() error {
-			_, err := sdk.AtlasSearchAPI.DeleteIndexByName(ctx, "group1", "cluster0", "..", "db", "idx").Execute()
-			return err
+			resp, err := sdk.AtlasSearchAPI.DeleteIndexByName(ctx, "group1", "cluster0", "..", "db", "idx").Execute()
+			return closeBody(resp, err)
 		}},
 		{"DeleteIndexByName collectionName=.", "collectionName", func() error {
-			_, err := sdk.AtlasSearchAPI.DeleteIndexByName(ctx, "group1", "cluster0", ".", "db", "idx").Execute()
-			return err
+			resp, err := sdk.AtlasSearchAPI.DeleteIndexByName(ctx, "group1", "cluster0", ".", "db", "idx").Execute()
+			return closeBody(resp, err)
 		}},
 		{"GetDatabaseUser username=..", "username", func() error {
-			_, _, err := sdk.DatabaseUsersAPI.GetDatabaseUser(ctx, "group1", "admin", "..").Execute()
-			return err
+			_, resp, err := sdk.DatabaseUsersAPI.GetDatabaseUser(ctx, "group1", "admin", "..").Execute()
+			return closeBody(resp, err)
 		}},
 	}
 	for _, tc := range cases {
@@ -93,8 +101,9 @@ func TestNonDotSegmentPathParamsStillWork(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			capturedURI = ""
-			_, err := sdk.AtlasSearchAPI.DeleteIndexByName(ctx, "group1", "cluster0", tc.collection, "db", "idx").Execute()
+			resp, err := sdk.AtlasSearchAPI.DeleteIndexByName(ctx, "group1", "cluster0", tc.collection, "db", "idx").Execute()
 			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
 			assert.Contains(t, capturedURI, tc.wantInURI)
 		})
 	}

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -157,6 +157,9 @@ func (a *{{{classname}}}Service) {{{nickname}}}Execute(r {{operationId}}ApiReque
 	if r.{{paramName}} == "" {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} is empty and must be specified")
 	}
+	if r.{{paramName}} == "." || r.{{paramName}} == ".." {
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must not be a dot-segment path parameter")
+	}
 	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", url.PathEscape(r.{{paramName}}), -1){{/pathParams}}
 
 	localVarHeaderParams := make(map[string]string)

--- a/tools/config/go-templates/client.mustache
+++ b/tools/config/go-templates/client.mustache
@@ -315,10 +315,11 @@ func (c *APIClient) prepareRequest(
 
 	// Defense-in-depth: refuse to send paths with dot-segments, which the
 	// server would normalize per RFC 3986, retargeting the request to a
-	// different endpoint. Path parameters are validated before splicing, so
-	// a dot-segment here means the path was tampered with. The check runs on
-	// the encoded path: a segment is rejected only if it is exactly "." or
-	// ".." once decoded, so escaped values like "a%2F..%2Fb" stay valid.
+	// different endpoint. Typed methods validate path parameters before
+	// splicing; callers of UntypedClient.PrepareRequest supply raw paths
+	// directly, so this is the only layer that protects them. The check runs
+	// on the encoded path: a segment is rejected only if it is exactly "."
+	// or ".." once decoded, so escaped values like "a%2F..%2Fb" stay valid.
 	for _, segment := range strings.Split(urlData.EscapedPath(), "/") {
 		if decoded, err := url.PathUnescape(segment); err == nil && (decoded == "." || decoded == "..") {
 			return nil, reportError("refusing to send request: path %q contains a dot-segment", urlData.EscapedPath())

--- a/tools/config/go-templates/client.mustache
+++ b/tools/config/go-templates/client.mustache
@@ -313,6 +313,18 @@ func (c *APIClient) prepareRequest(
 		return nil, err
 	}
 
+	// Defense-in-depth: refuse to send paths with dot-segments, which the
+	// server would normalize per RFC 3986, retargeting the request to a
+	// different endpoint. Path parameters are validated before splicing, so
+	// a dot-segment here means the path was tampered with. The check runs on
+	// the encoded path: a segment is rejected only if it is exactly "." or
+	// ".." once decoded, so escaped values like "a%2F..%2Fb" stay valid.
+	for _, segment := range strings.Split(urlData.EscapedPath(), "/") {
+		if decoded, err := url.PathUnescape(segment); err == nil && (decoded == "." || decoded == "..") {
+			return nil, reportError("refusing to send request: path %q contains a dot-segment", urlData.EscapedPath())
+		}
+	}
+
 	// Override request host, if applicable
 	if c.cfg.Host != "" {
 		urlData.Host = c.cfg.Host


### PR DESCRIPTION
## Summary

Path parameters equal to `.` or `..` are now rejected client-side before any request is sent. `url.PathEscape` does not escape dot-segments, so such values would be sent as live path segments; servers normalize them per RFC 3986 before routing, which can route the request to a different endpoint than intended.

Changes are limited to the generation templates:

- `tools/config/go-templates/api.mustache`: emit a guard rejecting `.`/`..` values next to the existing empty check for every path parameter.
- `tools/config/go-templates/client.mustache`: defense-in-depth check in `prepareRequest` that refuses to send any assembled path containing a dot-segment. The check runs on the encoded path, so escaped values like `a%2F..%2Fb` remain valid.

The generated `admin/` changes are intentionally **not** included in this PR; the SDK autogeneration action will produce them from these templates after merge, avoiding conflicts with the auto-release flow.

## Tests

- Adds `test/path_traversal_test.go` covering: rejection of `.`/`..` parameters (asserting no request reaches the network), that non-dot-segment values (including `a/../b`, escaped to `a%2F..%2Fb`) are unaffected, and the `prepareRequest` guard including `%2E%2E`.
- Note: the Go test job will fail on this PR until the autogeneration action regenerates `admin/` with the new guards. The tests were run successfully (including `-race`) with the SDK regenerated locally from these templates, and the behavior was additionally verified with read-only live calls against a real Atlas instance.

Ticket: [SECBUG-4400](https://jira.mongodb.org/browse/SECBUG-4400)